### PR TITLE
Add netdev providers to demo manifest

### DIFF
--- a/examples/demo_all.pp
+++ b/examples/demo_all.pp
@@ -26,15 +26,19 @@ class ciscopuppet::demo_all {
   #   proxy => 'http://proxy.domain.com:8080',
   # }
 
-  include ciscopuppet::demo_patching
-  include ciscopuppet::demo_command_config
   include ciscopuppet::demo_bgp
+  include ciscopuppet::demo_command_config
+  include ciscopuppet::demo_domain
   include ciscopuppet::demo_interface
-  include ciscopuppet::demo_vlan
+  include ciscopuppet::demo_ntp
   include ciscopuppet::demo_ospf
+  include ciscopuppet::demo_patching
+  include ciscopuppet::demo_radius
+  include ciscopuppet::demo_snmp
+  include ciscopuppet::demo_syslog
   include ciscopuppet::demo_tacacs_server
   include ciscopuppet::demo_tacacs_server_host
+  include ciscopuppet::demo_vlan
   include ciscopuppet::demo_vrf
   include ciscopuppet::demo_vtp
-  include ciscopuppet::demo_snmp
 }

--- a/examples/demo_domain.pp
+++ b/examples/demo_domain.pp
@@ -1,6 +1,6 @@
-# Manifest to demo cisco_snmp* providers
+# Manifest to demo domain providers
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2015 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,32 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class ciscopuppet::demo_snmp {
-  cisco_snmp_server { 'default':
-    aaa_user_cache_timeout => 200,
-    global_enforce_priv    => true,
-  }
-
-  cisco_snmp_group { 'network-admin':
+class ciscopuppet::demo_domain {
+  domain_name { 'demo.cisco.com':
     ensure => present,
   }
 
-  cisco_snmp_community { 'setcom':
+  name_server { '8.8.8.8':
     ensure => present,
-    group  => 'network-admin',
-    acl    => 'testcomacl',
   }
 
-  cisco_snmp_user { 'v3test':
-    ensure => present,
-    groups => ['network-admin'],
-  }
-
-  # netdev network_snmp
-  network_snmp {'default':
-    enable   => true,
-    location => 'UK',
-    contact  => 'SysAdmin',
+  network_dns { 'settings':
+    domain  => 'demo.cisco.com',
+    search  => ['test.com', 'test.net'],
+    servers => ['8.8.8.8', '2001:4860:4860::8888'],
   }
 
 }

--- a/examples/demo_ntp.pp
+++ b/examples/demo_ntp.pp
@@ -1,0 +1,27 @@
+# Manifest to demo ntp providers
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_ntp {
+
+  ntp_config { 'default':
+    source_interface => 'ethernet2/1',
+  }
+
+  ntp_server {'5.5.5.5':
+    ensure => present,
+  }
+
+}

--- a/examples/demo_radius.pp
+++ b/examples/demo_radius.pp
@@ -1,0 +1,42 @@
+# Manifest to demo radius providers
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_radius {
+
+  radius { 'default':
+    enable => true,
+  }
+
+  radius_global { 'default':
+    key              => '44444444',
+    key_format       => '7',
+    retransmit_count => '3',
+    timeout          => '1',
+  }
+
+  radius_server { '8.8.8.8':
+    ensure              => 'present',
+    accounting_only     => true,
+    acct_port           => '66',
+    auth_port           => '77',
+    authentication_only => true,
+    key                 => '44444444',
+    key_format          => '7',
+    retransmit_count    => '4',
+    timeout             => '2',
+  }
+
+}

--- a/examples/demo_syslog.pp
+++ b/examples/demo_syslog.pp
@@ -1,0 +1,29 @@
+# Manifest to demo syslog providers
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_syslog {
+
+  syslog_server {'1.2.3.4':
+    ensure         => present,
+    severity_level => 2,
+    vrf            => 'default',
+  }
+
+  syslog_settings {'default':
+    time_stamp_units => 'milliseconds',
+  }
+
+}

--- a/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
@@ -73,7 +73,7 @@ test_name "TestCase :: #{testheader}" do
                                         'no ip domain-list test.net ; ' \
                                         'no ip name-server 8.8.8.8 ; ' \
                                         'no ip name-server 2001:4860:4860::8888')
-    on(agent, cmd_str, acceptable_exit_codes: [0 , 2])
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.

--- a/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
@@ -73,7 +73,7 @@ test_name "TestCase :: #{testheader}" do
                                         'no ip domain-list test.net ; ' \
                                         'no ip name-server 8.8.8.8 ; ' \
                                         'no ip name-server 2001:4860:4860::8888')
-    on(agent, cmd_str)
+    on(agent, cmd_str, acceptable_exit_codes: [0 , 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
@@ -90,7 +90,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, NetworkDnsLib.create_network_dns_manifest('switch1.test.com',
                                                          ['test.com', 'test.net'],
-                                                         ['8.8.8.8', '2001:4860:4860::8888'],
+                                                         ['2001:4860:4860::8888', '8.8.8.8'],
                                                         ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
@@ -112,7 +112,7 @@ test_name "TestCase :: #{testheader}" do
                                           { 'ensure'  => 'present',
                                             'domain'  => 'switch1.test.com',
                                             'search'  => "\\['test.com', 'test.net'\\]",
-                                            'servers' => "\\['8.8.8.8', '2001:4860:4860::8888'\\]" },
+                                            'servers' => "\\['2001:4860:4860::8888', '8.8.8.8'\\]" },
                                           false, self, logger)
     end
 
@@ -130,7 +130,7 @@ test_name "TestCase :: #{testheader}" do
                                             /ip domain-name switch1\.test\.com/,
                                             /ip domain-list test\.com/,
                                             /ip domain-list test\.net/,
-                                            /ip name-server 8\.8\.8\.8 2001:4860:4860::8888/,
+                                            /ip name-server 2001:4860:4860::8888 8\.8\.8\.8/,
                                           ],
                                           false, self, logger)
     end
@@ -143,7 +143,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, NetworkDnsLib.create_network_dns_manifest('switch2.test.com',
                                                          ['test.net'],
-                                                         ['8.8.4.4', '2001:4860:4860::8888'],
+                                                         ['2001:4860:4860::8888', '8.8.4.4'],
                                                         ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.


### PR DESCRIPTION
1) All new cisco providers for netdev types added.
2) Fixed beaker test issues.

```
root@dt-n9k5-1#puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for dt-n9k5-1.cisco.com
Info: Applying configuration version '1446691554'
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp[55.77 blue]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_af[55.77 blue ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_af[55.77 blue ipv6 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 1.1.1.1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 2.2.2.2]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 3.3.3.3]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 1:1::1:1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 1.1.1.1 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 2.2.2.2 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 3.3.3.3 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Domain_name[demo.cisco.com]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Name_server[8.8.8.8]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Network_dns[settings]/search: search changed '[]' to '['test.com', 'test.net']'
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Network_dns[settings]/servers: servers changed '['8.8.8.8']' to '['8.8.8.8', '2001:4860:4860::8888']'
Notice: /Stage[main]/Ciscopuppet::Demo_interface/Cisco_interface[Ethernet1/3]/switchport_trunk_allowed_vlan: switchport_trunk_allowed_vlan changed '20,30' to '20, 30'
Notice: /Stage[main]/Ciscopuppet::Demo_interface/Cisco_interface[Vlan22]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf[Sample]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_interface_ospf[Ethernet1/1 Sample]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf_vrf[dark_blue default]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf_vrf[dark_blue vrf1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/key: key changed 'unset' to '44444444'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/key_format: key_format changed '-1' to '7'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/timeout: timeout changed '5' to '1'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/retransmit_count: retransmit_count changed '1' to '3'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_server[8.8.8.8]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Network_snmp[default]/enable: enable changed 'false' to 'true'
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Network_snmp[default]/contact: contact changed 'unset' to 'SysAdmin'
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Network_snmp[default]/location: location changed 'unset' to 'UK'
Notice: /Stage[main]/Ciscopuppet::Demo_syslog/Syslog_server[1.2.3.4]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_syslog/Syslog_settings[default]/time_stamp_units: time_stamp_units changed 'seconds' to 'milliseconds'
Notice: /Stage[main]/Ciscopuppet::Demo_tacacs_server/Cisco_tacacs_server[default]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_tacacs_server_host/Cisco_tacacs_server_host[tachost]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_vtp/Cisco_vtp[default]/ensure: created
Notice: Applied catalog in 46.49 seconds
```