### PR TITLE
Fixed bgp type processing errors

### DIFF
--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -17,6 +17,13 @@
 # limitations under the License.
 
 require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
 
 Puppet::Type.newtype(:cisco_bgp) do
   @doc = "Manages BGP global and vrf configuration.
@@ -147,7 +154,7 @@ Puppet::Type.newtype(:cisco_bgp) do
       end
     end
 
-    munge { |value| Cisco::RouterBgp.process_asnum(value.to_s) }
+    munge { |value| PuppetX::Cisco::BgpUtils.process_asnum(value.to_s) }
   end # param asn
 
   newparam(:vrf, namevar: true) do

--- a/lib/puppet/type/cisco_bgp_neighbor.rb
+++ b/lib/puppet/type/cisco_bgp_neighbor.rb
@@ -17,6 +17,13 @@
 # limitations under the License.
 
 require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
 
 Puppet::Type.newtype(:cisco_bgp_neighbor) do
   @doc = "Manages BGP Neighbor configuration.
@@ -149,7 +156,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
           or ASDOT notation or Integer"
     munge do |value|
       begin
-        value = Cisco::RouterBgp.process_asnum(value.to_s)
+        value = PuppetX::Cisco::BgpUtils.process_asnum(value.to_s)
         value.to_s
       rescue
         raise("BGP asn #{value} must be specified in ASPLAIN or ASDOT notation")
@@ -170,7 +177,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
           ipv4/prefix length, ipv6, or ipv6/prefix length'
     munge do |value|
       begin
-        value = Cisco::Utils.process_network_mask(value) unless value.nil?
+        value = PuppetX::Cisco::Utils.process_network_mask(value) unless value.nil?
         value
       rescue
         raise "neighbor must be in valid ipv4/v6 address or address/length
@@ -224,7 +231,8 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
           means not to configure it"
     validate do |value|
       begin
-        Cisco::RouterBgp.process_asnum(value.to_s) unless value.to_s.to_sym == :default
+        PuppetX::Cisco::BgpUtils.process_asnum(value.to_s) unless
+          value.to_s.to_sym == :default
       rescue
         raise("BGP asn #{value} must be specified in ASPLAIN or ASDOT notation")
       end
@@ -302,7 +310,8 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
           means not to configure it"
     validate do |value|
       begin
-        Cisco::RouterBgp.process_asnum(value.to_s) unless value.to_s.to_sym == :default
+        PuppetX::Cisco::BgpUtils.process_asnum(value.to_s) unless
+          value.to_s.to_sym == :default
       rescue
         raise("BGP asn #{value} must be specified in ASPLAIN or ASDOT notation")
       end

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -1,0 +1,66 @@
+# PuppetX::Cisco - Common utility methods used by Cisco Types/Providers
+#
+# November 2015
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module PuppetX
+  module Cisco
+    # PuppetX::Cisco::Utils: - Common helper methods shared by any Type/Provider
+    class Utils
+      require 'ipaddr'
+      # Helper utility method for ip/prefix format networks.
+      # For ip/prefix format '1.1.1.1/24' or '2000:123:38::34/64',
+      # we need to mask the address using the prefix length so that they
+      # are converted to '1.1.1.0/24' or '2000:123:38::/64'
+      def self.process_network_mask(network)
+        mask = network.split('/')[1]
+        address = IPAddr.new(network).to_s
+        network = address + '/' + mask unless mask.nil?
+        network
+      end
+    end
+
+    # PuppetX::Cisco::BgpUtil - Common BGP methods used by BGP Types/Providers
+    class BgpUtils
+      def self.process_asnum(asnum)
+        err_msg = "BGP asnum must be either a 'String' or an" \
+                  " 'Integer' object"
+        fail ArgumentError, err_msg unless asnum.is_a?(Integer) ||
+                                           asnum.is_a?(String)
+        if asnum.is_a? String
+          # Match ASDOT '1.5' or ASPLAIN '55' strings
+          fail ArgumentError unless /^(\d+|\d+\.\d+)$/.match(asnum)
+          asnum = dot_to_big(asnum) if /\d+\.\d+/.match(asnum)
+        end
+        asnum.to_i
+      end
+
+      # Convert BGP ASN ASDOT+ to ASPLAIN
+      def self.dot_to_big(dot_str)
+        fail ArgumentError unless dot_str.is_a? String
+        return dot_str unless /\d+\.\d+/.match(dot_str)
+        mask = 0b1111111111111111
+        high = dot_str.to_i
+        low = 0
+        low_match = dot_str.match(/\.(\d+)/)
+        low = low_match[1].to_i if low_match
+        high_bits = (mask & high) << 16
+        low_bits = mask & low
+        high_bits + low_bits
+      end
+    end
+  end
+end


### PR DESCRIPTION
BGP types were generating error because they were attempting to use cisco_node_utils gem methods before the gem was installed.  This fixes that problem.

1) Beaker Tests Pass
```
bgp/test_bgp_title_patterns.rb passed in 214.69 seconds
      Test Suite: tests @ 2015-11-10 02:46:39 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 367.25 seconds
      Average Test Time: 91.81 seconds
              Attempted: 4
                 Passed: 4
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 4

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:
```
2) Demo Manifest Works

```
root@agent-lab10-nx#puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for agent-lab10-nx.cisco.com
Warning: Found multiple default providers for package: yum, puppet_gem, pip3; using yum
Info: Applying configuration version '1447172748'
Notice: /Stage[main]/Ciscopuppet::Install/Package[cisco_node_utils]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp[55.77 blue]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_af[55.77 blue ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_af[55.77 blue ipv6 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 1.1.1.1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 2.2.2.2]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 3.3.3.3]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor[55.77 blue 1:1::1:1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 1.1.1.1 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 2.2.2.2 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp_neighbor_af[55.77 blue 3.3.3.3 ipv4 unicast]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Domain_name[demo.cisco.com]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_domain/Network_dns[settings]/search: search changed '[]' to '['test.com', 'test.net']'
Notice: /Stage[main]/Ciscopuppet::Demo_interface/Cisco_interface[Vlan22]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ntp/Ntp_server[5.5.5.5]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf[Sample]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_interface_ospf[Ethernet1/1 Sample]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf_vrf[dark_blue default]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_ospf/Cisco_ospf_vrf[dark_blue vrf1]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/key: key changed 'unset' to '44444444'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_global[default]/key_format: key_format changed '-1' to '7'
Notice: /Stage[main]/Ciscopuppet::Demo_radius/Radius_server[8.8.8.8]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Cisco_snmp_server[default]/aaa_user_cache_timeout: aaa_user_cache_timeout changed '3600' to '200'
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Cisco_snmp_server[default]/global_enforce_priv: global_enforce_priv changed 'false' to 'true'
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Network_snmp[default]/contact: contact changed 'unset' to 'SysAdmin'
Notice: /Stage[main]/Ciscopuppet::Demo_snmp/Network_snmp[default]/location: location changed 'unset' to 'UK'
Notice: /Stage[main]/Ciscopuppet::Demo_tacacs_server/Cisco_tacacs_server[default]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_tacacs_server_host/Cisco_tacacs_server_host[tachost]/ensure: created
Notice: /Stage[main]/Ciscopuppet::Demo_vtp/Cisco_vtp[default]/ensure: created
Notice: Applied catalog in 127.25 seconds
root@agent-lab10-nx#
```