### PR TITLE
puppet type, provider, beaker tests, manifest for aaa_group_tacacs

### DIFF
--- a/examples/demo_aaa.pp
+++ b/examples/demo_aaa.pp
@@ -21,9 +21,9 @@ class ciscopuppet::demo_aaa {
     cisco_aaa_group_tacacs { 'test':
       ensure                 => present,
       deadtime               => '30',
-      vrf_name               => 'blue',
-      source_interface       => 'Ethernet1/1',
       server_hosts           => ['testhost'],
+      source_interface       => 'Ethernet1/1',
+      vrf_name               => 'blue',
       require                => Cisco_tacacs_server_host['testhost']
   }
 }

--- a/examples/demo_aaa.pp
+++ b/examples/demo_aaa.pp
@@ -1,0 +1,29 @@
+# Manifest to demo cisco_aaa* providers
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_aaa {
+    cisco_tacacs_server_host { 'testhost':
+      ensure                 => present,
+  }
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      deadtime               => '30',
+      vrf_name               => 'blue',
+      source_interface       => 'Ethernet1/1',
+      server_hosts           => ['testhost'],
+      require                => Cisco_tacacs_server_host['testhost']
+  }
+}

--- a/examples/demo_all.pp
+++ b/examples/demo_all.pp
@@ -37,4 +37,5 @@ class ciscopuppet::demo_all {
   include ciscopuppet::demo_vrf
   include ciscopuppet::demo_vtp
   include ciscopuppet::demo_snmp
+  include ciscopuppet::demo_aaa
 }

--- a/lib/puppet/provider/cisco_aaa_group_tacacs/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_group_tacacs/nxapi.rb
@@ -116,16 +116,19 @@ Puppet::Type.type(:cisco_aaa_group_tacacs).provide(:nxapi) do
     @property_flush[:deadtime] = set_value
   end
 
-  def vrf_name
-    return :default if @resource[:vrf_name] == :default &&
-                       @property_hash[:vrf_name] ==
-                       Cisco::AaaServerGroup.default_vrf
-    @property_hash[:vrf_name]
+  def server_hosts
+    return [:default] if @resource[:server_hosts] &&
+                         @resource[:server_hosts][0] == :default &&
+                         @property_hash[:server_hosts] ==
+                         Cisco::AaaServerGroup.default_servers
+    @property_hash[:server_hosts]
   end
 
-  def vrf_name=(set_value)
-    set_value = Cisco::AaaServerGroup.default_vrf if set_value == :default
-    @property_flush[:vrf_name] = set_value
+  def server_hosts=(set_value)
+    if set_value.is_a?(Array) && set_value[0] == :default
+      set_value = Cisco::AaaServerGroup.default_servers
+    end
+    @property_flush[:server_hosts] = set_value
   end
 
   def source_interface
@@ -142,19 +145,16 @@ Puppet::Type.type(:cisco_aaa_group_tacacs).provide(:nxapi) do
     @property_flush[:source_interface] = set_value
   end
 
-  def server_hosts
-    return [:default] if @resource[:server_hosts] &&
-                         @resource[:server_hosts][0] == :default &&
-                         @property_hash[:server_hosts] ==
-                         Cisco::AaaServerGroup.default_servers
-    @property_hash[:server_hosts]
+  def vrf_name
+    return :default if @resource[:vrf_name] == :default &&
+                       @property_hash[:vrf_name] ==
+                       Cisco::AaaServerGroup.default_vrf
+    @property_hash[:vrf_name]
   end
 
-  def server_hosts=(set_value)
-    if set_value.is_a?(Array) && set_value[0] == :default
-      set_value = Cisco::AaaServerGroup.default_servers
-    end
-    @property_flush[:server_hosts] = set_value
+  def vrf_name=(set_value)
+    set_value = Cisco::AaaServerGroup.default_vrf if set_value == :default
+    @property_flush[:vrf_name] = set_value
   end
 
   def flush

--- a/lib/puppet/provider/cisco_aaa_group_tacacs/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_group_tacacs/nxapi.rb
@@ -1,0 +1,188 @@
+#
+# The NXAPI provider for cisco_aaa_group_tacacs.
+#
+# October, 2015
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+
+Puppet::Type.type(:cisco_aaa_group_tacacs).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_aaa_group_tacacs'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @aaa_group = Cisco::AaaServerGroup.groups(:tacacs)[@property_hash[:name]]
+    @property_flush = {}
+    debug 'Created provider instance of cisco_aaa_group_tacacs'
+  end
+
+  def self.instances
+    instances = []
+    Cisco::AaaServerGroup.groups(:tacacs).each do |name, group|
+      debug "Checking instance of #{name}"
+      instances << new(
+        ensure:           :present,
+        name:             name,
+        deadtime:         group.deadtime,
+        vrf_name:         group.vrf,
+        source_interface: group.source_interface,
+        server_hosts:     group.servers.keys)
+    end
+    instances
+  end
+
+  def self.prefetch(resources)
+    groups = instances
+    resources.keys.each do |name|
+      provider = groups.find { |group| group.name == name }
+      resources[name].provider = provider unless provider.nil?
+    end
+  end
+
+  def instance_name
+    group_tacacs
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  # rubocop:disable GuardClause
+  def properties_set(new_aaa_group=false)
+    %i(deadtime source_interface).each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_aaa_group
+      unless @property_flush[prop].nil?
+        @aaa_group.send("#{prop}=", @property_flush[prop]) if
+          @aaa_group.respond_to?("#{prop}=")
+      end
+    end
+
+    # node utils is named vrf instead of vrf_name, can't auto this one
+    if @resource[:vrf_name]
+      self.vrf_name = @resource[:vrf_name] if new_aaa_group
+      unless @property_flush[:vrf_name].nil?
+        @aaa_group.vrf = @property_flush[:vrf_name]
+      end
+    end
+    # node utils is named server= instead of server_hosts=
+    if @resource[:server_hosts]
+      self.server_hosts = @resource[:server_hosts] if new_aaa_group
+      unless @property_flush[:server_hosts].nil?
+        @aaa_group.servers = @property_flush[:server_hosts]
+      end
+    end
+  end
+  # rubocop:enable GuardClause
+
+  # can't autogen getters and setters because the default_<prop>
+  # functions are class functions
+  def deadtime
+    return :default if @resource[:deadtime] == :default &&
+                       @property_hash[:deadtime] ==
+                       Cisco::AaaServerGroup.default_deadtime
+    @property_hash[:deadtime]
+  end
+
+  def deadtime=(set_value)
+    set_value = Cisco::AaaServerGroup.default_deadtime if
+      set_value == :default
+    @property_flush[:deadtime] = set_value
+  end
+
+  def vrf_name
+    return :default if @resource[:vrf_name] == :default &&
+                       @property_hash[:vrf_name] ==
+                       Cisco::AaaServerGroup.default_vrf
+    @property_hash[:vrf_name]
+  end
+
+  def vrf_name=(set_value)
+    set_value = Cisco::AaaServerGroup.default_vrf if set_value == :default
+    @property_flush[:vrf_name] = set_value
+  end
+
+  def source_interface
+    return :default if @resource[:source_interface] == :default &&
+                       @property_hash[:source_interface] ==
+                       Cisco::AaaServerGroup.default_source_interface
+    @property_hash[:source_interface]
+  end
+
+  def source_interface=(set_value)
+    if set_value == :default
+      set_value = Cisco::AaaServerGroup.default_source_interface
+    end
+    @property_flush[:source_interface] = set_value
+  end
+
+  def server_hosts
+    return [:default] if @resource[:server_hosts] &&
+                         @resource[:server_hosts][0] == :default &&
+                         @property_hash[:server_hosts] ==
+                         Cisco::AaaServerGroup.default_servers
+    @property_hash[:server_hosts]
+  end
+
+  def server_hosts=(set_value)
+    if set_value.is_a?(Array) && set_value[0] == :default
+      set_value = Cisco::AaaServerGroup.default_servers
+    end
+    @property_flush[:server_hosts] = set_value
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @aaa_group.destroy
+      @aaa_group = nil
+    else
+      if @aaa_group.nil?
+        new_aaa_group = true
+        @aaa_group = Cisco::AaaServerGroup.new(@resource[:name], :tacacs)
+      end
+      properties_set(new_aaa_group)
+    end
+    put_aaa_group_tacacs
+  end
+
+  def put_aaa_group_tacacs
+    debug 'Current state:'
+    if @aaa_group.nil?
+      debug 'No aaa group'
+      return
+    end
+    debug "
+                  name: #{@resource[:name]}
+              deadtime: #{@aaa_group.deadtime}
+              vrf_name: #{@aaa_group.vrf}
+      source_interface: #{@aaa_group.source_interface}
+          server_hosts: #{@aaa_group.servers.keys}
+    "
+  end
+end

--- a/lib/puppet/type/cisco_aaa_group_tacacs.rb
+++ b/lib/puppet/type/cisco_aaa_group_tacacs.rb
@@ -91,7 +91,7 @@ Puppet::Type.newtype(:cisco_aaa_group_tacacs) do
 
   newproperty(:server_hosts, array_matching: :all) do
     desc "An array of TACACS+ server hosts associated with this TACACS+ server
-          group. Valid values are string, an array or the keyword 'default'."
+          group. Valid values are an array, or the keyword 'default'."
 
     validate do |value|
       fail "server_host #{value} must be a String" unless

--- a/lib/puppet/type/cisco_aaa_group_tacacs.rb
+++ b/lib/puppet/type/cisco_aaa_group_tacacs.rb
@@ -29,9 +29,9 @@ Puppet::Type.newtype(:cisco_aaa_group_tacacs) do
     cisco_aaa_group_tacacs {\"testgroup1\":
       ensure           => present,
       deadtime         => 30,
-      vrf_name         => \"blue\",
-      source_interface => 'Ethernet1/2',
       server_hosts     => ['13.13.13.13', 'host1.cisco.com'],
+      source_interface => 'Ethernet1/2',
+      vrf_name         => \"blue\",
     }"
 
   ensurable

--- a/lib/puppet/type/cisco_aaa_group_tacacs.rb
+++ b/lib/puppet/type/cisco_aaa_group_tacacs.rb
@@ -1,0 +1,143 @@
+# Manages configuration for a TACACS+ server group.
+#
+# October 2015
+#
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_aaa_group_tacacs) do
+  @doc = "Manages configuration for a TACACS+ server group
+
+  cisco_aaa_group_tacacs {\"<group>\":
+    ..attributes..
+  }
+
+  <group> is the name of the TACACS+ server group resource.
+
+  Example:
+    cisco_aaa_group_tacacs {\"testgroup1\":
+      ensure           => present,
+      deadtime         => 30,
+      vrf_name         => \"blue\",
+      source_interface => 'Ethernet1/2',
+      server_hosts     => ['13.13.13.13', 'host1.cisco.com'],
+    }"
+
+  ensurable
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse out the title to fill in the attributes in these patterns.
+  # These attributes can be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    patterns = []
+
+    # Below pattern matches both parts of the full composite name.
+    patterns << [
+      /^(\S+)$/,
+      [
+        [:group, identity],
+      ],
+    ]
+    patterns
+  end
+
+  newparam(:group, namevar: true) do
+    desc 'Name of the aaa group TACACS instance. Valid values are string.'
+
+    validate do |value|
+      fail "group #{value} must be a string" unless
+        value.kind_of?(String) || value == :default
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end
+
+  ##############
+  # Attributes #
+  ##############
+
+  newproperty(:deadtime) do
+    desc "Deadtime interval for this TACACS+ server group.
+          Valid values are integer, in minutes, keyword 'default'"
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise "deadtime - #{value} is not a valid number."
+      end
+      value
+    end
+  end
+
+  newproperty(:server_hosts, array_matching: :all) do
+    desc "An array of TACACS+ server hosts associated with this TACACS+ server
+          group. Valid values are string, an array or the keyword 'default'."
+
+    validate do |value|
+      fail "server_host #{value} must be a String" unless
+        value.kind_of?(String) || value == :default
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+
+    # override insync? method to compare server_hosts lists
+    def insync?(is)
+      (is.size == should.size && is.sort == should.sort)
+    end
+  end
+
+  newproperty(:source_interface) do
+    desc "Source interface for TACACS+ servers in this TACACS+ server group
+          Valid values are string, keyword 'default'."
+
+    validate do |value|
+      fail "source_interface #{value} must be a string" unless
+        value.kind_of?(String) || value == :default
+    end
+
+    munge do |value|
+      value.downcase!
+      value = :default if value == 'default'
+      value
+    end
+  end
+
+  newproperty(:vrf_name) do
+    desc "Specifies the virtual routing and forwarding instance (VRF)
+          to use to contact this TACACS server group.
+          Valid values are string, the keyword 'default'."
+
+    validate do |value|
+      fail "vrf_name #{value} must be a string" unless
+        value.kind_of?(String) || value == :default
+    end
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end
+end

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_defaults.rb
@@ -1,0 +1,186 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# AaaGroup-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AAAGROUP resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a AAAGROUPUNITY resource test that tests for default values for
+# ensure, group and acl attributes of a
+# cisco_aaa_group_tacacs resource when created with 'ensure' => 'present'.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# Steps 2-4 deal with cisco_aaa_group_tacacs_resource creation and its
+# verification using Puppet Agent and the switch running-config.
+# Steps 5-7 deal with cisco_aaa_group_tacacs resource deletion and its
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and AaaGroupLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaagrouplib.rb', __FILE__)
+# Require TacacsServer because vsh can't enable/disable feature tacacs
+require File.expand_path('../../tacacsserver/tacacsserverlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AAAGROUP Resource :: All Attributes Defaults'
+
+# @test_name [TestCase] Executes defaults testcase for AAAGROUP Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider test' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, TacacsServerLib.create_tacacsserver_absent)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
+    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str, acceptable_exit_codes: [16]) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/feature tacacs\+/],
+                                          true, self, logger)
+    end
+
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_present)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          { 'ensure'   => 'present',
+                                            'deadtime' => '0',
+                                            'vrf_name' => 'default' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance presence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/aaa group server tacacs\+ test/],
+                                          false, self, logger)
+    end
+
+    logger.info("Check aaagroup instance presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource absent manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_absent)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource absent manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          { 'ensure'   => 'present',
+                                            'deadtime' => '0',
+                                            'vrf_name' => 'default' },
+                                          true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/aaa group server tacacs\+ test/],
+                                          true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_defaults.rb
@@ -122,7 +122,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance presence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance presence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
@@ -132,7 +132,7 @@ test_name "TestCase :: #{testheader}" do
                                           false, self, logger)
     end
 
-    logger.info("Check aaagroup instance presence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance presence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -166,7 +166,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
@@ -176,7 +176,7 @@ test_name "TestCase :: #{testheader}" do
                                           true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_negatives.rb
@@ -1,0 +1,286 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# --------------
+# AaaGroup-Provider-Negatives.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AAAGROUP resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a AAAGROUP resource test that tests for negative values for
+# ensure, group and acl attributes of a
+# cisco_aaa_group_tacacs resource when created with 'ensure' => 'present'.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# The next set of teststeps deal with attribute negative tests and their
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and AaaGroupLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaagrouplib.rb', __FILE__)
+# Require TacacsServer because vsh can't enable/disable feature tacacs
+require File.expand_path('../../tacacsserver/tacacsserverlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AAAGROUP Resource :: All Attributes Negatives'
+
+# @test_name [TestCase] Executes negatives testcase for AAAGROUP Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider test' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, TacacsServerLib.create_tacacsserver_absent)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
+    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str, acceptable_exit_codes: [16]) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/feature tacacs\+/],
+                                          true, self, logger)
+    end
+
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, TacacsServerLib.create_tacacsserver_present)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get negative test resource manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_deadtime_negative)
+
+    # Expected exit_code is 1 since this is a puppet agent cmd with error.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [1])
+
+    logger.info("Get negative test resource manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'deadtime' => AaaGroupLib::DEADTIME_NEGATIVE },
+        true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        [/aaa group server tacacs\+ test/,
+         /^\s+deadtime #{AaaGroupLib::DEADTIME_NEGATIVE}/],
+        true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get negative test resource manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_vrf_name_negative)
+
+    # Expected exit_code is 1 since this is a puppet agent cmd with error.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [1])
+
+    logger.info("Get negative test resource manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'vrf_name' => AaaGroupLib::VRF_NAME_NEGATIVE },
+        true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        [/aaa group server tacacs\+ test/,
+         /^\s+use-vrf #{AaaGroupLib::VRF_NAME_NEGATIVE}/],
+        true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get negative test resource manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master,
+       AaaGroupLib.create_aaagroup_manifest_source_interface_negative)
+
+    # Expected exit_code is 1 since this is a puppet agent cmd with error.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [1])
+
+    logger.info("Get negative test resource manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'source_interface' => AaaGroupLib::SOURCE_INTERFACE_NEGATIVE },
+        true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        [/aaa group server tacacs\+ test/,
+         /^\s+source-interface #{AaaGroupLib::SOURCE_INTERFACE_NEGATIVE}/],
+        true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get negative test resource manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master,
+       AaaGroupLib.create_aaagroup_manifest_server_hosts_negative)
+
+    # Expected exit_code is 1 since this is a puppet agent cmd with error.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [1])
+
+    logger.info("Get negative test resource manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'server_hosts' => AaaGroupLib::SERVER_HOSTS_NEGATIVE },
+        true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        [/aaa group server tacacs\+ test/,
+         /^\s+server #{AaaGroupLib::SERVER_HOSTS_NEGATIVE}/],
+        true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_negatives.rb
@@ -127,7 +127,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
@@ -139,7 +139,7 @@ test_name "TestCase :: #{testheader}" do
         true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -172,7 +172,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
@@ -184,7 +184,7 @@ test_name "TestCase :: #{testheader}" do
         true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -218,7 +218,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
@@ -230,7 +230,7 @@ test_name "TestCase :: #{testheader}" do
         true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -264,7 +264,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs all')
@@ -276,7 +276,7 @@ test_name "TestCase :: #{testheader}" do
         true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
@@ -1,0 +1,192 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# AaaGroup-Provider-NonDefaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AAAGROUP resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a AAAGROUP resource test that tests for nondefault values for
+# ensure, group and acl attributes of a
+# cisco_aaa_group_tacacs resource when created with 'ensure' => 'present'.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# Steps 2-4 deal with cisco_aaa_group_tacacs_resource creation and its
+# verification using Puppet Agent and the switch running-config.
+# Steps 5-7 deal with cisco_aaa_group_tacacs resource deletion and its
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+# Require UtilityLib.rb and AaaGroupLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaagrouplib.rb', __FILE__)
+# Require TacacsServer because vsh can't enable/disable feature tacacs
+require File.expand_path('../../tacacsserver/tacacsserverlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AAAGROUP Resource :: All Attributes NonDefaults'
+
+# @test_name [TestCase] Executes nondefaults testcase for AAAGROUP Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider test' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, TacacsServerLib.create_tacacsserver_absent)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
+    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str, acceptable_exit_codes: [16]) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/feature tacacs\+/],
+                                          true, self, logger)
+    end
+
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource nondefaults manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_nondefaults)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource nondefaults manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'ensure'           => 'present',
+          'deadtime'         => '30',
+          'vrf_name'         => 'blue',
+          'source_interface' => 'Ethernet1/1',
+          'server_hosts'     => "\\['testhost'\\]" },
+        false, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance presence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/aaa group server tacacs\+ test/],
+                                          false, self, logger)
+    end
+
+    logger.info("Check aaagroup instance presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource absent manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, AaaGroupLib.create_aaagroup_manifest_absent)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource absent manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks cisco_aaa_group resource on agent using resource cmd.
+  step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_group_tacacs 'test'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(
+        stdout,
+        { 'ensure'           => 'present',
+          'deadtime'         => '30',
+          'vrf_name'         => 'blue',
+          'source_interface' => 'Ethernet1/1',
+          'server_hosts'     => "\\['testhost'\\]" },
+        true, self, logger)
+    end
+
+    logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
+  step 'TestStep :: Check aaagroup instance absence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [/aaa group server tacacs\+ test/],
+                                          true, self, logger)
+    end
+
+    logger.info("Check aaagroup instance absence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
@@ -117,7 +117,7 @@ test_name "TestCase :: #{testheader}" do
           'deadtime'         => '30',
           'vrf_name'         => 'blue',
           'source_interface' => 'Ethernet1/1',
-          'server_hosts'     => "\\['testhost'\\]" },
+          'server_hosts'     => "\\['testhost', '1.1.1.1'\\]" },
         false, self, logger)
     end
 
@@ -125,7 +125,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance presence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance presence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
@@ -135,7 +135,7 @@ test_name "TestCase :: #{testheader}" do
                                           false, self, logger)
     end
 
-    logger.info("Check aaagroup instance presence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance presence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -164,7 +164,7 @@ test_name "TestCase :: #{testheader}" do
           'deadtime'         => '30',
           'vrf_name'         => 'blue',
           'source_interface' => 'Ethernet1/1',
-          'server_hosts'     => "\\['testhost'\\]" },
+          'server_hosts'     => "\\['testhost', '1.1.1.1'\\]" },
         true, self, logger)
     end
 
@@ -172,7 +172,7 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check aaagroup instance absence on agent' do
+  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_vshell_cmd('show running-config tacacs')
@@ -182,7 +182,7 @@ test_name "TestCase :: #{testheader}" do
                                           true, self, logger)
     end
 
-    logger.info("Check aaagroup instance absence on agent :: #{result}")
+    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/aaagrouptacacs/aaagrouplib.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagrouplib.rb
@@ -1,0 +1,163 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# AAAGROUP Utility Library:
+# -------------------------
+# aaagrouplib.rb
+#
+# This is the utility library for the AAAGROUP provider Beaker test cases that
+# contains the common methods used across the AAAGROUP testsuite's cases. The
+# library is implemented as a module with related methods and constants defined
+# inside it for use as a namespace. All of the methods are defined as module
+# methods.
+#
+# Every Beaker AAAGROUP test case that runs an instance of Beaker::TestCase
+# requires AaaGroupLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for cisco_aaa_group Puppet provider test cases.
+module AaaGroupLib
+  # Group of Constants used in negative tests for AAAGROUP provider.
+  DEADTIME_NEGATIVE         = ''
+  VRF_NAME_NEGATIVE         = ''
+  SOURCE_INTERFACE_NEGATIVE = ''
+  SERVER_HOSTS_NEGATIVE     = ''
+
+  # A. Methods to create manifests for cisco_aaa_group Puppet provider test cases.
+
+  # Method to create a manifest for AAAGROUP resource attribute 'ensure' where
+  # 'ensure' is set to present.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_present
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      deadtime               => 'default',
+      vrf_name               => 'default',
+      source_interface       => 'default',
+      server_hosts           => 'default',
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP resource attribute 'ensure' where
+  # 'ensure' is set to absent.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_absent
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => absent,
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP resource attributes:
+  # deadtime, vrf_name, source_interface, and server_hosts.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_nondefaults
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_tacacs_server { 'default':
+      ensure                 => present,
+  }
+    cisco_tacacs_server_host { 'testhost':
+      ensure                 => present,
+  }
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      deadtime               => '30',
+      vrf_name               => 'blue',
+      source_interface       => 'Ethernet1/1',
+      server_hosts           => ['testhost'],
+      require                => Cisco_tacacs_server_host['testhost']
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP resource attribute 'deadtime'.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_deadtime_negative
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      deadtime               => #{AaaGroupLib::DEADTIME_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP resource attribute 'vrf_name'.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_vrf_name_negative
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      vrf_name               => #{AaaGroupLib::VRF_NAME_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP attribute 'source_interface'.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_source_interface_negative
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      source_interface       => #{AaaGroupLib::SOURCE_INTERFACE_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for AAAGROUP attribute 'server_hosts'.
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_aaagroup_manifest_server_hosts_negative
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+    cisco_aaa_group_tacacs { 'test':
+      ensure                 => present,
+      server_hosts           => #{AaaGroupLib::SERVER_HOSTS_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+end

--- a/tests/beaker_tests/aaagrouptacacs/aaagrouplib.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagrouplib.rb
@@ -88,13 +88,16 @@ node default {
     cisco_tacacs_server_host { 'testhost':
       ensure                 => present,
   }
+    cisco_tacacs_server_host { '1.1.1.1':
+      ensure                 => present,
+  }
     cisco_aaa_group_tacacs { 'test':
       ensure                 => present,
       deadtime               => '30',
       vrf_name               => 'blue',
       source_interface       => 'Ethernet1/1',
-      server_hosts           => ['testhost'],
-      require                => Cisco_tacacs_server_host['testhost']
+      server_hosts           => ['testhost', '1.1.1.1'],
+      require                => Cisco_tacacs_server_host['testhost', '1.1.1.1'],
   }
 }
 EOF"


### PR DESCRIPTION
Beaker tests pass, manifest runs, no rubocop complaints for ruby 2.2, etc. I'll update docs in an update commit.

I used the older beaker test layout because I based my tests off of snmp_community. I can rewrite them if necessary, but I will be sad.