### PR TITLE
Alpha-order bgp_af properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,9 +390,6 @@ Configures the maximum number of equal-cost paths for load sharing. Valid value 
 ##### `maximum_paths_ibgp`
 Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
-##### `next_hop_route_map`
-Configure route map for valid nexthops. Valid values are a string defining the name of the route-map.
-
 ##### `networks`
 Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional route-map.
 
@@ -416,6 +413,9 @@ Example: IPv6 Networks Array
  ['192:168::/32]
 ]
 ```
+
+##### `next_hop_route_map`
+Configure route map for valid nexthops. Valid values are a string defining the name of the route-map.
 
 ##### `redistribute`
 A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a route-map/route-policy name. A route-map/route-policy is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -337,83 +337,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
     end
   end # property dampening_suppress_time
 
-  newproperty(:default_information_originate) do
-    desc 'Control distribution of default information. Valid values are, ' \
-      "true, false, or 'default'"
-
-    newvalues(:true, :false, :default)
-  end # property :default_information_originate
-
-  newproperty(:maximum_paths) do
-    desc 'Configures the maximum number of equal-cost paths for load ' \
-          'sharing. Valid values are integers in the range 1 - 64, ' \
-          'default value is 1.'
-
-    munge do |value|
-      value = :default if value == 'default'
-      unless value == :default
-        value = value.to_i
-        fail 'maximum_paths value should be in the range 1 - 64' unless
-          value.between?(1, 64)
-      end
-      value
-    end
-  end # property :maximum_paths
-
-  newproperty(:maximum_paths_ibgp) do
-    desc 'Configures the maximum number of ibgp equal-cost paths for load ' \
-         'sharing. Valid values are integers in the range 1 - 64, default ' \
-         'value is 1.'
-
-    munge do |value|
-      value = :default if value == 'default'
-      unless value == :default
-        value = value.to_i
-        fail 'maximum_paths_ibgp value should be in the range of 1 - 64' unless
-          value.between?(1, 64)
-      end
-      value
-    end
-  end # property :maximum_paths_ibgp
-
-  newproperty(:next_hop_route_map) do
-    desc 'Configure route map for valid nexthops. Valid values are a string ' \
-      "defining the name of the route-map'."
-
-    validate do |value|
-      fail("'next_hop_route_map' value must be a string") unless
-        value.is_a? String
-    end
-
-    munge do |value|
-      value = :default if value == 'default'
-      value
-    end
-  end # property next_hop_route_map
-
-  newproperty(:networks, array_matching: :all) do
-    format = "[['network string'], ['routemap string]]"
-    desc "Networks to configure. Valid values match format #{format}."
-
-    # Override puppet's insync method, which checks whether current value is
-    # equal to value specified in manifest.  Make sure puppet considers
-    # 2 arrays with same elements but in different order as equal.
-    def insync?(is)
-      (is.size == should.size && is.sort == should.sort)
-    end
-
-    munge do |value|
-      begin
-        return value = :default if value == 'default'
-        fail("Value must match format #{format}") unless value.is_a?(Array)
-        if Cisco::Utils.process_network_mask(value[0]).split('/')[1].nil?
-          fail("Must supply network mask for #{value[0]}")
-        end
-        value
-      end
-    end
-  end # property networks
-
+  # dampening validation
   # Make sure dampening parameters are set properly in the manifest.
   validate do
     fail("The 'asn' parameter must be set in the manifest.") if self[:asn].nil?
@@ -456,6 +380,83 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       end
     end
   end
+
+  newproperty(:default_information_originate) do
+    desc 'Control distribution of default information. Valid values are, ' \
+      "true, false, or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property :default_information_originate
+
+  newproperty(:maximum_paths) do
+    desc 'Configures the maximum number of equal-cost paths for load ' \
+          'sharing. Valid values are integers in the range 1 - 64, ' \
+          'default value is 1.'
+
+    munge do |value|
+      value = :default if value == 'default'
+      unless value == :default
+        value = value.to_i
+        fail 'maximum_paths value should be in the range 1 - 64' unless
+          value.between?(1, 64)
+      end
+      value
+    end
+  end # property :maximum_paths
+
+  newproperty(:maximum_paths_ibgp) do
+    desc 'Configures the maximum number of ibgp equal-cost paths for load ' \
+         'sharing. Valid values are integers in the range 1 - 64, default ' \
+         'value is 1.'
+
+    munge do |value|
+      value = :default if value == 'default'
+      unless value == :default
+        value = value.to_i
+        fail 'maximum_paths_ibgp value should be in the range of 1 - 64' unless
+          value.between?(1, 64)
+      end
+      value
+    end
+  end # property :maximum_paths_ibgp
+
+  newproperty(:networks, array_matching: :all) do
+    format = "[['network string'], ['routemap string]]"
+    desc "Networks to configure. Valid values match format #{format}."
+
+    # Override puppet's insync method, which checks whether current value is
+    # equal to value specified in manifest.  Make sure puppet considers
+    # 2 arrays with same elements but in different order as equal.
+    def insync?(is)
+      (is.size == should.size && is.sort == should.sort)
+    end
+
+    munge do |value|
+      begin
+        return value = :default if value == 'default'
+        fail("Value must match format #{format}") unless value.is_a?(Array)
+        if Cisco::Utils.process_network_mask(value[0]).split('/')[1].nil?
+          fail("Must supply network mask for #{value[0]}")
+        end
+        value
+      end
+    end
+  end # property networks
+
+  newproperty(:next_hop_route_map) do
+    desc 'Configure route map for valid nexthops. Valid values are a string ' \
+      "defining the name of the route-map'."
+
+    validate do |value|
+      fail("'next_hop_route_map' value must be a string") unless
+        value.is_a? String
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property next_hop_route_map
 
   newproperty(:redistribute, array_matching: :all) do
     format = "[['protocol'], ['route-map string]]"

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -483,5 +483,4 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       end
     end
   end
-
 end

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -337,50 +337,6 @@ Puppet::Type.newtype(:cisco_bgp_af) do
     end
   end # property dampening_suppress_time
 
-  # dampening validation
-  # Make sure dampening parameters are set properly in the manifest.
-  validate do
-    fail("The 'asn' parameter must be set in the manifest.") if self[:asn].nil?
-    fail("The 'afi' parameter must be set in the manifest.") if self[:afi].nil?
-    fail("The 'safi' parameter must be set in the manifest.") if self[:safi].nil?
-
-    # Don't need to process remaining checks if ensure => absent.
-    return if self[:ensure] == :absent
-
-    def route_flap_properties?
-      self[:dampening_half_time] || self[:dampening_reuse_time] ||
-        self[:dampening_suppress_time] || self[:dampening_max_suppress_time]
-    end
-
-    def all_properties?
-      self[:dampening_half_time] || self[:dampening_reuse_time] ||
-        self[:dampening_suppress_time] || self[:dampening_max_suppress_time] ||
-        self[:dampening_routemap]
-    end
-    properties = [
-      :dampening_half_time,
-      :dampening_reuse_time,
-      :dampening_suppress_time,
-      :dampening_max_suppress_time,
-      :dampening_routemap,
-    ]
-    if all_properties? && self[:dampening_state] == :false
-      fail(":dampening_state cannot be 'false' when #{properties} are set")
-    end
-    # If any of these properties are set, then all of them must be.
-    if route_flap_properties?
-      properties.delete(:dampening_routemap)
-      properties.each do |prop|
-        if self[prop].nil?
-          fail("Must set all or none of the following properties #{properties}")
-        end
-      end
-      if self[:dampening_routemap]
-        fail(":dampening_routemap should not be set when #{properties} are set")
-      end
-    end
-  end
-
   newproperty(:default_information_originate) do
     desc 'Control distribution of default information. Valid values are, ' \
       "true, false, or 'default'"
@@ -482,4 +438,50 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       end
     end
   end # property :redistribute
+
+  #
+  # VALIDATIONS
+  #
+  validate do
+    fail("The 'asn' parameter must be set in the manifest.") if self[:asn].nil?
+    fail("The 'afi' parameter must be set in the manifest.") if self[:afi].nil?
+    fail("The 'safi' parameter must be set in the manifest.") if self[:safi].nil?
+
+    # Don't need to process remaining checks if ensure => absent.
+    return if self[:ensure] == :absent
+
+    def route_flap_properties?
+      self[:dampening_half_time] || self[:dampening_reuse_time] ||
+        self[:dampening_suppress_time] || self[:dampening_max_suppress_time]
+    end
+
+    def all_properties?
+      self[:dampening_half_time] || self[:dampening_reuse_time] ||
+        self[:dampening_suppress_time] || self[:dampening_max_suppress_time] ||
+        self[:dampening_routemap]
+    end
+    properties = [
+      :dampening_half_time,
+      :dampening_reuse_time,
+      :dampening_suppress_time,
+      :dampening_max_suppress_time,
+      :dampening_routemap,
+    ]
+    if all_properties? && self[:dampening_state] == :false
+      fail(":dampening_state cannot be 'false' when #{properties} are set")
+    end
+    # If any of these properties are set, then all of them must be.
+    if route_flap_properties?
+      properties.delete(:dampening_routemap)
+      properties.each do |prop|
+        if self[prop].nil?
+          fail("Must set all or none of the following properties #{properties}")
+        end
+      end
+      if self[:dampening_routemap]
+        fail(":dampening_routemap should not be set when #{properties} are set")
+      end
+    end
+  end
+
 end

--- a/tests/beaker_tests/bgpaf/test_bgpaf.rb
+++ b/tests/beaker_tests/bgpaf/test_bgpaf.rb
@@ -287,13 +287,13 @@ tests['non_default_properties_N'] = {
   :desc           => "2.5 Non Default Properties: 'N' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
-    next_hop_route_map              => 'RouteMap',
     networks                        => #{networks},
+    next_hop_route_map              => 'RouteMap',
   ",
 
   :resource_props => {
-    'next_hop_route_map' => 'RouteMap',
     'networks'           => "#{networks}",
+    'next_hop_route_map' => 'RouteMap',
   },
 }
 


### PR DESCRIPTION
It's not obvious from the diffs but there are no functional changes in this commit; I'm simply moving
the references into alpha order.

rubocop/beaker are clean