### PR TITLE
cisco_interface support for XR

### DIFF
--- a/examples/demo_interface.pp
+++ b/examples/demo_interface.pp
@@ -15,43 +15,60 @@
 # limitations under the License.
 
 class ciscopuppet::demo_interface {
-  cisco_interface { 'Ethernet1/1' :
-    shutdown            => true,
-    switchport_mode     => disabled,
-    description         => 'managed by puppet',
-    ipv4_address        => '192.168.55.55',
-    ipv4_netmask_length => 24,
-    mtu                 => 1600,
-    speed               => 100,
-    duplex              => 'full',
-    vrf                 => 'test',
-  }
+  if $operatingsystem == 'nexus' {
+    cisco_interface { 'Ethernet1/1' :
+      shutdown            => true,
+      switchport_mode     => disabled,
+      description         => 'managed by puppet',
+      ipv4_address        => '192.168.55.55',
+      ipv4_netmask_length => 24,
+      mtu                 => 1600,
+      speed               => 100,
+      duplex              => 'full',
+      vrf                 => 'test',
+    }
 
-  cisco_interface { 'Ethernet1/1.1':
-    encapsulation_dot1q => 20,
-  }
+    cisco_interface { 'Ethernet1/1.1':
+      encapsulation_dot1q => 20,
+    }
 
-  cisco_interface { 'Ethernet1/2':
-    description     => 'default',
-    shutdown        => 'default',
-    access_vlan     => 'default',
-    switchport_mode => access,
-  }
+    cisco_interface { 'Ethernet1/2':
+      description     => 'default',
+      shutdown        => 'default',
+      access_vlan     => 'default',
+      switchport_mode => access,
+    }
 
-  cisco_interface { 'Ethernet1/3':
-    switchport_mode               => trunk,
-    switchport_trunk_allowed_vlan => '20, 30',
-    switchport_trunk_native_vlan  => 40,
-  }
+    cisco_interface { 'Ethernet1/3':
+      switchport_mode               => trunk,
+      switchport_trunk_allowed_vlan => '20, 30',
+      switchport_trunk_native_vlan  => 40,
+    }
 
-  cisco_interface { 'Vlan22':
-    svi_autostate  => false,
-    svi_management => true,
-  }
+    cisco_interface { 'Vlan22':
+      svi_autostate  => false,
+      svi_management => true,
+    }
 
-  network_interface { 'ethernet1/9':
-    description => 'default',
-    duplex      => 'auto',
-    speed       => '100m',
+    network_interface { 'ethernet1/9':
+       description     => 'default',
+       duplex      => 'auto',
+       speed       => '100m',
+    }
+  }
+  elsif $operatingsystem == 'ios_xr' {
+    cisco_interface { 'GigabitEthernet0/0/0/1' :
+      shutdown            => true,
+      description         => 'managed by puppet',
+      ipv4_address        => '192.168.55.55',
+      ipv4_netmask_length => 24,
+      mtu                 => 1600,
+      vrf                 => 'test',
+    }
+
+    cisco_interface { 'GigabitEthernet0/0/0/2':
+      description     => 'default',
+      shutdown        => 'default',
+    }
   }
 }

--- a/lib/puppet/provider/cisco_interface/nxapi.rb
+++ b/lib/puppet/provider/cisco_interface/nxapi.rb
@@ -98,8 +98,8 @@ Puppet::Type.type(:cisco_interface).provide(:nxapi) do
     interfaces = []
     Cisco::Interface.interfaces.each do |interface_name, intf|
       begin
-        # Not allowed to create an interface for mgmt0
-        next if interface_name.match(/mgmt0/)
+        # Not allowed to create an interface for mgmt0 or MgmtEth0/*
+        next if interface_name.match(/mgmt/i)
         interfaces << properties_get(interface_name, intf)
       end
     end

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -85,7 +85,7 @@ Puppet::Type.newtype(:cisco_interface) do
     desc 'Name of the interface on the network element. Valid values are string.'
 
     validate do |name|
-      if name == 'mgmt0'
+      if name[/mgmt/i]
         fail('Stay away from the management port.')
       end # if
     end


### PR DESCRIPTION
- Subset of demo_interface.pp for features supported on XR
- Recognize `MgmtEth` as equivalent to `mgmt`

```puppet
# puppet resource cisco_interface gigabitethernet0/0/0/0
cisco_interface { 'gigabitethernet0/0/0/0':
  ensure              => 'present',
  ipv4_address        => '192.168.122.222',
  ipv4_netmask_length => '24',
  ipv4_proxy_arp      => 'false',
  ipv4_redirects      => 'false',
  mtu                 => '1514',
  shutdown            => 'false',
}

# puppet resource cisco_interface gigabitethernet0/0/0/1
cisco_interface { 'gigabitethernet0/0/0/1':
  ensure              => 'present',
  description         => 'managed by puppet',
  ipv4_address        => '192.168.55.55',
  ipv4_netmask_length => '24',
  ipv4_proxy_arp      => 'false',
  ipv4_redirects      => 'false',
  mtu                 => '1600',
  shutdown            => 'true',
  vrf                 => 'test',
}
```