### PR TITLE
Update Network vlan PR with rubocop and beaker tests

### DIFF
--- a/lib/puppet/provider/network_vlan/nxapi.rb
+++ b/lib/puppet/provider/network_vlan/nxapi.rb
@@ -1,35 +1,38 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
-require 'puppet/type/cisco_vlan'
-require 'puppet/provider/cisco_vlan/nxapi'
+# The NXAPI provider for network_vlan
+#
+# October, 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Puppet::Type.type(:network_vlan).provide(:nxapi, :parent => Puppet::Type.type(:cisco_vlan).provider(:nxapi)) do
-  @doc = "cisco VLAN"
-
-  has_features :activable, :describable
+Puppet::Type.type(:network_vlan).provide(:nxapi, parent: Puppet::Type.type(:cisco_vlan).provider(:nxapi)) do
+  @doc = 'cisco VLAN'
 
   mk_resource_methods
 
   def self.instances
     vlans = []
-    Cisco::Vlan.vlans.each { |vlan_id, v|
+    Cisco::Vlan.vlans.each do |vlan_id, v|
       vlan = {
-        :id          => vlan_id,
-        :name        => vlan_id,
-        :vlan_name   => v.send(:vlan_name),
-        :shutdown    => v.send(:shutdown),
-        :ensure      => :present,
+        name:      vlan_id,
+        ensure:    :present,
+        vlan_name: v.send(:vlan_name),
+        shutdown:  v.send(:shutdown),
       }
       vlans << new(vlan)
-    }
-    return vlans
-  end
-
-  def self.prefetch(resources)
-    instances.each do |prov|
-      if resource = resources[prov.name]
-        resource.provider = prov
-      end
     end
+    vlans
   end
 
   def flush
@@ -39,19 +42,17 @@ Puppet::Type.type(:network_vlan).provide(:nxapi, :parent => Puppet::Type.type(:c
       @property_hash[:ensure] = :absent
     else
       if @property_hash.empty?
-        #create a new vlan
+        # create a new vlan
         @vlan = Cisco::Vlan.new(@resource[:id])
+        @property_hash[:ensure] = :present
       end
-      #modify vlan properties
+      # modify vlan properties
       if @resource[:shutdown]
         shutdown = false
-        if @resource[:shutdown] == :true
-          shutdown = true
-        end
+        shutdown = true if @resource[:shutdown] == :true
         @vlan.shutdown = shutdown if @vlan.shutdown != shutdown
       end
       @vlan.vlan_name = @resource[:vlan_name] if @resource[:vlan_name] && @vlan.vlan_name != @resource[:vlan_name]
     end
   end
-
 end

--- a/lib/puppet/provider/network_vlan/nxapi.rb
+++ b/lib/puppet/provider/network_vlan/nxapi.rb
@@ -1,0 +1,57 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/type/cisco_vlan'
+require 'puppet/provider/cisco_vlan/nxapi'
+
+Puppet::Type.type(:network_vlan).provide(:nxapi, :parent => Puppet::Type.type(:cisco_vlan).provider(:nxapi)) do
+  @doc = "cisco VLAN"
+
+  has_features :activable, :describable
+
+  mk_resource_methods
+
+  def self.instances
+    vlans = []
+    Cisco::Vlan.vlans.each { |vlan_id, v|
+      vlan = {
+        :id          => vlan_id,
+        :name        => vlan_id,
+        :vlan_name   => v.send(:vlan_name),
+        :shutdown    => v.send(:shutdown),
+        :ensure      => :present,
+      }
+      vlans << new(vlan)
+    }
+    return vlans
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @vlan.destroy
+      @vlan = nil
+      @property_hash[:ensure] = :absent
+    else
+      if @property_hash.empty?
+        #create a new vlan
+        @vlan = Cisco::Vlan.new(@resource[:id])
+      end
+      #modify vlan properties
+      if @resource[:shutdown]
+        shutdown = false
+        if @resource[:shutdown] == :true
+          shutdown = true
+        end
+        @vlan.shutdown = shutdown if @vlan.shutdown != shutdown
+      end
+      @vlan.vlan_name = @resource[:vlan_name] if @resource[:vlan_name] && @vlan.vlan_name != @resource[:vlan_name]
+    end
+  end
+
+end

--- a/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
@@ -1,0 +1,191 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# NetworkVlan-Provider-NonDefaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet network_vlan resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a network_vlan resource test that tests for nondefault values for
+# domain, search, and servers of a network_vlan resource.
+#
+# There is 2 section to the testcase: Setup, group of teststeps. The 1st step is
+# the Setup teststep that cleans up the switch state.
+# Steps 2-8 deal with network_vlan resource declarations and
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and NetworkVlanLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../network_vlanlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'network_vlan Resource :: All Attributes NonDefaults'
+
+# @test_name [TestCase] Executes nondefaults testcase for network_vlan Resource.
+test_name "TestCase :: #{testheader}" do
+  ## @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider test' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    cmd_str = UtilityLib.get_vshell_cmd('conf t ; no vlan 666')
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout, [/vlan (\d+,)*666\D/],
+                                          true, self, logger)
+    end
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Set the properties in a manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NetworkVlanLib.create_network_vlan_manifest('666',
+                                                           'present',
+                                                           'somename',
+                                                           false,
+                                                          ))
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Set the domain property in a manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks network_vlan resource on agent using resource cmd.
+  step 'TestStep :: Check network_vlan resource on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource network_vlan '666'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          { 'ensure'    => 'present',
+                                            'shutdown'  => 'false',
+                                            'vlan_name' => 'somename' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_vlan resource on agent :: #{result}")
+  end
+
+  # @step [Step] Checks network_vlan instance on agent using switch show cli cmds.
+  step 'TestStep :: Check network_vlan settings on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config vlan')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [
+                                            /vlan (\d+,)*666\D/,
+                                            /vlan 666/,
+                                            /  name somename/,
+                                          ],
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_vlan resource on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Set the properties in a manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, NetworkVlanLib.create_network_vlan_manifest('666',
+                                                           'present',
+                                                           'othername',
+                                                           true,
+                                                          ))
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Set the domain property in a manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks network_vlan resource on agent using resource cmd.
+  step 'TestStep :: Check network_vlan resource on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource network_vlan '666'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          { 'ensure'    => 'present',
+                                            'shutdown'  => 'true',
+                                            'vlan_name' => 'othername' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_vlan resource on agent :: #{result}")
+  end
+
+  # @step [Step] Checks network_vlan instance on agent using switch show cli cmds.
+  step 'TestStep :: Check network_vlan settings on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [
+                                            /vlan (\d+,)*666\D/,
+                                            /vlan 666/,
+                                            /  name othername/,
+                                            /  shutdown/,
+                                          ],
+                                          false, self, logger)
+    end
+
+    logger.info("Check network_vlan resource on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/netdev_stdlib/network_vlanlib.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_vlanlib.rb
@@ -1,0 +1,73 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# Network VLAN Utility Library:
+# ---------------------
+# network_vlanlib.rb
+#
+# This is the utility library for the network_vlan provider Beaker test cases
+# that contains the common methods used across the network_vlan testsuite's
+# cases. The library is implemented as a module with related methods and
+# constants defined inside it for use as a namespace. All of the methods are
+# defined as module methods.
+#
+# Every Beaker network vlan test case that runs an instance of Beaker::TestCase
+# requires NetworkVlanLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for network_vlan Puppet provider test cases.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# A library to assist testing network_vlan resource
+module NetworkVlanLib
+  # A. Methods to create manifests for network_vlan Puppet provider test cases.
+
+  # Method to create a manifest for network_vlan resource properties
+  # @param name [String] The value to pass as the resource title
+  # @param ens [String] The value to pass to the ensure property
+  # @param vname [String] The value to pass to the vlan_name property
+  # @param shut [Boolean] The value to pass to the shutdown property
+  # @result none [None] Returns no object.
+  def self.create_network_vlan_manifest(name, ens, vname, shut)
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  network_vlan { #{name.inspect}:
+    ensure    => #{ens.inspect},
+    vlan_name => #{vname.inspect},
+    shutdown  => #{shut.inspect},
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for network_vlan resource with only ensure
+  # @param name [String] The value to pass as the resource title
+  # @param ensure [String] The value to pass to the ensure property
+  # @result none [None] Returns no object.
+  def self.create_network_vlan_manifest_ensure(name, ens)
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  network_vlan { #{name}:
+    ensure    => #{ens.inspect},
+  }
+}
+EOF"
+    manifest_str
+  end
+end


### PR DESCRIPTION
```
tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb passed in 72.26 seconds
      Test Suite: tests @ 2015-10-21 13:59:25 -0700

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 72.26 seconds
      Average Test Time: 72.26 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1
```

Closes #17