### PR TITLE
Upgrade rvm version to support dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ sudo: false
 
 language: ruby
 cache: bundler
+
+rvm:
+  - 2.1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.2.2
   - 2.1.6
+  - 2.0.0
+  - 1.9.3


### PR DESCRIPTION
Travis is failing all builds due to beaker's dependency on fog-google.  fog-google 0.1.1 requires ruby version 2.0 minimum and Travis attempts to build with 1.9.

> Gem::InstallError: fog-google requires Ruby version >= 2.0.
> Installing specinfra 2.43.10
> An error occurred while installing fog-google (0.1.1), and Bundler cannot
> continue.

This is a quick fix for the puppet module to use the 2.1.6 rvm and resume passing the Travis build checks.  I am queueing up another pull request for cisco-network-node-utils that will require ruby version 2.1 or higher.  Puppet [appears to be in the process of deprecating ruby 1.9](https://docs.puppetlabs.com/guides/platforms.html#ruby-versions) so it would be best in the long run to upgrade to 2.1 now.