### PR TITLE
Add name_server provider

### DIFF
--- a/lib/puppet/provider/name_server/nxapi.rb
+++ b/lib/puppet/provider/name_server/nxapi.rb
@@ -1,0 +1,74 @@
+# The NXAPI provider for ip name-server
+#
+# September, 2015
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.type(:name_server).provide(:nxapi) do
+  desc 'The NXAPI provider for ip name-server.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  def initialize(value = {})
+    super(value)
+    @nameserver = Cisco::NameServer.nameservers[@property_hash[:name]]
+    @property_flush = {}
+  end
+
+  def self.instances
+    nameserver_instances = []
+    Cisco::NameServer.nameservers.each_key do |id|
+      nameserver_instances << new(
+        name:   id,
+        ensure: :present
+      )
+    end
+    nameserver_instances
+  end
+
+  def self.prefetch(resources)
+    instance_array = instances
+    resources.keys.each do |name|
+      provider = instance_array.find { |inst| inst.name == name }
+      resources[name].provider = provider unless provider.nil?
+    end
+  end
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @nameserver.destroy
+      @nameserver = nil
+      @property_hash[:ensure] = :absent
+    else
+      @nameserver = Cisco::NameServer.new(@resource[:name])
+      @property_hash[:ensure] = :present
+    end
+  end
+end

--- a/tests/beaker_tests/netdev_stdlib/name_server_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/name_server_provider_defaults.rb
@@ -1,0 +1,173 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# NameServer-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a name_server resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a name_server resource test that tests for default value for
+# 'ensure' attribute of a name_server resource.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.  The 1st
+# step is the Setup teststep that cleans up the switch state.  Steps 2-4 deal
+# with the name_server resource and its verification using Puppet Agent and the
+# switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and NameServerLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../name_serverlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'NAME_SERVER Resource :: All Attributes Defaults'
+
+# @test_name [TestCase] Executes defaults testcase for NAME_SERVER Resource.
+test_name "TestCase :: #{testheader}" do
+  ## @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider test' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    # Let's check and make sure that an expected default group/role is present
+    # and an unexpected non-default group/role is absent
+
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    cmd_str = UtilityLib.get_vshell_cmd('conf t ; no ip name-server 7.7.7.7')
+    on(agent, cmd_str)
+
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd("show running-config section name-server")
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, [/name-server 7\.7\.7\.7$/],
+        true, self, logger)
+    end
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NameServerLib.create_name_server_manifest_present)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks name_server resource on agent using resource cmd.
+  step 'TestStep :: Check name_server resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'resource name_server 7.7.7.7', options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, { 'ensure' => 'present' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check name_server resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks name_server instance on agent using switch show cli
+  # cmds.
+  step 'TestStep :: Check name_server instance presence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config section ' \
+                                        'name-server')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, [/name-server 7\.7\.7\.7/],
+                                          false, self, logger)
+    end
+
+    logger.info("Check name_server instance presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource absent manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NameServerLib.create_name_server_manifest_absent)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+                                           'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource absent manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks name_server resource on agent using resource cmd.
+  step 'TestStep :: Check name_server resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'resource name_server 7.7.7.7', options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, { 'ensure' => 'present' },
+                                          true, self, logger)
+    end
+
+    logger.info("Check name_server resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks name_server instance on agent using switch show cli
+  # cmds.
+  step 'TestStep :: Check name_server instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config section ' \
+                                        'name-server')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, [/name-server 7\.7\.7\.7/],
+                                          true, self, logger)
+    end
+
+    logger.info("Check name_server instance absence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/netdev_stdlib/name_serverlib.rb
+++ b/tests/beaker_tests/netdev_stdlib/name_serverlib.rb
@@ -1,0 +1,87 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# Name Server Utility Library:
+# ---------------------
+# name_serverlib.rb
+#
+# This is the utility library for the name server provider Beaker test cases
+# that contains the common methods used across the name server testsuite's
+# cases. The library is implemented as a module with related methods and
+# constants defined inside it for use as a namespace. All of the methods are
+# defined as module methods.
+#
+# Every Beaker name server test case that runs an instance of Beaker::TestCase
+# requires NameServerLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for name_server Puppet provider test cases.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# A library to assist testing name_server resource
+module NameServerLib
+  # Group of Constants used in negative tests for name_server provider.
+  ENSURE_NEGATIVE = 'unknown'
+
+  # A. Methods to create manifests for name_server Puppet provider test cases.
+
+  # Method to create a manifest for name_server resource attribute 'ensure'
+  # where 'ensure' is set to present.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_name_server_manifest_present
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  name_server {'7.7.7.7':
+    ensure => present,
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for name_server resource attribute 'ensure'
+  # where 'ensure' is set to absent.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_name_server_manifest_absent
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    name_server {'7.7.7.7':
+      ensure => absent,
+    }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for name_server resource attribute 'ensure'
+  # where 'ensure' is set to unknown.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_name_server_manifest_negative
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  name_server {'7.7.7.7':
+    ensure => #{NameServerLib::ENSURE_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+end


### PR DESCRIPTION
The puppetlabs-netdev_stdlib module has a name_server resource. This
commit adds a provider for this resource.

Requires cisco/cisco-network-node-utils#2