### PR TITLE
New cisco_bgp_af properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,22 +367,74 @@ Address Family Identifier (AFI). Required. Valid values are `ipv4` and `ipv6`.
 ##### `safi`
 Sub Address Family Identifier (SAFI). Required. Valid values are `unicast` and `multicast`.
 
+##### `additional_paths_install`
+install a backup path into the forwarding table and provide prefix
+'independent convergence (PIC) in case of a PE-CE link failure.
+Valid values are true, false, or 'default'
+
+##### `additional_paths_receive`
+Enables the receive capability of additional paths for all of the
+neighbors under this address family for which the capability has
+not been disabled.  Valid values are true, false, or 'default'
+
+##### `additional_paths_selection`
+Configures the capability of selecting additional paths for a prefix.
+Valid values are a string defining the name of the route-map.
+
+##### `additional_paths_send`
+Enables the send capability of additional paths for all of the
+neighbors under this address family for which the capability has
+not been disabled. Valid values are true, false, or 'default'
+
 ##### `client_to_client`
-`client-to-client reflection`. Valid values are true and false.
+Configure client-to-client route reflection. Valid values are true and false.
+
+##### `dampen_igp_metric`
+Specify dampen value for IGP metric-related changes, in seconds.
+Valid values are Integer, keyword 'default'.
+
+##### `dampening_state`
+Enable/disable route-flap dampening. Valid values are true, false or 'default'
+
+##### `dampening_half_time`
+Specify decay half-life in minutes for route-flap dampening.
+Valid values are Integer, keyword 'default'.
+
+##### `dampening_max_suppress_time`
+Specify max suppress time for route-flap dampening stable route.
+Valid values are Integer, keyword 'default'.
+
+##### `dampening_reuse_time`
+Specify route reuse time for route-flap dampening.
+Valid values are Integer, keyword 'default'.
+
+##### `dampening_routemap`
+Specify routemap for route-flap dampening.
+Valid values are a string defining the name of the route-map.
+
+##### `dampening_suppress_time`
+Specify route suppress time for route-flap dampening.
+Valid values are Integer, keyword 'default'.
 
 ##### `default_information_originate`
 `default-information originate`. Valid values are true and false.
 
-##### `maximum_path`
-Configures the maximum number of equal-cost paths for load sharing. Valid value is an integer in the range 1-64.
-Default value is 1.
+##### `maximum_paths`
+Configures the maximum number of equal-cost paths for load sharing. Valid value
+is an integer in the range 1-64. Default value is 1.
 
 ##### `maximum_paths_ibgp`
-Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64.
+Configures the maximum number of ibgp equal-cost paths for load
+sharing. Valid value is an integer in the range 1-64.
 Default value is 1.
 
 ##### `next_hop_route_map`
-`nexthop route-map`. Valid values are a string defining a route-map.
+Configure route map for valid nexthops. Valid values are a string
+defining the name of the route-map'.
+
+##### `next_hop_route_map`
+Networks to configure. Valid values match the following format.
+[['IPv4|IPv6 Address','Optional Routemap']]
 
 --
 ### Type: cisco_bgp_neighbor

--- a/README.md
+++ b/README.md
@@ -239,20 +239,16 @@ Manages configuration of a BGP instance.
 #### Parameters
 
 ##### `ensure`
-Determines whether the config should be present or not on the device. Valid
-values are 'present' and 'absent'.
+Determines whether the config should be present or not on the device. Valid values are 'present' and 'absent'.
 
 ##### `asn`
-BGP autonomous system number.  Valid values are String, Integer in ASPLAIN or
-ASDOT notation.
+BGP autonomous system number.  Valid values are String, Integer in ASPLAIN or ASDOT notation.
 
 ##### `vrf`
-Name of the resource instance. Valid values are string. The name 'default' is
-a valid VRF representing the global bgp.
+Name of the resource instance. Valid values are string. The name 'default' is a valid VRF representing the global bgp.
 
 ##### `router_id`
-Router Identifier (ID) of the BGP router VRF instance.
-Valid values are string, and keyword 'default'.
+Router Identifier (ID) of the BGP router VRF instance. Valid values are string, and keyword 'default'.
 
 ##### `cluster_id`
 Route Reflector Cluster-ID. Valid values are String, keyword 'default'.
@@ -264,78 +260,58 @@ Routing domain confederation AS. Valid values are String, keyword 'default'.
 AS confederation parameters. Valid values are String, keyword 'default'.
 
 ##### `enforce_first_as`
-Enable/Disable enforces the neighbor autonomous system to be the first AS number 
-listed in the AS path attribute for eBGP. Valid values are 'true', 'false', and 'default'.
+Enable/Disable enforces the neighbor autonomous system to be the first AS number listed in the AS path attribute for eBGP. Valid values are 'true', 'false', and 'default'.
 
 ##### `maxas_limit`
-Specify Maximum number of AS numbers allowed in the AS-path attribute.
-Valid values are integers between 1 and 512, or keyword 'default' to disable this property.
+Specify Maximum number of AS numbers allowed in the AS-path attribute. Valid values are integers between 1 and 512, or keyword 'default' to disable this property.
 
 ##### `shutdown`
-Administratively shutdown the BGP protocol. Valid values are 'true', 'false',
-and 'default'.
+Administratively shutdown the BGP protocol. Valid values are 'true', 'false', and 'default'.
 
 ##### `supress_fib_pending`
-Enable/Disable advertise only routes that are programmed in hardware to peers.
-Valid values are 'true', 'false', and 'default'
+Enable/Disable advertise only routes programmed in hardware to peers. Valid values are 'true', 'false', and 'default'
 
 ##### `log_neighbor_changes`
-Enable/Disable message logging for neighbor up/down event.
-Valid values are 'true', 'false', and 'default'
+Enable/Disable message logging for neighbor up/down event. Valid values are 'true', 'false', and 'default'
 
 ##### `bestpath_always_compare_med`
-Enable/Disable MED comparison on paths from different autonomous systems.
-Valid values are 'true', 'false', and 'default'.
+Enable/Disable MED comparison on paths from different autonomous systems. Valid values are 'true', 'false', and 'default'.
 
 ##### `bestpath_aspath_multipath_relax`
-Enable/Disable load sharing across the providers with different
-(but equal-length) AS paths. Valid values are 'true', 'false', and 'default'
+Enable/Disable load sharing across the providers with different (but equal-length) AS paths. Valid values are 'true', 'false', and 'default'
 
 ##### `bestpath_compare_routerid`
-Enable/Disable comparison of router IDs for identical eBGP paths.
-Valid values are 'true', 'false', and 'default'
+Enable/Disable comparison of router IDs for identical eBGP paths. Valid values are 'true', 'false', and 'default'
 
 ##### `bestpath_cost_community_ignore`
-Enable/Disable Ignores the cost community for BGP best-path calculations.
-Valid values are 'true', 'false', and 'default'
+Enable/Disable Ignores the cost community for BGP best-path calculations. Valid values are 'true', 'false', and 'default'
 
 ##### `bestpath_med_confed`
-Enable/Disable enforcement of bestpath to do a MED comparison only between
-paths originated within a confederation. Valid values are 'true', 'false',
-and 'default'
+Enable/Disable enforcement of bestpath to do a MED comparison only between paths originated within a confederation. Valid values are 'true', 'false', and 'default'
 
 ##### `bestpath_med_missing_as_worst`
-Enable/Disable assigns the value of infinity to received routes that do not
-carry the MED attribute, making these routes the least desirable. Valid values
-are 'true', 'false', and 'default'.
+Enable/Disable assigns the value of infinity to received routes that do not carry the MED attribute, making these routes the least desirable. Valid values are 'true', 'false', and 'default'.
 
 ##### `bestpath_med_non_deterministic`
-Enable/Disable deterministic selection of the best MED path from among
-the paths from the same autonomous system. Valid values are 'true', 'false',
-and 'default'
+Enable/Disable deterministic selection of the best MED path from among the paths from the same autonomous system. Valid values are 'true', 'false', and 'default'
 
 ##### `timer_bestpath_limit`
-Specify timeout for the first best path after a restart, in seconds.
-Valid values are Integer, keyword 'default'.
+Specify timeout for the first best path after a restart, in seconds. Valid values are Integer, keyword 'default'.
 
 ##### `timer_bestpath_limit_always`
-Enable/Disable update-delay-always option. Valid values are 'true', 'false',
-and 'default'
+Enable/Disable update-delay-always option. Valid values are 'true', 'false', and 'default'
 
 ##### `graceful_restart`
 Enable/Disable graceful restart. Valid values are 'true', 'false', and 'default'
 
 ##### `graceful_restart_helper`
-Enable/Disable graceful restart helper mode. Valid values are 'true', 'false',
-and 'default'
+Enable/Disable graceful restart helper mode. Valid values are 'true', 'false', and 'default'
 
 ##### `graceful_restart_timers_restart`
-Set maximum time for a restart sent to the BGP peer. Valid values are Integer,
-keyword 'default'.
+Set maximum time for a restart sent to the BGP peer. Valid values are Integer, keyword 'default'.
 
 ##### `graceful_restart_timers_stalepath_time`
-Set maximum time that BGP keeps the stale routes from the restarting BGP peer.
-Valid values are Integer, keyword 'default'.
+Set maximum time that BGP keeps the stale routes from the restarting BGP peer. Valid values are Integer, keyword 'default'.
 
 ##### `timer_bgp_keepalive`
 Set bgp keepalive timer. Valid values are Integer, keyword 'default'.
@@ -355,8 +331,7 @@ Determine whether the interface config should be present or not. Valid values
  are 'present' and 'absent'.
 
 ##### `asn`
-BGP autonomous system number. Required. Valid values are String, Integer in ASPLAIN or
-ASDOT notation.
+BGP autonomous system number. Required. Valid values are String, Integer in ASPLAIN or ASDOT notation.
 
 ##### `vrf`
 VRF name. Required. Valid values are string. The name 'default' is a valid VRF representing the global bgp.
@@ -368,73 +343,79 @@ Address Family Identifier (AFI). Required. Valid values are `ipv4` and `ipv6`.
 Sub Address Family Identifier (SAFI). Required. Valid values are `unicast` and `multicast`.
 
 ##### `additional_paths_install`
-install a backup path into the forwarding table and provide prefix
-'independent convergence (PIC) in case of a PE-CE link failure.
-Valid values are true, false, or 'default'
+install a backup path into the forwarding table and provide prefix 'independent convergence (PIC) in case of a PE-CE link failure. Valid values are true, false, or 'default'
 
 ##### `additional_paths_receive`
-Enables the receive capability of additional paths for all of the
-neighbors under this address family for which the capability has
-not been disabled.  Valid values are true, false, or 'default'
+Enables the receive capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled.  Valid values are true, false, or 'default'
 
 ##### `additional_paths_selection`
-Configures the capability of selecting additional paths for a prefix.
-Valid values are a string defining the name of the route-map.
+Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the route-map.
 
 ##### `additional_paths_send`
-Enables the send capability of additional paths for all of the
-neighbors under this address family for which the capability has
-not been disabled. Valid values are true, false, or 'default'
+Enables the send capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled. Valid values are true, false, or 'default'
 
 ##### `client_to_client`
 Configure client-to-client route reflection. Valid values are true and false.
 
 ##### `dampen_igp_metric`
-Specify dampen value for IGP metric-related changes, in seconds.
-Valid values are Integer, keyword 'default'.
+Specify dampen value for IGP metric-related changes, in seconds. Valid values are Integer, keyword 'default'.
 
 ##### `dampening_state`
 Enable/disable route-flap dampening. Valid values are true, false or 'default'
 
 ##### `dampening_half_time`
-Specify decay half-life in minutes for route-flap dampening.
-Valid values are Integer, keyword 'default'.
+Specify decay half-life in minutes for route-flap dampening. Valid values are Integer, keyword 'default'.
 
 ##### `dampening_max_suppress_time`
-Specify max suppress time for route-flap dampening stable route.
-Valid values are Integer, keyword 'default'.
+Specify max suppress time for route-flap dampening stable route. Valid values are Integer, keyword 'default'.
 
 ##### `dampening_reuse_time`
-Specify route reuse time for route-flap dampening.
-Valid values are Integer, keyword 'default'.
+Specify route reuse time for route-flap dampening. Valid values are Integer, keyword 'default'.
 
 ##### `dampening_routemap`
-Specify routemap for route-flap dampening.
-Valid values are a string defining the name of the route-map.
+Specify route-map for route-flap dampening. Valid values are a string defining the name of the route-map.
 
 ##### `dampening_suppress_time`
-Specify route suppress time for route-flap dampening.
-Valid values are Integer, keyword 'default'.
+Specify route suppress time for route-flap dampening. Valid values are Integer, keyword 'default'.
+
+##### Dampening Properties
+Note: dampening_routemap is mutually exclusive with dampening_half_time, reuse_time, suppress_time and max_suppress_time.
 
 ##### `default_information_originate`
 `default-information originate`. Valid values are true and false.
 
 ##### `maximum_paths`
-Configures the maximum number of equal-cost paths for load sharing. Valid value
-is an integer in the range 1-64. Default value is 1.
+Configures the maximum number of equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
 ##### `maximum_paths_ibgp`
-Configures the maximum number of ibgp equal-cost paths for load
-sharing. Valid value is an integer in the range 1-64.
-Default value is 1.
+Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
 ##### `next_hop_route_map`
-Configure route map for valid nexthops. Valid values are a string
-defining the name of the route-map'.
+Configure route map for valid nexthops. Valid values are a string defining the name of the route-map.
 
-##### `next_hop_route_map`
-Networks to configure. Valid values match the following format.
-[['IPv4|IPv6 Address','Optional Routemap']]
+##### `networks`
+Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional route-map.
+
+Example: IPv4 Networks Array
+
+```ruby
+[
+ ['10.0.0.0/16', 'routemap_LA'],
+ ['192.168.1.1', 'Chicago'],
+ ['192.168.2.0/24],
+ ['192.168.3.0/24', 'routemap_NYC']
+]
+```
+
+Example: IPv6 Networks Array
+
+```ruby
+[
+ ['10::0/64', 'routemap_LA'],
+ ['192:168::1', 'Chicago'],
+ ['192:168::/32]
+]
+```
 
 --
 ### Type: cisco_bgp_neighbor
@@ -444,104 +425,73 @@ Manages configuration of a BGP Neighbor.
 #### Parameters
 
 ###### `ensure`
-Determine whether the neighbor config should be present or not. Valid values 
-are 'present' and 'absent'.
+Determine whether the neighbor config should be present or not. Valid values are 'present' and 'absent'.
 
 ##### `asn`
-BGP autonomous system number. Required. Valid values are String, Integer in 
-ASPLAIN or ASDOT notation.
+BGP autonomous system number. Required. Valid values are String, Integer in  ASPLAIN or ASDOT notation.
 
 ##### `vrf`
-VRF name. Required. Valid values are string. The name 'default' is a valid
-VRF representing the global bgp.
+VRF name. Required. Valid values are string. The name 'default' is a valid VRF representing the global bgp.
 
 ##### `neighbor`
-Neighbor Identifier. Required. Valid values are string. Neighbors may use
-IPv4 or IPv6 notation, with or without prefix length.
+Neighbor Identifier. Required. Valid values are string. Neighbors may use IPv4 or IPv6 notation, with or without prefix length.
 
 ##### `description`
 Description of the neighbor. Valid value is string.
 
 ##### `connected_check`
-Configure whether or not to check for directly connected peer. Valid values are 
-true and false.
+Configure whether or not to check for directly connected peer. Valid values are true and false.
 
 ##### `capability_negotiation`
-Configure whether or not to negotiate capability with this neighbor. Valid 
-values are true and false.
+Configure whether or not to negotiate capability with this neighbor. Valid  values are true and false.
 
 ##### `dynamic_capability`
-Configure whether or not to enable dynamic capability. Valid values are true
-and false.
+Configure whether or not to enable dynamic capability. Valid values are true and false.
 
 ##### `ebgp_multihop`
-Specify multihop TTL for a remote peer. Valid values are integers between 2 
-and 255, or keyword 'default' to disable this property.
+Specify multihop TTL for a remote peer. Valid values are integers between 2  and 255, or keyword 'default' to disable this property.
 
 ##### `local_as`
-Specify the local-as number for the eBGP neighbor. Valid values are String or
-Integer in ASPLAIN or ASDOT notation, or 'default', which means not to 
-configure it.
+Specify the local-as number for the eBGP neighbor. Valid values are String or Integer in ASPLAIN or ASDOT notation, or 'default', which means not to configure it.
 
 ##### `log_neighbor_changes`
-Specify wether or not to enable log messages for neighbor up/down event. Valid 
-values are 'enable', to enable it, 'disable' to disable it, or 'inherit' to use
-the configuration in the cisco_bgp type.
+Specify wether or not to enable log messages for neighbor up/down event. Valid values are 'enable', to enable it, 'disable' to disable it, or 'inherit' to use the configuration in the cisco_bgp type.
 
 ##### `low_memory_exempt`
-Specify whether or not to shut down this neighbor under memory pressue. Valid
-values are 'true' to exempt the neighbor from being shutdown, 'false' to shut it 
-down, or 'default' to perform the default shutdown behavior"
+Specify whether or not to shut down this neighbor under memory pressure. Valid values are 'true' to exempt the neighbor from being shutdown, 'false' to shut it down, or 'default' to perform the default shutdown behavior"
 
 ##### `maximum_peers`
-Specify Maximum number of peers for this neighbor prefix. Valid values are 
-between 1 and 1000, or 'default', which does not impose the limit. This 
-attribute can only be configured if neighbor is in 'ip/prefix' format.
+Specify Maximum number of peers for this neighbor prefix. Valid values are between 1 and 1000, or 'default', which does not impose the limit. This  attribute can only be configured if neighbor is in 'ip/prefix' format.
 
 ##### `password`
 Specify the password for neighbor. Valid value is string.
 
 ##### `password_type`
-Specify the encryption type the password will use. Valid values are 
-'cleartext', '3des' or 'cisco_type_7' encryption, and 'default', which
-defaults to 'cleartext'.
+Specify the encryption type the password will use. Valid values are 'cleartext', '3des' or 'cisco_type_7' encryption, and 'default',which defaults to 'cleartext'.
 
 ##### `remote_as`
-Specify Autonomous System Number of the neighbor. Valid values are String or 
-Integer in ASPLAIN or ASDOT notation, or 'default', which means not to
-configure it. 
+Specify Autonomous System Number of the neighbor. Valid values are String or Integer in ASPLAIN or ASDOT notation, or 'default', which means not to configure it. 
 
 ##### `remove_private_as`
-Specify the config to remove private AS number from outbound updates. Valid 
-values are 'enable' to enable this config, 'disable' to disable this config,
-'all' to remove all private AS number, or 'replace-as', to replace the 
-private AS number.
+Specify the config to remove private AS number from outbound updates. Valid  values are 'enable' to enable this config, 'disable' to disable this config, 'all' to remove all private AS number, or 'replace-as', to replace the private AS number.
 
 ##### `shutdown`
-Configure to administratively shutdown this neighbor. Valid values are true
-and false.
+Configure to administratively shutdown this neighbor. Valid values are true and false.
 
 ##### `suppress_4_byte_as`
-Configure to suppress 4-byte AS Capability. Valid values are 'true', 'false',
-and 'default', which sets to the default 'false' value.
+Configure to suppress 4-byte AS Capability. Valid values are 'true', 'false', and 'default', which sets to the default 'false' value.
 
 ##### `timers_keepalive`
-Specify keepalive timer value. Valid values are integers between 0 and 3600
-in terms of seconds, or 'default', which is 60.
+Specify keepalive timer value. Valid values are integers between 0 and 3600 in terms of seconds, or 'default', which is 60.
 
 ##### `timers_holdtime`
-Specify holdtime timer value. Valid values are integers between 0 and 3600 in
-terms of seconds, or 'default', which is 180.
+Specify holdtime timer value. Valid values are integers between 0 and 3600 in terms of seconds, or 'default', which is 180.
 
 ##### `transport_passive_only`
-Configure whether or not to only allow passive connection setup. Valid values
-are 'true', 'false', and 'default', which defaults to 'false'. This attribute
-can only be configured when the neighbor is in 'ip' address format without
-prefix length.
+Configure whether or not to only allow passive connection setup. Valid values are 'true', 'false', and 'default', which defaults to 'false'. This attribute can only be configured when the neighbor is in 'ip' address format without prefix length.
 
 ##### `update_source`
-Specify source interface of BGP session and updates. Valid value is a string
-of the interface name.
+Specify source interface of BGP session and updates. Valid value is a string of the interface name.
 
 --
 ### Type: cisco_bgp_neighbor_af

--- a/examples/demo_bgp.pp
+++ b/examples/demo_bgp.pp
@@ -78,15 +78,16 @@ class ciscopuppet::demo_bgp {
     additional_paths_send         => true,
     dampen_igp_metric             => 55,
     networks                      => $ipv4_networks,
+
+    # dampening_routemap is mutually exclusive with
+    # dampening_half_time, reuse_time, suppress_time
+    # and max_suppress_time.
+    #
     dampening_state               => true,
     dampening_half_time           => 1,
     dampening_reuse_time          => 2,
     dampening_suppress_time       => 3,
     dampening_max_suppress_time   => 4,
-    # dampening_routemap is mutually exclusive with
-    # dampening_half_time, reuse_time, suppress_time
-    # and max_suppress_time.
-    #
     #dampening_routemap            => default,
   }
 
@@ -94,7 +95,6 @@ class ciscopuppet::demo_bgp {
   # Configure Address Family IPv6 Unicast                                     #
   # --------------------------------------------------------------------------#
   $ipv6_networks = [['192:168::5:0/64', 'nrtemap1'], ['192:168::6:0/64']]
-  #$networks = []
   cisco_bgp_af { 'ipv6_default':
     ensure                        => present,
     asn                           => 55.77,
@@ -113,15 +113,16 @@ class ciscopuppet::demo_bgp {
     additional_paths_send         => true,
     dampen_igp_metric             => 55,
     networks                      => $ipv6_networks,
+
+    # dampening_routemap is mutually exclusive with
+    # dampening_half_time, reuse_time, suppress_time
+    # and max_suppress_time.
+    #
     dampening_state               => true,
     #dampening_half_time           => 1,
     #dampening_reuse_time          => 2,
     #dampening_suppress_time       => 3,
     #dampening_max_suppress_time   => 4,
-    # dampening_routemap is mutually exclusive with
-    # dampening_half_time, reuse_time, suppress_time
-    # and max_suppress_time.
-    #
     dampening_routemap            => 'RouteMap',
   }
 

--- a/examples/demo_bgp.pp
+++ b/examples/demo_bgp.pp
@@ -57,139 +57,156 @@ class ciscopuppet::demo_bgp {
   # --------------------------------------------------------------------------#
   # Configure Address Family IPv4 Unicast                                     #
   # --------------------------------------------------------------------------#
+  $ipv4_networks = [['192.168.5.0/24', 'nrtemap1'], ['192.168.6.0/32']]
+  #$networks = []
   cisco_bgp_af { 'default':
-    ensure                                 => present,
-    asn                                    => 55.77,
-    vrf                                    => 'blue',
-    afi                                    => 'ipv4',
-    safi                                   => 'unicast',
+    ensure                        => present,
+    asn                           => 55.77,
+    vrf                           => 'blue',
+    afi                           => 'ipv4',
+    safi                          => 'unicast',
 
     # Properties
-    client_to_client                       => false,
-    default_information_originate          => false,
-    maximum_paths                          => '7',
-    maximum_paths_ibgp                     => '7',
-    next_hop_route_map                     => 'RouteMap',
-  }
-
-  # --------------------------------------------------------------------------#
-  # Configure Address Family IPv4 Multicast                                   #
-  # --------------------------------------------------------------------------#
-  cisco_bgp_af { 'default':
-    ensure                                 => present,
-    asn                                    => 55.77,
-    vrf                                    => 'blue',
-    afi                                    => 'ipv4',
-    safi                                   => 'multicast',
-
-    # Properties
-    client_to_client                       => false,
-    default_information_originate          => false,
-    maximum_paths                          => '7',
-    maximum_paths_ibgp                     => '7',
-    next_hop_route_map                     => 'RouteMap',
+    client_to_client              => false,
+    default_information_originate => true,
+    maximum_paths                 => '7',
+    maximum_paths_ibgp            => '7',
+    next_hop_route_map            => 'RouteMap',
+    additional_paths_install      => true,
+    additional_paths_receive      => true,
+    additional_paths_selection    => 'RouteMap',
+    additional_paths_send         => true,
+    dampen_igp_metric             => 55,
+    networks                      => $ipv4_networks,
+    dampening_state               => true,
+    dampening_half_time           => 1,
+    dampening_reuse_time          => 2,
+    dampening_suppress_time       => 3,
+    dampening_max_suppress_time   => 4,
+    # dampening_routemap is mutually exclusive with
+    # dampening_half_time, reuse_time, suppress_time
+    # and max_suppress_time.
+    #
+    #dampening_routemap            => default,
   }
 
   # --------------------------------------------------------------------------#
   # Configure Address Family IPv6 Unicast                                     #
   # --------------------------------------------------------------------------#
-  cisco_bgp_af { 'default':
-    ensure                                 => present,
-    asn                                    => 55.77,
-    vrf                                    => 'blue',
-    afi                                    => 'ipv6',
-    safi                                   => 'unicast',
+  $ipv6_networks = [['192:168::5:0/64', 'nrtemap1'], ['192:168::6:0/64']]
+  #$networks = []
+  cisco_bgp_af { 'ipv6_default':
+    ensure                        => present,
+    asn                           => 55.77,
+    vrf                           => 'blue',
+    afi                           => 'ipv6',
+    safi                          => 'unicast',
 
     # Properties
-    client_to_client                       => false,
-    default_information_originate          => false,
-    maximum_paths                          => '7',
-    maximum_paths_ibgp                     => '7',
-    next_hop_route_map                     => 'RouteMap',
+    client_to_client              => false,
+    default_information_originate => true,
+    maximum_paths                 => '7',
+    maximum_paths_ibgp            => '7',
+    next_hop_route_map            => 'RouteMap',
+    additional_paths_receive      => true,
+    additional_paths_selection    => 'RouteMap',
+    additional_paths_send         => true,
+    dampen_igp_metric             => 55,
+    networks                      => $ipv6_networks,
+    dampening_state               => true,
+    #dampening_half_time           => 1,
+    #dampening_reuse_time          => 2,
+    #dampening_suppress_time       => 3,
+    #dampening_max_suppress_time   => 4,
+    # dampening_routemap is mutually exclusive with
+    # dampening_half_time, reuse_time, suppress_time
+    # and max_suppress_time.
+    #
+    dampening_routemap            => 'RouteMap',
   }
 
   #---------------------------------------------------------------------------#
   # Configure A BGP Neighbor
   #---------------------------------------------------------------------------#
   cisco_bgp_neighbor {'default':
-    ensure                                 => present,
-    asn                                    => 55.77,
-    vrf                                    => 'blue',
-    neighbor                               => '1.1.1.1',
+    ensure                 => present,
+    asn                    => 55.77,
+    vrf                    => 'blue',
+    neighbor               => '1.1.1.1',
 
     #Properties
-    description                            => 'my description',
-    connected_check                        => true,
-    capability_negotiation                 => true,
-    dynamic_capability                     => true,
-    ebgp_multihop                          => 2,
-    local_as                               => 55.77,
-    log_neighbor_changes                   => disable,
-    low_memory_exempt                      => false,
-    remote_as                              => 12,
-    remove_private_as                      => 'all',
-    shutdown                               => true,
-    suppress_4_byte_as                     => true,
-    timers_keepalive                       => 90,
-    timers_holdtime                        => 270,
-    update_source                          => 'ethernet1/1',
-    transport_passive_only                 => false,
+    description            => 'my description',
+    connected_check        => true,
+    capability_negotiation => true,
+    dynamic_capability     => true,
+    ebgp_multihop          => 2,
+    local_as               => 55.77,
+    log_neighbor_changes   => disable,
+    low_memory_exempt      => false,
+    remote_as              => 12,
+    remove_private_as      => 'all',
+    shutdown               => true,
+    suppress_4_byte_as     => true,
+    timers_keepalive       => 90,
+    timers_holdtime        => 270,
+    update_source          => 'ethernet1/1',
+    transport_passive_only => false,
   }
 
   # --------------------------------------------------------------------------#
   # Configure Neighbor-level Address Family IPv4 Unicast
   # --------------------------------------------------------------------------#
   cisco_bgp_neighbor_af { '55.77 blue 1.1.1.1 ipv4 unicast':
-    ensure                                 => present,
+    ensure                      => present,
 
     # Properties
-    additional_paths_receive               => 'enable',
-    additional_paths_send                  => 'disable',
-    allowas_in_max                         => 5,
-    default_originate_route_map            => 'my_def_map',
-    disable_peer_as_check                  => true,
-    filter_list_in                         => 'flin',
-    filter_list_out                        => 'flout',
-    max_prefix_limit                       => 100,
-    max_prefix_threshold                   => 50,
-    max_prefix_interval                    => 30,
-    next_hop_self                          => true,
-    next_hop_third_party                   => false,
-    prefix_list_in                         => 'pfx_in',
-    prefix_list_out                        => 'pfx_out',
-    route_map_in                           => 'rm_in',
-    route_map_out                          => 'rm_out',
-    send_community                         => 'extended',
-    soft_reconfiguration_in                => 'always',
-    soo                                    => '3:3',
-    suppress_inactive                      => true,
-    unsuppress_map                         => 'unsup_map',
-    weight                                 => 30,
+    additional_paths_receive    => 'enable',
+    additional_paths_send       => 'disable',
+    allowas_in_max              => 5,
+    default_originate_route_map => 'my_def_map',
+    disable_peer_as_check       => true,
+    filter_list_in              => 'flin',
+    filter_list_out             => 'flout',
+    max_prefix_limit            => 100,
+    max_prefix_threshold        => 50,
+    max_prefix_interval         => 30,
+    next_hop_self               => true,
+    next_hop_third_party        => false,
+    prefix_list_in              => 'pfx_in',
+    prefix_list_out             => 'pfx_out',
+    route_map_in                => 'rm_in',
+    route_map_out               => 'rm_out',
+    send_community              => 'extended',
+    soft_reconfiguration_in     => 'always',
+    soo                         => '3:3',
+    suppress_inactive           => true,
+    unsuppress_map              => 'unsup_map',
+    weight                      => 30,
   }
 
   # --------------------------------------------------------------------------#
   # Configure A BGP Neighbor using title pattern
   # --------------------------------------------------------------------------#
   cisco_bgp_neighbor { '55.77 blue2 2.2.2.0/24':
-    ensure                                 => present,
+    ensure                 => present,
 
     #Properties
-    description                            => 'my description',
-    connected_check                        => true,
-    capability_negotiation                 => true,
-    dynamic_capability                     => true,
-    ebgp_multihop                          => 2,
-    local_as                               => 55.77,
-    log_neighbor_changes                   => disable,
-    low_memory_exempt                      => false,
-    remote_as                              => 12,
-    remove_private_as                      => 'all',
-    shutdown                               => true,
-    suppress_4_byte_as                     => true,
-    timers_keepalive                       => 90,
-    timers_holdtime                        => 270,
-    update_source                          => 'ethernet1/1',
-    maximum_peers                          => 2,
+    description            => 'my description',
+    connected_check        => true,
+    capability_negotiation => true,
+    dynamic_capability     => true,
+    ebgp_multihop          => 2,
+    local_as               => 55.77,
+    log_neighbor_changes   => disable,
+    low_memory_exempt      => false,
+    remote_as              => 12,
+    remove_private_as      => 'all',
+    shutdown               => true,
+    suppress_4_byte_as     => true,
+    timers_keepalive       => 90,
+    timers_holdtime        => 270,
+    update_source          => 'ethernet1/1',
+    maximum_peers          => 2,
   }
 
   # TBD: The following manifests need cisco_bgp_neighbor to define remote-as ***

--- a/lib/puppet/provider/cisco_bgp_af/nxapi.rb
+++ b/lib/puppet/provider/cisco_bgp_af/nxapi.rb
@@ -40,8 +40,8 @@ Puppet::Type.type(:cisco_bgp_af).provide(:nxapi) do
   BGP_AF_NON_BOOL_PROPS = [
     :additional_paths_selection,
     :dampen_igp_metric,
-    :dampening_max_suppress_time,
     :dampening_half_time,
+    :dampening_max_suppress_time,
     :dampening_reuse_time,
     :dampening_routemap,
     :dampening_suppress_time,
@@ -96,6 +96,7 @@ Puppet::Type.type(:cisco_bgp_af).provide(:nxapi) do
       val = obj.send(prop)
       current_state[prop] = val.nil? ? nil : val.to_s.to_sym
     end
+    # Call custom networks getter.
     current_state[:networks] = obj.networks
     new(current_state)
   end # self.properties_get
@@ -226,6 +227,11 @@ Puppet::Type.type(:cisco_bgp_af).provide(:nxapi) do
     end
   end
 
+  # Networks requires a custom getter and setter because we are
+  # working with arrays.  When the manifest entry is set to default,
+  # puppet creates an array with the symbol default. [:default].
+  # The net result is the getter needs to return [:default] and
+  # the setter must check the array for symbol :default.
   def networks
     return @property_hash[:networks] if @resource[:networks].nil?
     if @resource[:networks][0] == :default &&

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -239,8 +239,8 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property client_to_client
 
   newproperty(:dampen_igp_metric) do
-    desc "Specify dampen value for IGP metric-related changes, in seconds.
-          Valid values are Integer, keyword 'default'."
+    desc 'Specify dampen value for IGP metric-related changes, in seconds. ' \
+          "Valid values are Integer, keyword 'default'."
 
     munge do |value|
       begin
@@ -254,15 +254,15 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property dampen_igp_metric
 
   newproperty(:dampening_state) do
-    desc "Enable/disable route-flap dampening.
-          Valid values are true, false or 'default'"
+    desc 'Enable/disable route-flap dampening. ' \
+          "Valid values are true, false or 'default'."
 
     newvalues(:true, :false, :default)
   end # property dampening
 
   newproperty(:dampening_half_time) do
-    desc "Specify decay half-life in minutes for route-flap dampening.
-          Valid values are Integer, keyword 'default'."
+    desc 'Specify decay half-life in minutes for route-flap dampening. ' \
+          "Valid values are Integer, keyword 'default'."
 
     munge do |value|
       begin
@@ -276,8 +276,8 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property dampening_half_time
 
   newproperty(:dampening_max_suppress_time) do
-    desc "Specify max suppress time for route-flap dampening stable route.
-          Valid values are Integer, keyword 'default'."
+    desc 'Specify max suppress time for route-flap dampening stable route. ' \
+          "Valid values are Integer, keyword 'default'."
 
     munge do |value|
       begin
@@ -291,8 +291,8 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property dampening_max_suppress_time
 
   newproperty(:dampening_reuse_time) do
-    desc "Specify route reuse time for route-flap dampening.
-          Valid values are Integer, keyword 'default'."
+    desc 'Specify route reuse time for route-flap dampening. ' \
+          "Valid values are Integer, keyword 'default'."
 
     munge do |value|
       begin
@@ -306,8 +306,8 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property dampening_reuse_time
 
   newproperty(:dampening_routemap) do
-    desc "Specify routemap for route-flap dampening.
-          Valid values are a string defining the name of the route-map."
+    desc 'Specify routemap for route-flap dampening. ' \
+          'Valid values are a string defining the name of the route-map.'
 
     validate do |value|
       fail("'dampening_routemap' value must be a string") unless
@@ -321,8 +321,8 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property dampening_routemap
 
   newproperty(:dampening_suppress_time) do
-    desc "Specify route suppress time for route-flap dampening.
-          Valid values are Integer, keyword 'default'."
+    desc 'Specify route suppress time for route-flap dampening. ' \
+          "Valid values are Integer, keyword 'default'."
 
     munge do |value|
       begin
@@ -343,8 +343,10 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property :default_information_originate
 
   newproperty(:maximum_paths) do
-    desc "Configures the maximum number of equal-cost paths for load sharing.
-          Valid values are integers in the range 1 - 64, default value is 1."
+    desc 'Configures the maximum number of equal-cost paths for load ' \
+          'sharing. Valid values are integers in the range 1 - 64, ' \
+          'default value is 1.'
+
     munge do |value|
       value = :default if value == 'default'
       unless value == :default
@@ -357,8 +359,10 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property :maximum_paths
 
   newproperty(:maximum_paths_ibgp) do
-    desc "Configures the maximum number of ibgp equal-cost paths for load sharing.
-          Valid values are integers in the range 1 - 64, default value is 1."
+    desc 'Configures the maximum number of ibgp equal-cost paths for load ' \
+         'sharing. Valid values are integers in the range 1 - 64, default ' \
+         'value is 1.'
+
     munge do |value|
       value = :default if value == 'default'
       unless value == :default

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -31,6 +31,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
 
   Example:
 
+  $network_list = [['192.168.5.0/24', 'rtmap1'], ['192.168.10.0/24']]
   ~~~puppet
     cisco_bgp_af { 'raleigh':
       ensure                                 => present,
@@ -38,12 +39,23 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       vrf                                    => 'default',
       afi                                    => 'ipv4',
       safi                                   => 'unicast',
-
+      additional_paths_install               => 'true',
+      additional_paths_receive               => 'true',
+      additional_paths_selection             => 'Route_Map',
+      additional_paths_send                  => 'true',
       client_to_client                       => 'true',
+      dampen_igp_metric                      => 200,
+      dampening_state                        => 'true',
+      dampening_half_time                    => 5,
+      dampening_max_suppress_time            => 200,
+      dampening_reuse_time                   => 10,
+      dampening_routemap                     => 'Dampening_Route_Map',
+      dampening_suppress_time                => 15,
       default_information_originate          => 'true',
       maximum_paths                          => '7',
       maximum_paths_ibgp                     => '7',
       next_hop_route_map                     => 'Default_Route_Map',
+      network                                => $network_list,
     }
   ~~~
 
@@ -154,7 +166,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       end
     end
 
-    munge { |value| Cisco::RouterBgp.process_asnum(value) }
+    munge { |value| Cisco::RouterBgp.process_asnum(value.to_s) }
   end
 
   newparam(:vrf, namevar: true) do
@@ -179,21 +191,153 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   # Properties #
   ##############
 
-  validate do
-    fail("The 'asn' parameter must be set in the manifest.") if self[:asn].nil?
-    fail("The 'afi' parameter must be set in the manifest.") if self[:afi].nil?
-    fail("The 'safi' parameter must be set in the manifest.") if self[:safi].nil?
-  end
+  newproperty(:additional_paths_install) do
+    desc 'install a backup path into the forwarding table and provide prefix ' \
+         'independent convergence (PIC) in case of a PE-CE link failure. ' \
+         "Valid values are true, false, or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property additional_paths_install
+
+  newproperty(:additional_paths_receive) do
+    desc 'Enables the receive capability of additional paths for all' \
+      'of the neighbors under this address family for which the ' \
+      'capability has not been disabled. ' \
+      "Valid values are true, false, or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property additional_paths_receive
+
+  newproperty(:additional_paths_selection) do
+    desc 'Configures the capability of selecting additional paths for a prefix. ' \
+      'Valid values are a string defining the name of the route-map.'
+
+    validate do |value|
+      fail("'additional_paths_selection' value must be a string") unless
+        value.is_a? String
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property additional_paths_selection
+
+  newproperty(:additional_paths_send) do
+    desc 'Enables the send capability of additional paths for all of the ' \
+      'neighbors under this address family for which the capability has ' \
+      "not been disabled. Valid values are true, false, or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property additional_paths_send
 
   newproperty(:client_to_client) do
-    desc "client_to_client. Valid values are true, false, or 'default'"
+    desc 'Configure client-to-client route reflection. Valid values are ' \
+         "true, false, or 'default'"
 
     newvalues(:true, :false, :default)
   end # property client_to_client
 
+  newproperty(:dampen_igp_metric) do
+    desc "Specify dampen value for IGP metric-related changes, in seconds.
+          Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "'dampen_igp_metric' must be an Integer."
+      end # rescue
+      value
+    end
+  end # property dampen_igp_metric
+
+  newproperty(:dampening_state) do
+    desc "Enable/disable route-flap dampening.
+          Valid values are true, false or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property dampening
+
+  newproperty(:dampening_half_time) do
+    desc "Specify decay half-life in minutes for route-flap dampening.
+          Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "'dampening_half_time' must be an Integer."
+      end # rescue
+      value
+    end
+  end # property dampening_half_time
+
+  newproperty(:dampening_max_suppress_time) do
+    desc "Specify max suppress time for route-flap dampening stable route.
+          Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "'dampening_max_suppress_time' must be an Integer."
+      end # rescue
+      value
+    end
+  end # property dampening_max_suppress_time
+
+  newproperty(:dampening_reuse_time) do
+    desc "Specify route reuse time for route-flap dampening.
+          Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "'dampening_reuse_time' must be an Integer."
+      end # rescue
+      value
+    end
+  end # property dampening_reuse_time
+
+  newproperty(:dampening_routemap) do
+    desc "Specify routemap for route-flap dampening.
+          Valid values are a string defining the name of the route-map."
+
+    validate do |value|
+      fail("'dampening_routemap' value must be a string") unless
+        value.is_a? String
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property dampening_routemap
+
+  newproperty(:dampening_suppress_time) do
+    desc "Specify route suppress time for route-flap dampening.
+          Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "'dampening_suppress_time' must be an Integer."
+      end # rescue
+      value
+    end
+  end # property dampening_suppress_time
+
   newproperty(:default_information_originate) do
-    desc ':default_information_originate. Valid values are true, ' \
-      "false, or 'default'"
+    desc 'Control distribution of default information. Valid values are, ' \
+      "true, false, or 'default'"
 
     newvalues(:true, :false, :default)
   end # property :default_information_originate
@@ -227,12 +371,83 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   end # property :maximum_paths_ibgp
 
   newproperty(:next_hop_route_map) do
-    desc ':next_hop_route_map in state. Valid values are a string ' \
+    desc 'Configure route map for valid nexthops. Valid values are a string ' \
       "defining the name of the route-map'."
+
+    validate do |value|
+      fail("'next_hop_route_map' value must be a string") unless
+        value.is_a? String
+    end
 
     munge do |value|
       value = :default if value == 'default'
       value
     end
   end # property next_hop_route_map
+
+  newproperty(:networks, array_matching: :all) do
+    format = "[['network string'], ['routemap string]]"
+    desc "Networks to configure. Valid values match format #{format}."
+
+    # Override puppet's insync method, which checks whether current value is
+    # equal to value specified in manifest.  Make sure puppet considers
+    # 2 arrays with same elements but in different order as equal.
+    def insync?(is)
+      (is.size == should.size && is.sort == should.sort)
+    end
+
+    munge do |value|
+      begin
+        return value = :default if value == 'default'
+        fail("Value must match format #{format}") unless value.is_a?(Array)
+        if Cisco::Utils.process_network_mask(value[0]).split('/')[1].nil?
+          fail("Must supply network mask for #{value[0]}")
+        end
+        value
+      end
+    end
+  end # property networks
+
+  # Make sure dampening parameters are set properly in the manifest.
+  validate do
+    fail("The 'asn' parameter must be set in the manifest.") if self[:asn].nil?
+    fail("The 'afi' parameter must be set in the manifest.") if self[:afi].nil?
+    fail("The 'safi' parameter must be set in the manifest.") if self[:safi].nil?
+
+    # Don't need to process remaining checks if ensure => absent.
+    return if self[:ensure] == :absent
+
+    def route_flap_properties?
+      self[:dampening_half_time] || self[:dampening_reuse_time] ||
+        self[:dampening_suppress_time] || self[:dampening_max_suppress_time]
+    end
+
+    def all_properties?
+      self[:dampening_half_time] || self[:dampening_reuse_time] ||
+        self[:dampening_suppress_time] || self[:dampening_max_suppress_time] ||
+        self[:dampening_routemap]
+    end
+    properties = [
+      :dampening_half_time,
+      :dampening_reuse_time,
+      :dampening_suppress_time,
+      :dampening_max_suppress_time,
+      :dampening_routemap,
+    ]
+    if all_properties? && self[:dampening_state] == :false
+      fail(":dampening_state cannot be 'false' when #{properties} are set")
+    end
+    # If any of these properties are set, then all of them must be.
+    if route_flap_properties?
+      properties.delete(:dampening_routemap)
+      properties.each do |prop|
+        if self[prop].nil?
+          fail("Must set all or none of the following properties #{properties}")
+        end
+      end
+      if self[:dampening_routemap]
+        fail(":dampening_routemap should not be set when #{properties} are set")
+      end
+    end
+  end
 end

--- a/tests/beaker_tests/bgpaf/test_bgpaf.rb
+++ b/tests/beaker_tests/bgpaf/test_bgpaf.rb
@@ -111,31 +111,86 @@ tests = {
 
 # default_properties
 #
-# client_to_client (default is no client-to-client reflection)
-# default_information_originate
 tests['default_properties'] = {
   :desc           => '1.1 Default Properties',
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
+    additional_paths_install      => 'default',
+    additional_paths_receive      => 'default',
+    additional_paths_selection    => 'default',
+    additional_paths_send         => 'default',
     client_to_client              => 'default',
+    dampen_igp_metric             => 'default',
+    dampening_state               => 'default',
+    dampening_half_time           => 'default',
+    dampening_max_suppress_time   => 'default',
+    dampening_reuse_time          => 'default',
+    dampening_suppress_time       => 'default',
     default_information_originate => 'default',
     maximum_paths                 => 'default',
     maximum_paths_ibgp            => 'default',
+    next_hop_route_map            => 'default',
+    networks                      => 'default',
     ",
 
   :resource_props => {
-    'client_to_client'              => 'false',
+    'additional_paths_install'      => 'false',
+    'additional_paths_receive'      => 'false',
+    'additional_paths_send'         => 'false',
+    'client_to_client'              => 'true',
+    'dampen_igp_metric'             => '600',
+    'dampening_state'               => 'true',
+    'dampening_half_time'           => '15',
+    'dampening_max_suppress_time'   => '45',
+    'dampening_reuse_time'          => '750',
+    'dampening_suppress_time'       => '2000',
     'default_information_originate' => 'false',
     'maximum_paths'                 => '1',
     'maximum_paths_ibgp'            => '1',
   },
 }
 
+# Special case: When dampening_routemap is set to default
+# it means that dampening is enabled without routemap.
+tests['default_dampening_routemap'] = {
+  :desc           => '1.2 Default dampening_routemap',
+  :title_pattern  => '2 blue ipv4 unicast',
+  :manifest_props => "
+    dampening_routemap            => 'default',
+    ",
+
+  :resource_props => {
+    'dampening_state'             => 'true',
+    'dampening_half_time'         => '15',
+    'dampening_max_suppress_time' => '45',
+    'dampening_reuse_time'        => '750',
+    'dampening_suppress_time'     => '2000',
+  },
+}
+
 #
 # non_default_properties
 #
+tests['non_default_properties_A'] = {
+  :desc           => "2.1 Non Default Properties: 'A' commands",
+  :title_pattern  => '2 blue ipv4 unicast',
+  :manifest_props => "
+    additional_paths_install        => true,
+    additional_paths_receive        => true,
+    additional_paths_selection      => 'RouteMap',
+    additional_paths_send           => true,
+  ",
+
+  :resource_props => {
+    'additional_paths_install'   => 'true',
+    'additional_paths_receive'   => 'true',
+    'additional_paths_selection' => 'RouteMap',
+    'additional_paths_send'      => 'true',
+  },
+}
+
 tests['non_default_properties_C'] = {
-  :desc           => "2.1 Non Default Properties: 'C' commands",
+  :desc           => "2.2 Non Default Properties: 'C' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
     client_to_client                => false,
@@ -147,19 +202,72 @@ tests['non_default_properties_C'] = {
 }
 
 tests['non_default_properties_D'] = {
-  :desc           => "2.2 Non Default Properties: 'D' commands",
+  :desc           => "2.3 Non Default Properties: 'D' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
+    dampen_igp_metric               => 200,
+    dampening_half_time             => 1,
+    dampening_max_suppress_time     => 4,
+    dampening_reuse_time            => 2,
+    dampening_suppress_time         => 3,
     default_information_originate   => true,
   ",
 
   :resource_props => {
+    'dampen_igp_metric'             => '200',
+    'dampening_half_time'           => '1',
+    'dampening_max_suppress_time'   => '4',
+    'dampening_reuse_time'          => '2',
+    'dampening_suppress_time'       => '3',
     'default_information_originate' => 'true',
   },
 }
 
+# Special case: Just dampening_state, no properties.
+tests['non_default_properties_Dampening_true'] = {
+  :desc           => '2.3.1 Non-Default dampening true',
+  :title_pattern  => '2 blue ipv4 unicast',
+  :manifest_props => "
+    dampening_state               => 'true',
+    ",
+
+  :resource_props => {
+    'dampening_state'             => 'true',
+    'dampening_half_time'         => '15',
+    'dampening_max_suppress_time' => '45',
+    'dampening_reuse_time'        => '750',
+    'dampening_suppress_time'     => '2000',
+  },
+}
+
+tests['non_default_properties_Dampening_false'] = {
+  :desc           => '2.3.2 Non-Default dampening false',
+  :title_pattern  => '2 blue ipv4 unicast',
+  :manifest_props => "
+    dampening_state               => 'false',
+    ",
+
+  :resource_props => {
+    'dampening_state' => 'false',
+  },
+}
+
+# Special case: When dampening_routemap is mutually exclusive
+# with other dampening properties.
+tests['non_default_properties_Dampening_routemap'] = {
+  :desc           => '2.3.3 Non-Default dampening_routemap',
+  :title_pattern  => '2 blue ipv4 unicast',
+  :manifest_props => "
+    dampening_routemap              => 'RouteMap',
+    ",
+
+  :resource_props => {
+    'dampening_routemap'            => 'RouteMap',
+  },
+}
+
 tests['non_default_properties_M'] = {
-  :desc           => "2.3 Non Default Properties: 'M' commands",
+  :desc           => "2.4 Non Default Properties: 'M' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
     maximum_paths                   => 9,
@@ -173,15 +281,18 @@ tests['non_default_properties_M'] = {
   },
 }
 
+networks = [['192.168.5.0/24', 'nrtemap1'], ['192.168.6.0/32']]
 tests['non_default_properties_N'] = {
-  :desc           => "2.4 Non Default Properties: 'N' commands",
+  :desc           => "2.5 Non Default Properties: 'N' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
     next_hop_route_map              => 'RouteMap',
+    networks                        => #{networks},
   ",
 
   :resource_props => {
-    'next_hop_route_map'            => 'RouteMap',
+    'next_hop_route_map' => 'RouteMap',
+    'networks'           => "#{networks}",
   },
 }
 
@@ -265,12 +376,17 @@ test_name "TestCase :: #{testheader}" do
   tests[id][:ensure] = :absent
   test_harness_bgp_af(tests, id)
 
+  test_harness_bgp_af(tests, 'default_dampening_routemap')
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   node_feature_cleanup(agent, 'bgp')
 
   test_harness_bgp_af(tests, 'non_default_properties_C')
   test_harness_bgp_af(tests, 'non_default_properties_D')
+  test_harness_bgp_af(tests, 'non_default_properties_Dampening_routemap')
+  node_feature_cleanup(agent, 'bgp')
+  test_harness_bgp_af(tests, 'non_default_properties_Dampening_true')
+  test_harness_bgp_af(tests, 'non_default_properties_Dampening_false')
   test_harness_bgp_af(tests, 'non_default_properties_M')
   test_harness_bgp_af(tests, 'non_default_properties_N')
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -97,6 +97,14 @@ module UtilityLib
   def self.hash_to_patterns(hash)
     regexparr = []
     hash.each do |key, value|
+      # Need to escape '[', ']', '"' characters for nested array of arrays.
+      # Example:
+      #   [["192.168.5.0/24", "nrtemap1"], ["192.168.6.0/32"]]
+      # Becomes:
+      #   \[\['192.168.5.0\/24', 'nrtemap1'\], \['192.168.6.0\/32'\]\]
+      if /^\[.*\]$/.match(value)
+        value.gsub!(/[\[\]]/) { |s| '\\' + "#{s}" }.gsub!(/\"/) { |_s| '\'' }
+      end
       regexparr << Regexp.new("#{key}\s+=>\s+'?#{value}'?")
     end
     regexparr


### PR DESCRIPTION
Summary:

1) Added `additional_paths*`, `dampening*`, `dampen_igp_metric` and `networks` properties.
2) Modification to beaker infra `tests/beaker_tests/lib/utilitylib.rb` to support array of arrays.
3) Update to `cisco_bgp.rb` to use `Cisco::RouterBgp.process_asnum` method

All beaker tests pass
Rubocop passes