### PR TITLE
Added cleanup logic to radius_server beaker tests

### DIFF
--- a/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
+++ b/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
@@ -66,6 +66,15 @@ test_name "TestCase :: #{testheader}" do
     UtilityLib.set_manifest_path(master, self)
 
     logger.info('Setup switch for provider')
+
+    # Make sure radius server is not configured before test starts.
+    on(master, RadiusServerLib.create_radius_server_manifest_absent)
+
+    # Expected exit_code is 0,2 since server may or may not be configured.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0,2])
+
   end
 
   # @step [Step] Requests manifest from the master server to the agent.

--- a/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
+++ b/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
@@ -73,8 +73,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0,2 since server may or may not be configured.
     cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
       'agent -t', options)
-    on(agent, cmd_str, acceptable_exit_codes: [0,2])
-
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
   # @step [Step] Requests manifest from the master server to the agent.


### PR DESCRIPTION
The test did not cleanup existing server before starting the test.

./radius_server_provider_defaults.rb passed in 30.94 seconds
Begin ./radius_serverlib.rb
./radius_serverlib.rb passed in 0.05 seconds
      Test Suite: tests @ 2015-11-04 04:01:44 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 30.99 seconds
      Average Test Time: 15.50 seconds
              Attempted: 2
                 Passed: 2
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
