### PR TITLE
Beaker snmpserver fix

### DIFF
--- a/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_defaults.rb
@@ -108,7 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'aaa_user_cache_timeout' => '3600',
-                                            'global_enforce_priv'    => 'true',
+                                            'global_enforce_priv'    => 'false',
                                             'packet_size'            => '1500',
                                             'protocol'               => 'true',
                                             'tcp_session_auth'       => 'true' },
@@ -125,8 +125,7 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp')
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
-                                          [/snmp-server packetsize 1500/,
-                                           /snmp-server globalEnforcePriv/],
+                                          [/snmp-server packetsize 1500/],
                                           false, self, logger)
     end
 

--- a/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/snmpserver/snmpserver_provider_nondefaults.rb
@@ -110,7 +110,7 @@ test_name "TestCase :: #{testheader}" do
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'aaa_user_cache_timeout' => '1000',
-                                            'global_enforce_priv'    => 'false',
+                                            'global_enforce_priv'    => 'true',
                                             'packet_size'            => '2500',
                                             'protocol'               => 'false',
                                             'tcp_session_auth'       => 'false',
@@ -161,7 +161,7 @@ test_name "TestCase :: #{testheader}" do
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'aaa_user_cache_timeout' => '3600',
-                                            'global_enforce_priv'    => 'true',
+                                            'global_enforce_priv'    => 'false',
                                             'packet_size'            => '1500',
                                             'protocol'               => 'true',
                                             'tcp_session_auth'       => 'true' },
@@ -178,8 +178,7 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = UtilityLib.get_vshell_cmd('show running-config snmp')
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
-                                          [/snmp-server packetsize 1500/,
-                                           /snmp-server globalEnforcePriv/],
+                                          [/snmp-server packetsize 1500/],
                                           false, self, logger)
     end
 

--- a/tests/beaker_tests/snmpserver/snmpserverlib.rb
+++ b/tests/beaker_tests/snmpserver/snmpserverlib.rb
@@ -101,7 +101,7 @@ node default {
       aaa_user_cache_timeout => 1000,
       tcp_session_auth       => false,
       protocol               => false,
-      global_enforce_priv    => false,
+      global_enforce_priv    => true,
       contact                => 'user1',
       location               => 'rtp',
     }


### PR DESCRIPTION
Begin ./snmpserverlib.rb
./snmpserverlib.rb passed in 0.01 seconds
      Test Suite: tests @ 2015-11-05 07:15:33 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 86.49 seconds
      Average Test Time: 21.62 seconds
              Attempted: 4
                 Passed: 4
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 4

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

