### PR TITLE
snmpserver beaker fixes

### DIFF
--- a/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
@@ -80,7 +80,7 @@ test_name "TestCase :: #{testheader}" do
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      SnmpServerLib.match_default_cli(stdout, logger)
+      SnmpServerLib.match_default_cli(stdout, self, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
@@ -78,11 +78,9 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp')
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      UtilityLib.search_pattern_in_output(stdout,
-                                          [/snmp-server user admin network-admin auth md5/],
-                                          false, self, logger)
+      SnmpServerLib.match_default_cli(stdout, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_negatives.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_negatives.rb
@@ -80,7 +80,7 @@ test_name "TestCase :: #{testheader}" do
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      SnmpServerLib.match_default_cli(stdout, logger)
+      SnmpServerLib.match_default_cli(stdout, self, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_negatives.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_negatives.rb
@@ -78,11 +78,9 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp')
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      UtilityLib.search_pattern_in_output(stdout,
-                                          [/snmp-server user admin network-admin auth md5/],
-                                          false, self, logger)
+      SnmpServerLib.match_default_cli(stdout, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
@@ -80,11 +80,9 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp')
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      UtilityLib.search_pattern_in_output(stdout,
-                                          [/snmp-server user admin network-admin auth md5/],
-                                          false, self, logger)
+      SnmpServerLib.match_default_cli(stdout, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
@@ -82,7 +82,7 @@ test_name "TestCase :: #{testheader}" do
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp all')
     on(agent, cmd_str) do
-      SnmpServerLib.match_default_cli(stdout, logger)
+      SnmpServerLib.match_default_cli(stdout, self, logger)
     end
 
     logger.info("Setup switch for provider test :: #{result}")

--- a/tests/beaker_tests/snmpserver/snmpserverlib.rb
+++ b/tests/beaker_tests/snmpserver/snmpserverlib.rb
@@ -64,6 +64,30 @@ EOF"
     manifest_str
   end
 
+  # Helper method for comparing all of the snmpserver properties against their
+  # expected default settings.
+  def self.match_default_cli(output, logger)
+    # Match strings
+    ['snmp-server aaa-user cache-timeout 3600',
+     'snmp-server aaa-user cache-timeout 3600',
+     'snmp-server packetsize 1500',
+     'snmp-server protocol enable',
+     'snmp-server tcp-session auth',
+     'snmp-server globalEnforcePriv',
+    ].each do |pattern|
+      UtilityLib.search_pattern_in_output(output, [/#{Regexp.quote(pattern)}/],
+                                          false, self, logger)
+    end
+
+    # Refute strings
+    ['snmp-server contact',
+     'snmp-server location',
+    ].each do |pattern|
+      UtilityLib.search_pattern_in_output(output, [/#{Regexp.quote(pattern)}/],
+                                          true, self, logger)
+    end
+  end
+
   # Method to create a manifest for SNMPSERVER resource attributes:
   # aaa_user_cache_timeout, global_enforce_priv, packet_size,
   # protocol, tcp_session_auth, contact and location.

--- a/tests/beaker_tests/snmpserver/snmpserverlib.rb
+++ b/tests/beaker_tests/snmpserver/snmpserverlib.rb
@@ -66,7 +66,7 @@ EOF"
 
   # Helper method for comparing all of the snmpserver properties against their
   # expected default settings.
-  def self.match_default_cli(output, logger)
+  def self.match_default_cli(output, testcase, logger)
     # Match strings
     ['snmp-server aaa-user cache-timeout 3600',
      'snmp-server aaa-user cache-timeout 3600',
@@ -76,7 +76,7 @@ EOF"
      'snmp-server globalEnforcePriv',
     ].each do |pattern|
       UtilityLib.search_pattern_in_output(output, [/#{Regexp.quote(pattern)}/],
-                                          false, self, logger)
+                                          false, testcase, logger)
     end
 
     # Refute strings
@@ -84,7 +84,7 @@ EOF"
      'snmp-server location',
     ].each do |pattern|
       UtilityLib.search_pattern_in_output(output, [/#{Regexp.quote(pattern)}/],
-                                          true, self, logger)
+                                          true, testcase, logger)
     end
   end
 


### PR DESCRIPTION
    snmpserver tests were validating defaults against an erroneous cli
    
    Added a helper function to check each property's default cli string

rubocop is clean
```
   beaker_tests/snmpserver:
          Attempted: 4
                 Passed: 4
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 4
```
