### PR TITLE
modify aaa group tacacs to be compatible with the new netdev compatib…

### DIFF
--- a/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/aaagrouptacacs/aaagroup_provider_nondefaults.rb
@@ -116,7 +116,7 @@ test_name "TestCase :: #{testheader}" do
         { 'ensure'           => 'present',
           'deadtime'         => '30',
           'vrf_name'         => 'blue',
-          'source_interface' => 'Ethernet1/1',
+          'source_interface' => 'ethernet1/1',
           'server_hosts'     => "\\['testhost', '1.1.1.1'\\]" },
         false, self, logger)
     end
@@ -163,7 +163,7 @@ test_name "TestCase :: #{testheader}" do
         { 'ensure'           => 'present',
           'deadtime'         => '30',
           'vrf_name'         => 'blue',
-          'source_interface' => 'Ethernet1/1',
+          'source_interface' => 'ethernet1/1',
           'server_hosts'     => "\\['testhost', '1.1.1.1'\\]" },
         true, self, logger)
     end


### PR DESCRIPTION
beaker passes, rubocop passes

I'll merge this at the same time I merge the node utils changes. This also addresses using autogen to gen a couple of the properties.