### PR TITLE
Update urls to Puppet Labs repo packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- Updated documentation links to reflect that the repo and agent RPM packages have had their platform renamed from 'nxos' to 'cisco-wrlinux'.
+
 ### Added
 - Extended cisco_interface with the following attributes:
   - encapsulation dot1q

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The Puppet Agent requires installation and setup on each device. Agent setup can
 ##### Artifacts
 
 As noted in the agent installation guide, these are the current RPM versions for use with ciscopuppet:
-* `bash-shell`: Use [http://yum.puppetlabs.com/puppetlabs-release-pc1-nxos-5.noarch.rpm](http://yum.puppetlabs.com/puppetlabs-release-pc1-nxos-5.noarch.rpm)
+* `bash-shell`: Use [http://yum.puppetlabs.com/puppetlabs-release-pc1-cisco-wrlinux-5.noarch.rpm](http://yum.puppetlabs.com/puppetlabs-release-pc1-cisco-wrlinux-5.noarch.rpm)
 * `guestshell`: Use [http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm](http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm)
 
 ##### Gems

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -209,7 +209,7 @@ The `bash-shell` and `guestshell` environments use different puppet RPMs.
 * For `bash-shell` use:
 
 ~~~bash
-yum install http://yum.puppetlabs.com/puppetlabs-release-pc1-nxos-5.noarch.rpm
+yum install http://yum.puppetlabs.com/puppetlabs-release-pc1-cisco-wrlinux-5.noarch.rpm
 yum install puppet
 ~~~
 


### PR DESCRIPTION
We've changed the platform name used in the puppet agent packages from
nxos -> cisco-wrlinux to reflect that these packages may not be limited
to NX-OS in the future. All nxos named packages will be removed from
yum.puppetlabs.com shortly.