### PR TITLE
Authentication login

### DIFF
--- a/examples/demo_aaa.pp
+++ b/examples/demo_aaa.pp
@@ -26,4 +26,11 @@ class ciscopuppet::demo_aaa {
       vrf_name               => 'blue',
       require                => Cisco_tacacs_server_host['testhost']
   }
+    cisco_aaa_authentication_login { 'default':
+      ascii_authentication => 'true',
+      chap                 => 'false',
+      error_display        => 'true',
+      mschap               => 'false',
+      mschapv2             => 'false',
+  }
 }

--- a/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
@@ -53,13 +53,13 @@ Puppet::Type.type(:cisco_aaa_authentication_login).provide(:nxapi) do
     authe_login = Cisco::AaaAuthenticationLogin
 
     inst << new(
-      ensure:                 :present,
-      name:                   'default', # necessary for puppet resource cmd
-      ascii_authentication:   authe_login.ascii_authentication ? :true : :false,
-      chap:                   authe_login.chap ? :true : :false,
-      error_display:          authe_login.error_display ? :true : :false,
-      mschap:                 authe_login.mschap ? :true : :false,
-      mschapv2:               authe_login.mschapv2 ? :true : :false)
+      ensure:               :present,
+      name:                 'default', # necessary for puppet resource cmd
+      ascii_authentication: authe_login.ascii_authentication ? :true : :false,
+      chap:                 authe_login.chap ? :true : :false,
+      error_display:        authe_login.error_display ? :true : :false,
+      mschap:               authe_login.mschap ? :true : :false,
+      mschapv2:             authe_login.mschapv2 ? :true : :false)
     debug 'Created new resource type cisco_aaa_authentication_login'
     inst
   end

--- a/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
@@ -1,0 +1,104 @@
+# The NXAPI (cisco_aaa_authentication_login) provider.
+#
+# November, 2015
+#
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_aaa_authentication_login).provide(:nxapi) do
+  desc 'The nxapi provider.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  AAA_AUTHE_PROPS = [:ascii_authentication,
+                     :chap,
+                     :error_display,
+                     :mschap,
+                     :mschapv2]
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@aaa_authe_login',
+                                            AAA_AUTHE_PROPS)
+
+  def initialize(value={})
+    super(value)
+    @aaa_authe_login = Cisco::AaaAuthenticationLogin
+    @property_flush = {}
+    debug 'Created provider instance of cisco_aaa_authentication_login.'
+  end
+
+  def self.instances
+    inst = []
+    authe_login = Cisco::AaaAuthenticationLogin
+
+    inst << new(
+      ensure:                 :present,
+      name:                   'default', # necessary for puppet resource cmd
+      ascii_authentication:   authe_login.ascii_authentication ? :true : :false,
+      chap:                   authe_login.chap ? :true : :false,
+      error_display:          authe_login.error_display ? :true : :false,
+      mschap:                 authe_login.mschap ? :true : :false,
+      mschapv2:               authe_login.mschapv2 ? :true : :false)
+    debug 'Created new resource type cisco_aaa_authentication_login'
+    inst
+  end
+
+  def self.prefetch(resources)
+    resources.values.first.provider = instances.first
+  end
+
+  def properties_set
+    # any current method of authentication must be turned off before a new
+    # indended method can be turned on, so configuration order is important
+    off_props = AAA_AUTHE_PROPS.select do |prop|
+      @resource[prop] && @property_flush[prop] == false
+    end
+    on_props = AAA_AUTHE_PROPS.select do |prop|
+      @resource[prop] && @property_flush[prop] == true
+    end
+    # add on_props to the end of off_props so they're configured last
+    off_props.concat(on_props).each do |prop|
+      @aaa_authe_login.send("#{prop}=", @property_flush[prop]) if
+        @aaa_authe_login.respond_to?("#{prop}=")
+    end
+  end
+
+  def flush
+    properties_set
+    put_aaa_authe_login
+  end
+
+  def put_aaa_authe_login
+    debug 'Current state:'
+    return if @aaa_authe_login.nil?
+
+    debug "
+      ascii_authentication: #{@aaa_authe_login.ascii_authentication}
+                      chap: #{@aaa_authe_login.chap}
+             error_display: #{@aaa_authe_login.error_display}
+                    mschap: #{@aaa_authe_login.mschap}
+                  mschapv2: #{@aaa_authe_login.mschapv2}
+    "
+  end
+end

--- a/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_authentication_login/nxapi.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:cisco_aaa_authentication_login).provide(:nxapi) do
 
   def properties_set
     # any current method of authentication must be turned off before a new
-    # indended method can be turned on, so configuration order is important
+    # intended method can be turned on, so configuration order is important
     off_props = AAA_AUTHE_PROPS.select do |prop|
       @resource[prop] && @property_flush[prop] == false
     end

--- a/lib/puppet/type/cisco_aaa_authentication_login.rb
+++ b/lib/puppet/type/cisco_aaa_authentication_login.rb
@@ -23,7 +23,7 @@ Puppet::Type.newtype(:cisco_aaa_authentication_login) do
   cisco_aaa_authentication_login {\"default\":
     ..attributes..
   }
-\~~~
+~~~
 
   There can only be one instance of the cisco_aaa_authentication_login.
 
@@ -36,7 +36,7 @@ Puppet::Type.newtype(:cisco_aaa_authentication_login) do
       mschap                 => false,
       mschapv2               => false,
     }
-\~~~"
+~~~"
 
   ###################
   # Resource Naming #

--- a/lib/puppet/type/cisco_aaa_authentication_login.rb
+++ b/lib/puppet/type/cisco_aaa_authentication_login.rb
@@ -1,0 +1,115 @@
+# Manages configuration for an SNMP server.
+#
+# November 2015
+#
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_aaa_authentication_login) do
+  @doc = "Manages AAA Authentication Login configuration.
+
+  cisco_aaa_authentication_login {\"default\":
+    ..attributes..
+  }
+
+  There can only be one instance of the cisco_aaa_authentication_login.
+
+  Example:
+    cisco_aaa_authentication_login {\"default\":
+      ascii_authentication   => true,
+      chap                   => false,
+      error_display          => true,
+      mschap                 => false,
+      mschapv2               => false,
+    }"
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse out the title to fill in the attributes in these patterns. These
+  # attributes can be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    patterns = []
+
+    # Below pattern matches both parts of the full composite name.
+    patterns << [
+      /^(\S+)$/,
+      [
+        [:name, identity],
+      ],
+    ]
+    patterns
+  end
+
+  ##############
+  # Attributes #
+  ##############
+
+  newparam(:name, namevar: :true) do
+    # Note, this parameter is only created to satisfy the namevar
+    # since none of the aaa_authentication_login attributes are good candidates.
+    desc 'The name of the AAA Authentication Login instance. Must be "default".'
+    validate do |name|
+      error "only 'default' is accepted as a valid name" if name != 'default'
+    end
+  end # property name
+
+  newproperty(:ascii_authentication) do
+    desc 'Enable/disable ascii_authentication for AAA Authentication Login.'
+
+    newvalues(:true, :false, :default)
+  end
+
+  newproperty(:chap) do
+    desc 'Enable/disable chap for AAA Authentication Login.'
+
+    newvalues(:true, :false, :default)
+  end
+
+  newproperty(:error_display) do
+    desc 'Enable/disable error_display for AAA Authentication Login.'
+
+    newvalues(:true, :false, :default)
+  end
+
+  newproperty(:mschap) do
+    desc 'Enable/disable mschap for AAA Authentication Login.'
+
+    newvalues(:true, :false, :default)
+  end
+
+  newproperty(:mschapv2) do
+    desc 'Enable/disable mschapv2 for AAA Authentication Login.'
+
+    newvalues(:true, :false, :default)
+  end
+
+  # validate only one authentication method is configured before munging
+  validate do
+    props = [:ascii_authentication, :chap, :mschap, :mschapv2]
+
+    auth_methods_intended = props.select { |prop| self[prop] == :true }
+    fail 'Only one authentication login method can be configured at a time' if
+      auth_methods_intended.size > 1
+
+    # if user configures an auth method, make sure all other methods are off so
+    # that configuration succeeds
+    if auth_methods_intended.size == 1
+      props.delete(auth_methods_intended.first) # remove from tmp array
+      props.each { |prop| self[prop] = :false } # ensure others are disabled
+    end
+  end
+end

--- a/lib/puppet/type/cisco_aaa_authentication_login.rb
+++ b/lib/puppet/type/cisco_aaa_authentication_login.rb
@@ -19,20 +19,24 @@
 Puppet::Type.newtype(:cisco_aaa_authentication_login) do
   @doc = "Manages AAA Authentication Login configuration.
 
+~~~puppet
   cisco_aaa_authentication_login {\"default\":
     ..attributes..
   }
+\~~~
 
   There can only be one instance of the cisco_aaa_authentication_login.
 
   Example:
+~~~puppet
     cisco_aaa_authentication_login {\"default\":
       ascii_authentication   => true,
       chap                   => false,
       error_display          => true,
       mschap                 => false,
       mschapv2               => false,
-    }"
+    }
+\~~~"
 
   ###################
   # Resource Naming #
@@ -68,7 +72,8 @@ Puppet::Type.newtype(:cisco_aaa_authentication_login) do
   end # property name
 
   newproperty(:ascii_authentication) do
-    desc 'Enable/disable ascii_authentication for AAA Authentication Login.'
+    desc 'Enable/disable ascii_authentication for AAA Authentication Login.' \
+         "Valid values are true, false, keyword 'default'"
 
     newvalues(:true, :false, :default)
   end

--- a/tests/beaker_tests/aaaauthelogin/aaaautheloginlib.rb
+++ b/tests/beaker_tests/aaaauthelogin/aaaautheloginlib.rb
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Method to create a manifest for bgp neighbor with attributes:
+# @param name [String] Name of the bgp neighbor.
+# @param tests [Hash] a hash that contains the supported attributes
+# @result none [None] Returns no object.
+def create_aaaauthelogin_manifest(tests, name)
+  tests[name][:manifest] = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+  node default {
+    cisco_aaa_authentication_login { '#{name}':\n
+    #{prop_hash_to_manifest(tests[name][:manifest_props])}
+  }\n      }\n EOF"
+end

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_defaults.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_defaults.rb
@@ -1,0 +1,122 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaAutheLogin-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet Aaa Authentication Login resource testcase for Puppet Agent
+# on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a Aaa Authentication Login resource test that tests for attribute
+# default values.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax,Style/ExtraSpacing,Metrics/MethodLength
+
+# Require UtilityLib.rb and aaaauthelogin.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaautheloginlib.rb', __FILE__)
+
+UtilityLib.set_manifest_path(master, self)
+result = 'PASS'
+testheader = 'AAA Authentication Login:: Attribute Defaults'
+id = 'default'
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+def create_aaaauthelogin_defaults(tests, id, string=false)
+  val = string ? 'default' : :default
+  title = 'default' # only allowed
+
+  tests[id][:manifest_props] = {
+    :name                 => title,
+    :ascii_authentication => val,
+    :chap                 => val,
+    :error_display        => val,
+    :mschap               => val,
+    :mschapv2             => val,
+  }
+
+  tests[id][:resource] = {
+    'ascii_authentication' => 'false',
+    'chap'                 => 'false',
+    'error_display'        => 'false',
+    'mschap'               => 'false',
+    'mschapv2'             => 'false',
+  }
+
+  create_aaaauthelogin_manifest(tests, id)
+  resource_cmd_str =
+    UtilityLib::PUPPET_BINPATH +
+    "resource cisco_aaa_authentication_login '#{title}'"
+  tests[id][:resource_cmd] =
+    UtilityLib.get_namespace_cmd(agent, resource_cmd_str, options)
+end
+
+test_name "TestCase :: #{testheader}" do
+  # aaa authentication login is a singleton, and requires no feature or setup
+  tests[id] = {}
+  # may or may not already be default
+  tests[id][:code] = [0, 2]
+  tests[id][:desc] =
+    "1.1 Apply default manifest with 'default' as a string in attributes"
+  create_aaaauthelogin_defaults(tests, id, true)
+  test_manifest(tests, id)
+
+  tests[id][:desc] =
+    '1.2 Check cisco_aaa_authentication_login resource present on agent'
+  test_resource(tests, id)
+
+  tests[id][:desc] =
+    "1.3 Apply default manifest with 'default' as a symbol in attributes"
+  create_aaaauthelogin_defaults(tests, id, false)
+  # In this case, nothing changed, we would expect the puppet run return 0,
+  # It also verified idempotent of the provider.
+  tests[id][:code] = [0]
+  test_manifest(tests, id)
+
+  # aaa authentication login is not ensurable, so no need to test present/absent
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_defaults.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_defaults.rb
@@ -48,7 +48,7 @@
 # instance attributes to verify resource properties.
 #
 ###############################################################################
-# rubocop:disable Style/HashSyntax,Style/ExtraSpacing,Metrics/MethodLength
+# rubocop:disable Style/HashSyntax
 
 # Require UtilityLib.rb and aaaauthelogin.rb paths.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
@@ -1,0 +1,118 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaAutheLogin-Provider-negative.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet Aaa Authentication Login resource testcase to test negative
+# values in the manifest
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a Aaa Authentication Login resource test that tests for various negative
+# values when created with 'ensure' => 'present' to make sure the type validation
+# is working
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax
+
+# Require UtilityLib.rb and AaaAutheLoginLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaautheloginlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'Aaa Authentication Login Resource :: Negative Value Test'
+UtilityLib.set_manifest_path(master, self)
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+test_name "TestCase :: #{testheader}" do
+  # only 'default' title pattern is allowed so this should fail
+  id = 'not_default'
+  tests[id] = {
+    :desc           => '1.1 Apply id pattern of resource name',
+    :code           => [0],
+    :manifest_props => {},
+  }
+  create_aaaauthelogin_manifest(tests, id)
+  # search for error pattern in puppet agent cmd output
+  test_manifest(tests, id, /only 'default' is accepted as a valid name/)
+
+  id = 'default'
+  # setting 2 authentication methods at once should fail
+  tests[id] = {
+    :desc           => '1.2 Attempt to set multiple auth login methods',
+    :code           => [1],
+    :manifest_props => {
+      :ascii_authentication => :true,
+      :chap                 => :true,
+    },
+  }
+  create_aaaauthelogin_manifest(tests, id)
+  test_manifest(tests, id)
+
+  # anything besides boolean properties should fail
+  [:ascii_authentication, :chap, :mschap, :mschapv2].each do |prop|
+    tests[id] = {
+      :desc           => "1.3 Apply non-bool value to #{prop} property",
+      :code           => [1],
+      :manifest_props => {
+        prop => 42,
+      },
+    }
+    create_aaaauthelogin_manifest(tests, id)
+    test_manifest(tests, id)
+
+    tests[id] = {
+      :desc           => "1.3 Apply invalid symbol to #{prop} property",
+      :code           => [1],
+      :manifest_props => {
+        prop => :invalid,
+      },
+    }
+    create_aaaauthelogin_manifest(tests, id)
+    test_manifest(tests, id)
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
@@ -95,7 +95,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply non-bool value to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => 42
+        prop => 42,
       },
     }
     create_aaaauthelogin_manifest(tests, id)
@@ -105,7 +105,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply invalid symbol to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => :invalid
+        prop => :invalid,
       },
     }
     create_aaaauthelogin_manifest(tests, id)

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
@@ -94,7 +94,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply non-bool value to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => 42,
+        prop => 42
       },
     }
     create_aaaauthelogin_manifest(tests, id)
@@ -104,7 +104,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply invalid symbol to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => :invalid,
+        prop => :invalid
       },
     }
     create_aaaauthelogin_manifest(tests, id)

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
@@ -73,7 +73,8 @@ test_name "TestCase :: #{testheader}" do
   }
   create_aaaauthelogin_manifest(tests, id)
   # search for error pattern in puppet agent cmd output
-  test_manifest(tests, id, /only 'default' is accepted as a valid name/)
+  tests[id][:stderr_pattern] = /only 'default' is accepted as a valid name/
+  test_manifest(tests, id)
 
   id = 'default'
   # setting 2 authentication methods at once should fail

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
@@ -48,7 +48,7 @@
 # instance attributes to verify resource properties.
 #
 ###############################################################################
-# rubocop:disable Style/HashSyntax,Style/ExtraSpacing
+# rubocop:disable Style/HashSyntax
 
 # Require UtilityLib.rb and AaaAutheLogin.rb paths.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
@@ -75,18 +75,18 @@ test_name "TestCase :: #{testheader}" do
 
     tests[id] = {
       :manifest_props => {
-        :ascii_authentication   => ascii,
-        :chap                   => chap,
-        :error_display          => :true,
-        :mschap                 => mschap,
-        :mschapv2               => mschapv2,
+        :ascii_authentication => ascii,
+        :chap                 => chap,
+        :error_display        => :true,
+        :mschap               => mschap,
+        :mschapv2             => mschapv2,
       },
       :resource       => {
-        'ascii_authentication'   => ascii.to_s,
-        'chap'                   => chap.to_s,
-        'error_display'          => 'true',
-        'mschap'                 => mschap.to_s,
-        'mschapv2'               => mschapv2.to_s,
+        'ascii_authentication' => ascii.to_s,
+        'chap'                 => chap.to_s,
+        'error_display'        => 'true',
+        'mschap'               => mschap.to_s,
+        'mschapv2'             => mschapv2.to_s,
       },
     }
     resource_cmd_str =
@@ -104,14 +104,14 @@ test_name "TestCase :: #{testheader}" do
     tests[id][:desc] =
       '1.2 Apply manifest with string format non-default attributes'
     tests[id][:manifest_props] = {
-        :ascii_authentication   => ascii.to_s,
-        :chap                   => chap.to_s,
-        :error_display          => 'true',
-        :mschap                 => mschap.to_s,
-        :mschapv2               => mschapv2.to_s,
+      :ascii_authentication => ascii.to_s,
+      :chap                 => chap.to_s,
+      :error_display        => 'true',
+      :mschap               => mschap.to_s,
+      :mschapv2             => mschapv2.to_s,
     }
     create_aaaauthelogin_manifest(tests, id)
-    tests[id][:show_cmd] = "show run aaa all | section login"
+    tests[id][:show_cmd] = 'show run aaa all | section login'
     # this will check existence of each prop enablement in turn
     tests[id][:show_pattern] = [/^aaa authentication login #{prop} enable/]
     tests[id][:state] = true

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
@@ -81,7 +81,7 @@ test_name "TestCase :: #{testheader}" do
         :mschap               => mschap,
         :mschapv2             => mschapv2,
       },
-      :resource       => {
+      :resource => { # rubocop:disable Style/AlignHash
         'ascii_authentication' => ascii.to_s,
         'chap'                 => chap.to_s,
         'error_display'        => 'true',

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_nondefaults.rb
@@ -1,0 +1,126 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaAuthenticationLogin-Provider-Nondefaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AAA Authetentication Login resource testcase for Puppet Agent
+# on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a AAA Authentication Login resource test that tests for non-default
+# values of all attributes
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax,Style/ExtraSpacing
+
+# Require UtilityLib.rb and AaaAutheLogin.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaautheloginlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AAA Authentication Login Resource :: Attribute Non-defaults'
+UtilityLib.set_manifest_path(master, self)
+id = 'default'
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+test_name "TestCase :: #{testheader}" do
+  # aaa authentication login is a singleton, and requires no feature or setup
+  tests[id] = {}
+
+  # set each of the authentication methods to true, in turn
+  vals = [:true, :false, :false, :false]
+  ['ascii-authentication', 'chap', 'mschap', 'mschapv2'].each do |prop|
+    ascii, chap, mschap, mschapv2 = vals
+    vals.rotate! # vals => [:false, :true, :false, :false]
+
+    tests[id] = {
+      :manifest_props => {
+        :ascii_authentication   => ascii,
+        :chap                   => chap,
+        :error_display          => :true,
+        :mschap                 => mschap,
+        :mschapv2               => mschapv2,
+      },
+      :resource       => {
+        'ascii_authentication'   => ascii.to_s,
+        'chap'                   => chap.to_s,
+        'error_display'          => 'true',
+        'mschap'                 => mschap.to_s,
+        'mschapv2'               => mschapv2.to_s,
+      },
+    }
+    resource_cmd_str =
+      UtilityLib::PUPPET_BINPATH +
+      "resource cisco_aaa_authentication_login 'default'"
+    tests[id][:resource_cmd] =
+      UtilityLib.get_namespace_cmd(agent, resource_cmd_str, options)
+
+    tests[id][:code] = [0, 2]
+    tests[id][:desc] =
+      '1.1 Apply manifest with non-default attributes, and test harness'
+    create_aaaauthelogin_manifest(tests, id)
+    test_harness_common(tests, id)
+
+    tests[id][:desc] =
+      '1.2 Apply manifest with string format non-default attributes'
+    tests[id][:manifest_props] = {
+        :ascii_authentication   => ascii.to_s,
+        :chap                   => chap.to_s,
+        :error_display          => 'true',
+        :mschap                 => mschap.to_s,
+        :mschapv2               => mschapv2.to_s,
+    }
+    create_aaaauthelogin_manifest(tests, id)
+    tests[id][:show_cmd] = "show run aaa all | section login"
+    # this will check existence of each prop enablement in turn
+    tests[id][:show_pattern] = [/^aaa authentication login #{prop} enable/]
+    tests[id][:state] = true
+    # In this case, nothing changed, we would expect the puppet run return 0,
+    tests[id][:code] = [0]
+    test_harness_common(tests, id)
+  end
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -120,7 +120,7 @@ module UtilityLib
   # @param logger [Logger] A default instance of Beaker::Logger.
   # @result none [None] Returns no object.
   def self.search_pattern_in_output(output, patarr, inverse, testcase,\
-    logger)
+                                    logger)
     patarr = UtilityLib.hash_to_patterns(patarr) if patarr.instance_of?(Hash)
     patarr.each do |pattern|
       inverse ? (match = (output !~ pattern)) : (match = (output =~ pattern))
@@ -143,7 +143,7 @@ module UtilityLib
   # @param logger [Logger] A default instance of Beaker::Logger.
   # @result none [None] Returns no object.
   def self.raise_passfail_exception(testresult, message, testcase, logger)
-    if (testresult == 'PASS')
+    if testresult == 'PASS'
       testcase.pass_test("\nTestCase :: #{message} :: PASS")
     else
       testcase.fail_test("\nTestCase :: #{message} :: FAIL")
@@ -241,7 +241,7 @@ def test_manifest(tests, id, find_pattern=nil)
         if stdout =~ find_pattern || stderr =~ find_pattern
           logger.debug("TestStep :: Match #{find_pattern} :: PASS")
         else
-          self.fail_test("TestStep :: Match #{find_pattern} :: FAIL")
+          fail_test("TestStep :: Match #{find_pattern} :: FAIL")
         end
       end
     end


### PR DESCRIPTION
AAA Authentication Login Type/Provider/Beaker tests

Tests pass, rubocop passes, etc.

I noticed there isn't a good way for beaker to detect errors/warnings in puppet runs, e.g. invalid title patterns. I modified test_manifest to enable this. Thoughts?

Edit: I'm not sure why my local rubocop disagrees with github, will update.