### PR TITLE
Demo manifest bug fixes

### DIFF
--- a/examples/demo_bgp_ipv4.pp
+++ b/examples/demo_bgp_ipv4.pp
@@ -107,6 +107,7 @@ class ciscopuppet::demo_bgp_ipv4 {
   # Configure IPv4 Neighbor                                                   #
   #  Requires: cisco_bgp (Global BGP)                                         #
   # --------------------------------------------------------------------------#
+  # NOTE: password below is not idempotent.
   cisco_command_config { 'cisco_bgp_neighbor':
   command   => "
     router bgp 55

--- a/examples/demo_roles_site.pp
+++ b/examples/demo_roles_site.pp
@@ -41,6 +41,6 @@ node 'n9k-internal-switch' {
 }
 
 node 'n3k-internal-switch' {
-  include demo_role::internal_switch
+  include ciscopuppet::demo_role::internal_switch
 }
 

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -167,7 +167,8 @@ Puppet::Type.newtype(:cisco_interface) do
     desc "The allowed VLANs for the specified Ethernet interface. Valid values
           are string, keyword 'default'."
 
-    munge { |value| value == 'default' ? :default : value }
+    # Strip whitespace if manifest specified as '20, 30' vs '20,30'
+    munge { |value| value == 'default' ? :default : value.sub(/\s/, '') }
   end # property switchport_trunk_allowed_vlan
 
   newproperty(:switchport_trunk_native_vlan) do


### PR DESCRIPTION
1) Comment to clarify that bgp command config password is not idempotent. (expected)
2) Namespace fix for roles based demo manifest.
3) Fixed property switchport_trunk_allowed_vlan idempotence issue.