### PR TITLE
Beaker passes on XR for builtin service provider

### DIFF
--- a/tests/beaker_tests/fileservicepkg/filesvcpkglib.rb
+++ b/tests/beaker_tests/fileservicepkg/filesvcpkglib.rb
@@ -33,6 +33,8 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 # The module has a single set of methods:
 # A. Methods to create manifests for file, service and pkg Puppet test cases.
 module FileSvcPkgLib
+  TEST_SERVICE = 'bootlogd'
+
   # A. Methods to create manifests for file, service and pkg Puppet test cases.
 
   # Method to create a manifest for FILE resource attributes:
@@ -79,8 +81,8 @@ EOF"
   def self.create_service_manifest_nondefaults
     manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
 node default {
-    service { 'syslog':
-        name            => 'syslog',
+    service { '#{TEST_SERVICE}':
+        name            => '#{TEST_SERVICE}',
         ensure          => 'running',
         enable          => 'true',
     }
@@ -96,8 +98,8 @@ EOF"
   def self.create_service_manifest_stopped
     manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
 node default {
-    service { 'syslog':
-        name            => 'syslog',
+    service { '#{TEST_SERVICE}':
+        name            => '#{TEST_SERVICE}',
         ensure          => 'stopped',
     }
 }

--- a/tests/beaker_tests/fileservicepkg/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/fileservicepkg/service_provider_nondefaults.rb
@@ -126,7 +126,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      "resource service 'syslog'", options)
+      "resource service '#{FileSvcPkgLib::TEST_SERVICE}'", options)
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure' => 'running' },

--- a/tests/beaker_tests/fileservicepkg/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/fileservicepkg/service_provider_nondefaults.rb
@@ -98,7 +98,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      "resource service 'syslog'", options)
+      "resource service '#{FileSvcPkgLib::TEST_SERVICE}'", options)
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure' => 'running' },


### PR DESCRIPTION
The following testcases pass for XR and Nexus:

```
fileservicepkg/file_provider_nondefaults.rb
fileservicepkg/service_provider_nondefaults.rb
fileservicepkg/package_provider_nondefaults_1.rb
```

Tested service is now `bootlogd` because `syslog` does not function on XR.