### PR TITLE
grpc_port parameter supported in hosts cfg file

### DIFF
--- a/docs/README-develop-beaker-scripts.md
+++ b/docs/README-develop-beaker-scripts.md
@@ -74,6 +74,8 @@ $ cd cisco-network-puppet-module/tests/beaker_tests/
 
 Under the `beaker_tests` directory, create file named `host.cfg` and add the following content.
 
+Note: If running puppet on XR, specify the gRPC port number configured on the switch.
+
 Replace the `< >` markers with specific information.
 
 ```bash
@@ -83,6 +85,7 @@ HOSTS:
             - agent
         platform: cisco-7-x86_64
         ip: <fully qualified domain name>
+        grpc_port <grpc port number for XR switch>
         vrf: <vrf used for beaker workstation and puppet master ip reachability>
         ssh:
           auth_methods: ["password"]
@@ -126,6 +129,18 @@ HOSTS:
           auth_methods: ["password"]
           user: devops
           password: devopspassword
+
+    xr-agent:
+        roles:
+            - agent
+        platform: cisco-7-x86_64
+        ip: xr_agent.domain.com
+        vrf: tpnns
+        grpc_port: 57777
+        ssh:
+          auth_methods: ["password"]
+          user: root
+          password: password
 
     puppetmaster1:
         roles:

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -57,8 +57,12 @@ module UtilityLib
     when /cisco/
       agentvrf = options[:HOSTS][host.to_s.to_sym]['vrf']
       grpc_port = options[:HOSTS][host.to_s.to_sym]['grpc_port']
-      node_var = "export NODE=\"127.0.0.1:#{grpc_port} root lab\""
-      return "#{node_var} && ip netns exec #{agentvrf} " + cmdstr
+      if grpc_port.nil?
+        return "sudo ip netns exec #{agentvrf} " + cmdstr
+      else
+        node_var = "export NODE=\"127.0.0.1:#{grpc_port} root lab\""
+        return "#{node_var} && ip netns exec #{agentvrf} " + cmdstr
+      end
     else
       return cmdstr
     end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -60,6 +60,7 @@ module UtilityLib
       if grpc_port.nil?
         return "sudo ip netns exec #{agentvrf} " + cmdstr
       else
+        # TODO: remove this workaround when we have grpc UDS support
         node_var = "export NODE=\"127.0.0.1:#{grpc_port} root lab\""
         return "#{node_var} && ip netns exec #{agentvrf} " + cmdstr
       end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -56,7 +56,9 @@ module UtilityLib
     case host['platform']
     when /cisco/
       agentvrf = options[:HOSTS][host.to_s.to_sym]['vrf']
-      return "sudo ip netns exec #{agentvrf} " + cmdstr
+      grpc_port = options[:HOSTS][host.to_s.to_sym]['grpc_port']
+      node_var = "export NODE=\"127.0.0.1:#{grpc_port} root lab\""
+      return "#{node_var} && ip netns exec #{agentvrf} " + cmdstr
     else
       return cmdstr
     end


### PR DESCRIPTION
Adds support for grpc_port parameter in hosts.cfg file and allows connection to grpc port on switch.