### PR TITLE
Feature/grpc with cisco_command_config support

### DIFF
--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -1,7 +1,7 @@
 require 'facter'
 
 Facter.add(:cisco) do
-  confine operatingsystem: :nexus
+  confine operatingsystem: [:ios_xr, :nexus]
   confine :cisco_node_utils do
     # Any version is OK so long as it is installed
     true

--- a/lib/puppet/provider/cisco_command_config/cisco_os_shim.rb
+++ b/lib/puppet/provider/cisco_command_config/cisco_os_shim.rb
@@ -20,7 +20,7 @@ require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
 
 Puppet::Type.type(:cisco_command_config).provide(:cisco_os_shim) do
   confine feature: :cisco_node_utils
-  defaultfor operatingsystem: :nexus
+  defaultfor operatingsystem: [:ios_xr, :nexus]
 
   def initialize(value={})
     super(value)

--- a/lib/puppet/provider/cisco_command_config/cisco_os_shim.rb
+++ b/lib/puppet/provider/cisco_command_config/cisco_os_shim.rb
@@ -18,7 +18,7 @@
 
 require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
 
-Puppet::Type.type(:cisco_command_config).provide(:nxapi) do
+Puppet::Type.type(:cisco_command_config).provide(:cisco_os_shim) do
   confine feature: :cisco_node_utils
   defaultfor operatingsystem: :nexus
 


### PR DESCRIPTION
Renamed provider from nxapi to cisco_os_shim.  Added XR symbol to provider and facter.

```
robgrie@puppetmaster:~/forks/robert-w-gries/cisco-network-puppet-module$ rubocop
Inspecting 152 files
........................................................................................................................................................

152 files inspected, no offenses detected
```

Note:  Facter errors because structured output is not supported in grpc yet.

```
[sunstone47:/harddisk:]$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Facter: error while resolving custom fact "cisco": no implicit conversion of String into Integer
Info: Caching catalog for sunstone47.cisco.com
Info: Applying configuration version '1446134674'
Notice: /Stage[main]/Main/Node[default]/Cisco_command_config[test]/command: command changed '' to 'no domain name-server 10.10.10.10
no domain name-server 10.10.10.11
no domain name-server 10.10.10.12
no domain name-server 10.10.10.13
no domain name-server 10.10.10.14
no domain name-server 10.10.10.15
'
```