### PR TITLE
Added NXOS provider for network_snmp

### DIFF
--- a/lib/puppet/provider/network_snmp/nxapi.rb
+++ b/lib/puppet/provider/network_snmp/nxapi.rb
@@ -1,0 +1,108 @@
+# The NXAPI provider for network_snmp.
+#
+# November, 2014
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:network_snmp).provide(:nxapi) do
+  desc "The Cisco NXAPI provider for network_snmp."
+
+  confine :feature => :cisco_node_utils
+  defaultfor :operatingsystem => :nexus
+
+  mk_resource_methods
+
+  NETWORK_SNMP_PROPS={
+    :enable => :protocol,
+    :contact => :contact,
+    :location => :location,
+  }
+
+  def initialize(value={})
+    super(value)
+    @network_snmp = Cisco::SnmpServer.new()
+    @property_flush = {}
+    debug "Created provider instance of network_snmp"
+  end
+
+  def self.get_properties
+    network_snmp = Cisco::SnmpServer.new()
+
+    current_state = {
+      :name => 'default',
+      :enable => network_snmp.protocol? ? :true : :false,
+      :contact => network_snmp.contact.empty? ? 'unset' : network_snmp.contact,
+      :location => network_snmp.location.empty? ? 'unset' : network_snmp.location,
+    }
+
+    new(current_state)
+  end # self.get_properties
+
+  def self.instances
+    network_snmp = []
+    network_snmp << get_properties
+
+    return network_snmp
+  end
+
+  def self.prefetch(resources)
+    network_snmp = instances
+
+    resources.keys.each do |id|
+      provider = network_snmp.find { |instance| instance.name == id }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def munge_flush(val)
+    if val.is_a?(String) && val.eql?('unset')
+      ''
+    elsif val.is_a?(Symbol) && val.eql?(:true)
+      true
+    elsif val.is_a?(Symbol) && val.eql?(:false)
+      false
+    elsif val.is_a?(Symbol)
+      val.to_s
+    else
+      val
+    end
+  end
+
+  def validate
+    fail ArgumentError,
+         "This provider only supports a namevar of 'default'" unless @resource[:name].to_s == 'default'
+  end
+
+  def flush
+    validate
+
+    NETWORK_SNMP_PROPS.each { |puppet_prop,cisco_prop|
+      if @resource[puppet_prop]
+          @network_snmp.send("#{cisco_prop}=", munge_flush(@resource[puppet_prop])) \
+            if @network_snmp.respond_to?("#{cisco_prop}=")
+      end
+    }
+  end
+end   #Puppet::Type
+

--- a/tests/beaker_tests/network_snmp/network_snmp-provider-defaults.rb
+++ b/tests/beaker_tests/network_snmp/network_snmp-provider-defaults.rb
@@ -1,0 +1,137 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# NetworkSnmp-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a network_snmp resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a network_snmp resource test that tests for default value for
+# 'ensure' attribute of a network_snmp resource.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# Steps 2-4 deal with cisco_snmp_group_resource and its
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and SnmpGroupLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../network_snmplib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'network_snmp Resource :: All Attributes Defaults'
+
+# @test_name [TestCase] Executes defaults testcase for network_snmp Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    logger.info("Setup switch for provider")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource set manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NetworkSnmpLib.create_network_snmp_manifest_set)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource set manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks network_snmp resource on agent using resource cmd.
+  step 'TestStep :: Check network_snmp resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource network_snmp default", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, { 'enable' => 'true' },
+                                          false, self, logger)
+      UtilityLib.search_pattern_in_output(stdout, { 'contact' => 'SysAdmin' },
+                                          false, self, logger)
+      UtilityLib.search_pattern_in_output(stdout, { 'location' => 'UK' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_snmp resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource unset manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NetworkSnmpLib.create_network_snmp_manifest_unset)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource unset manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks network_snmp resource on agent using resource cmd.
+  step 'TestStep :: Check network_snmp resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource network_snmp default", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, { 'enable' => 'false' },
+                                          false, self, logger)
+      UtilityLib.search_pattern_in_output(stdout, { 'contact' => 'unset' },
+                                          false, self, logger)
+      UtilityLib.search_pattern_in_output(stdout, { 'location' => 'unset' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_snmp resource presence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/network_snmp/network_snmplib.rb
+++ b/tests/beaker_tests/network_snmp/network_snmplib.rb
@@ -1,0 +1,74 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# Network SNMP Utility Library:
+# ---------------------
+# network_snmplib.rb
+#
+# This is the utility library for the Network SNMP provider Beaker test cases
+# that contains the common methods used across the Network SNMP testsuite's
+# cases. The library is implemented as a module with related methods and
+# constants defined inside it for use as a namespace. All of the methods are
+# defined as module methods.
+#
+# Every Beaker Network SNMP test case that runs an instance of Beaker::TestCase
+# requires NetworkSnmpLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for network_snmp Puppet provider test cases.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# A library to assist testing network_snmp resource
+module NetworkSnmpLib
+  # Group of Constants used in negative tests for network_snmp provider.
+  ENSURE_NEGATIVE = 'unknown'
+
+  # A. Methods to create manifests for network_snmp Puppet provider test cases.
+
+  # Method to create a manifest for network_snmp with properties set
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_network_snmp_manifest_set
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  network_snmp {'default':
+    enable => true,
+    location => 'UK',
+    contact => 'SysAdmin',
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for network_snmp with properties unset
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_network_snmp_manifest_unset
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  network_snmp {'default':
+    enable => false,
+    location => 'unset',
+    contact => 'unset',
+  }
+}
+EOF"
+    manifest_str
+  end
+end


### PR DESCRIPTION
tests/beaker_tests/network_snmp/network_snmp-provider-defaults.rb passed in 17.47 seconds
      Test Suite: tests @ 2015-10-08 13:57:25 +0100

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 17.46 seconds
      Average Test Time: 17.46 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1