### PR TITLE
Couple of confed peers fixes

### DIFF
--- a/lib/puppet/provider/cisco_bgp/nxapi.rb
+++ b/lib/puppet/provider/cisco_bgp/nxapi.rb
@@ -199,6 +199,11 @@ Puppet::Type.type(:cisco_bgp).provide(:nxapi) do
     @bgp_vrf.timer_bestpath_limit_set(limit, always)
   end
 
+  def confederation_peers=(should_list)
+    should_list = @bgp_vrf.default_confederation_peers if should_list[0] == :default
+    @property_flush[:confederation_peers] = should_list
+  end
+
   def flush
     if @property_flush[:ensure] == :absent
       @bgp_vrf.destroy

--- a/lib/puppet/provider/cisco_bgp/nxapi.rb
+++ b/lib/puppet/provider/cisco_bgp/nxapi.rb
@@ -201,7 +201,7 @@ Puppet::Type.type(:cisco_bgp).provide(:nxapi) do
 
   def confederation_peers=(should_list)
     should_list = @bgp_vrf.default_confederation_peers if should_list[0] == :default
-    @property_flush[:confederation_peers] = should_list
+    @property_flush[:confederation_peers] = should_list.flatten
   end
 
   def flush

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -231,11 +231,7 @@ Puppet::Type.newtype(:cisco_bgp) do
     end
 
     munge do |peers|
-      if peers == 'default'
-        peers = :default
-      else
-        peers = peers.split
-      end
+      peers == 'default' ? :default : peers.split
     end
 
     def insync?(is)

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -103,7 +103,7 @@ Puppet::Type.newtype(:cisco_bgp) do
       [
         /^(\d+|\d+\.\d+)$/,
         [
-          [:asn, identity]
+          [:asn, identity],
         ],
       ],
       [
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:cisco_bgp) do
       [
         /^(\S+)$/,
         [
-          [:name, identity]
+          [:name, identity],
         ],
       ],
     ]

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -223,32 +223,24 @@ Puppet::Type.newtype(:cisco_bgp) do
     match_error = 'must be specified in ASPLAIN or ASDOT notation'
 
     validate do |peers|
-      if peers.is_a? String
-        peers_array = peers.split(' ')
-      else
-        peers_array = peers
-      end
-      peers_array.each do |value|
+      peers.split.each do |value|
         fail "Confederation peer value '#{value}' #{match_error}" unless
           /^(\d+|\d+\.\d+)$/.match(value) ||
-          peers_array == 'default' || peers_array == :default
+          value == 'default' || value == :default
       end
     end
 
     munge do |peers|
-      if peers.is_a? String
-        if peers == 'default'
-          peers = :default
-        else
-          peers = peers.split(' ')
-        end
+      if peers == 'default'
+        peers = :default
+      else
+        peers = peers.split
       end
     end
 
     def insync?(is)
       (is.size == should.flatten.size && is.sort == should.flatten.sort)
     end
-
   end # confederation_peers
 
   newproperty(:shutdown) do


### PR DESCRIPTION
I wasn't handling the default case at all (mea culpa). So added the puppet setter to override the default behavior.

Then I had a bug in the validate method (checking peers_array instead of 'value').

Then Chris sent out his simplified code for all this, applied that and everything, including the default case works well now.

Rubocop happy.

manual testing happy

Log of puppet agent and outcome below:

Notice: /File[/opt/puppetlabs/puppet/cache/lib/puppet/type/cisco_bgp.rb]/content: content changed '{md5}daee343152471f669d56379ce8010641' to '{md5}b5aa67d0e668a81bd04b1b41057d8cbb'
Info: Loading facts
Info: Caching catalog for sunstone123.cisco.com
Info: Applying configuration version '1447953276'
Notice: /Stage[main]/Main/Node[default]/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed [] to 'default'
Notice: Applied catalog in 2.92 seconds
bash-4.3# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for sunstone123.cisco.com
Info: Applying configuration version '1447953398'
Notice: /Stage[main]/Main/Node[default]/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed [] to '33 44 66 77 88 99'
Notice: Applied catalog in 5.49 seconds
bash-4.3# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for sunstone123.cisco.com
Info: Applying configuration version '1447953481'
Notice: /Stage[main]/Main/Node[default]/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed ['33', '44', '66', '77', '88', '99'] to '11 12 13'
Notice: Applied catalog in 6.85 seconds
bash-4.3# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for sunstone123.cisco.com
Info: Applying configuration version '1447953570'
Notice: /Stage[main]/Main/Node[default]/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed ['11', '12', '13'] to 'default'
Notice: Applied catalog in 4.34 seconds

RP/0/RP0/CPU0:ios#sh run router bgp
Thu Nov 19 17:23:06.912 UTC
router bgp 55
 bgp router-id 1.1.1.1
 bgp log neighbor changes disable
 vrf blue
  rd auto
  bgp router-id 192.168.0.66
 !
!

RP/0/RP0/CPU0:ios#RP/0/RP0/CPU0:Nov 19 17:23:38.262 : smartlicserver[178]: %LIBRARY-REPLICATOR-3-IDT_FAIL : Failed to complete IDT after several retries: rc 0x0 (Success)

RP/0/RP0/CPU0:ios#sh run router bgp
Thu Nov 19 17:24:56.817 UTC
router bgp 55
 bgp confederation peers
  33
  44
  66
  77
  88
  99
 !
 bgp router-id 1.1.1.1
 bgp log neighbor changes disable
 vrf blue
  rd auto
  bgp router-id 192.168.0.66
 !
!

RP/0/RP0/CPU0:ios#sh run router bgp
Thu Nov 19 17:26:27.190 UTC
router bgp 55
 bgp confederation peers
  11
  12
  13
 !
 bgp router-id 1.1.1.1
 bgp log neighbor changes disable
 vrf blue
  rd auto
  bgp router-id 192.168.0.66
 !
!

RP/0/RP0/CPU0:ios#RP/0/RP0/CPU0:Nov 19 17:26:58.268 : smartlicserver[178]: %LIBRARY-REPLICATOR-3-IDT_FAIL : Failed to complete IDT after several retries: rc 0x0 (Success)

RP/0/RP0/CPU0:ios#sh run router bgp
Thu Nov 19 17:27:49.247 UTC
router bgp 55
 bgp router-id 1.1.1.1
 bgp log neighbor changes disable
 vrf blue
  rd auto
  bgp router-id 192.168.0.66
 !
!
