### PR TITLE
Added dummy NXOS provider for radius

### DIFF
--- a/lib/puppet/provider/radius/nxapi.rb
+++ b/lib/puppet/provider/radius/nxapi.rb
@@ -1,0 +1,72 @@
+# The NXAPI provider for radius.
+#
+# October, 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:radius).provide(:nxapi) do
+  desc 'The Cisco NXAPI provider for radius_global.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+    debug 'Created provider instance of radius'
+  end
+
+  def self.get_properties(name)
+    debug "Checking instance, Radius #{name}"
+
+    current_state = {
+      name:   'default',
+    }
+
+    new(current_state)
+  end # self.get_properties
+
+  def self.instances
+    radius = []
+    radius << get_properties('default')
+    radius
+  end
+
+  def self.prefetch(resources)
+    radius = instances
+
+    resources.keys.each do |id|
+      provider = radius.find { |instance| instance.name == id }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def enable
+    @resource[:enable]
+  end
+
+  def enable=(_val)
+    # Do Nothing
+  end
+end # Puppet::Type

--- a/tests/beaker_tests/radius/radius_provider_defaults.rb
+++ b/tests/beaker_tests/radius/radius_provider_defaults.rb
@@ -1,0 +1,101 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# Radius-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a radius resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a radius resource test that tests for default value for
+# 'ensure' attribute of a radius resource.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# Steps 2-4 deal with cisco_snmp_group_resource and its
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and SnmpGroupLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../radiuslib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'radius Resource :: All Attributes Defaults'
+
+# @test_name [TestCase] Executes defaults testcase for radius Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    logger.info('Setup switch for provider')
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, RadiusLib.create_radius_manifest_true)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no changes.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present (with changes)manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, RadiusLib.create_radius_manifest_false)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no changes.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/radius/radiuslib.rb
+++ b/tests/beaker_tests/radius/radiuslib.rb
@@ -1,0 +1,67 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# Radius Global Utility Library:
+# ---------------------
+# radiuslib.rb
+#
+# This is the utility library for the Radius provider Beaker test cases
+# that contains the common methods used across the Radius Server testsuite's
+# cases. The library is implemented as a module with related methods and
+# constants defined inside it for use as a namespace. All of the methods are
+# defined as module methods.
+#
+# Every Beaker Radius test case that runs an instance of Beaker::TestCase
+# requires RadiusSettingLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for radius Puppet provider test cases.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# A library to assist testing radius resource
+module RadiusLib
+  # A. Methods to create manifests for radius Puppet provider test cases.
+
+  # Method to create a manifest for radius true
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_radius_manifest_true
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  radius { 'default':
+    enable => 'true',
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for radius false
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_radius_manifest_false
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  radius { 'default':
+    enable => 'false',
+  }
+}
+EOF"
+    manifest_str
+  end
+end


### PR DESCRIPTION
This is a dummy provider. That is, when a manifest has enable set to either true or false, the provider will come back as if the same value is already set.