### PR TITLE
add vni to cisco_vrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - route_target_both_auto, route_target_both_auto_evpn
   - route_target_import, route_target_import_evpn
   - route_target_export, route_target_export_evpn
+- Extended cisco_vrf with `vni`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,10 @@ Description of the VRF. Valid value is string.
 ##### `shutdown`
 Shutdown state of the VRF. Valid values are 'true' and 'false'.
 
+##### `vni`
+Specify virtual network identifier. Valid values are integers between 4096
+and 16777215, or keyword 'default' to disable this property.
+
 --
 ### Type: cisco_vtp
 

--- a/README.md
+++ b/README.md
@@ -1182,8 +1182,8 @@ Description of the VRF. Valid value is string.
 Shutdown state of the VRF. Valid values are 'true' and 'false'.
 
 ##### `vni`
-Specify virtual network identifier. Valid values are integers between 4096
-and 16777215, or keyword 'default' to disable this property.
+Specify virtual network identifier. Valid values are integers between
+or keyword 'default' to disable this property.
 
 --
 ### Type: cisco_vtp

--- a/examples/demo_vrf.pp
+++ b/examples/demo_vrf.pp
@@ -19,5 +19,6 @@ class ciscopuppet::demo_vrf {
     ensure      => present,
     description => 'test vrf for puppet',
     shutdown    => false,
+    vrf         => 4096,
   }
 }

--- a/lib/puppet/provider/cisco_vrf/nxapi.rb
+++ b/lib/puppet/provider/cisco_vrf/nxapi.rb
@@ -38,6 +38,7 @@ Puppet::Type.type(:cisco_vrf).provide(:nxapi) do
   # because the boolean-based methods are processed slightly different.
   VRF_NON_BOOL_PROPS = [
     :description,
+    :vni,
   ]
   VRF_BOOL_PROPS = [
     :shutdown,

--- a/lib/puppet/type/cisco_vrf.rb
+++ b/lib/puppet/type/cisco_vrf.rb
@@ -82,16 +82,9 @@ Puppet::Type.newtype(:cisco_vrf) do
 
   newproperty(:vni) do
     desc "Specify virtual network identifier. Valid values are
-          integers between 4096 and 16777215, or keyword
-          'default' to disable this property"
+          integers or keyword 'default' to disable this property"
     munge do |value|
-      value = :default if value == 'default'
-      unless value == :default
-        value = value.to_i
-        fail 'vni value should be between 4096 and 16777215' unless
-          value.between?(4096, 167_772_15)
-      end
-      value
+      value == 'default' ? :default : value.to_i
     end
   end
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_vrf.rb
+++ b/lib/puppet/type/cisco_vrf.rb
@@ -32,6 +32,7 @@ Puppet::Type.newtype(:cisco_vrf) do
      ensure                       => present,
      shutdown                     => false,
      description                  => 'vrf red',
+     vni                          => 4096,
     }
   ~~~
   "
@@ -78,4 +79,19 @@ Puppet::Type.newtype(:cisco_vrf) do
     desc 'Shutdown state of the VRF.'
     newvalues(:true, :false)
   end # property shutdown
+
+  newproperty(:vni) do
+    desc "Specify virtual network identifier. Valid values are
+          integers between 4096 and 16777215, or keyword
+          'default' to disable this property"
+    munge do |value|
+      value = :default if value == 'default'
+      unless value == :default
+        value = value.to_i
+        fail 'vni value should be between 4096 and 16777215' unless
+          value.between?(4096, 167_772_15)
+      end
+      value
+    end
+  end
 end # Puppet::Type.newtype

--- a/tests/beaker_tests/vrf/test_vrf_provider_nondefaults.rb
+++ b/tests/beaker_tests/vrf/test_vrf_provider_nondefaults.rb
@@ -88,10 +88,11 @@ test_name "TestCase :: #{testheader}" do
   stepinfo = 'Get resource nondefault manifest from master and apply on agent'
   description = 'tested by beaker'
   shutdown = true
+  vni = 4096
   step "TestStep :: #{stepinfo}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VrfLib.create_vrf_manifest_nondefaults(vrf_name, description,
-                                                      shutdown))
+                                                      shutdown, vni))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     on(agent, puppet_agent_cmd, acceptable_exit_codes: [2])
@@ -106,7 +107,8 @@ test_name "TestCase :: #{testheader}" do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure'      => 'present',
                                             'description' => "#{description}",
-                                            'shutdown'    => "#{shutdown}" },
+                                            'shutdown'    => "#{shutdown}",
+                                            'vni'         => "#{vni}" },
                                           test[:present], self, logger)
     end
 
@@ -118,7 +120,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /description #{description}/, /shutdown/],
+                                                   /description #{description}/, /shutdown/, /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -140,7 +142,8 @@ test_name "TestCase :: #{testheader}" do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure'      => 'present',
                                             'description' => "#{description}",
-                                            'shutdown'    => "#{shutdown}" },
+                                            'shutdown'    => "#{shutdown}",
+                                            'vni'         => "#{vni}" },
                                           test[:present], self, logger)
     end
 
@@ -152,7 +155,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /description #{description}/, /shutdown/],
+                                                   /description #{description}/, /shutdown/, /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -162,10 +165,11 @@ test_name "TestCase :: #{testheader}" do
   stepinfo = 'Get vrf update manifest from master and apply on agent'
   description = 'updated by beaker'
   shutdown = false
+  vni = 'default'
   step "TestStep :: #{stepinfo}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VrfLib.create_vrf_manifest_nondefaults(vrf_name,
-                                                      description, shutdown))
+                                                      description, shutdown, vni))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     on(agent, puppet_agent_cmd, acceptable_exit_codes: [2])
@@ -179,7 +183,8 @@ test_name "TestCase :: #{testheader}" do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure'      => 'present',
                                             'description' => "#{description}",
-                                            'shutdown'    => "#{shutdown}" },
+                                            'shutdown'    => "#{shutdown}",
+                                            'vni'         => 'false' },
                                           test[:present], self, logger)
     end
 
@@ -196,6 +201,8 @@ test_name "TestCase :: #{testheader}" do
       # when shutdown is false, show cli should not have a line containing
       # "shutdown"
       UtilityLib.search_pattern_in_output(stdout, [/shutdown/],
+                                          test[:absent], self, logger)
+      UtilityLib.search_pattern_in_output(stdout, [/vni/],
                                           test[:absent], self, logger)
     end
 
@@ -245,10 +252,11 @@ test_name "TestCase :: #{testheader}" do
   stepinfo = 'Get vrf manifest that swaps cases in title and apply on agent'
   description = "update using #{vrf_name.swapcase}"
   shutdown = true
+  vni = 4096
   step "TestStep :: #{stepinfo}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VrfLib.create_vrf_manifest_nondefaults(vrf_name.swapcase,
-                                                      description, shutdown))
+                                                      description, shutdown, vni))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     on(agent, puppet_agent_cmd, acceptable_exit_codes: [2])
@@ -263,7 +271,8 @@ test_name "TestCase :: #{testheader}" do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure'      => 'present',
                                             'description' => "#{description}",
-                                            'shutdown'    => "#{shutdown}" },
+                                            'shutdown'    => "#{shutdown}",
+                                            'vni'         => "#{vni}" },
                                           test[:present], self, logger)
     end
 
@@ -275,7 +284,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /#{description}/, /shutdown/],
+                                                   /#{description}/, /shutdown/, /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -285,10 +294,11 @@ test_name "TestCase :: #{testheader}" do
   stepinfo = 'Get vrf manifest that uses name attribute and apply on agent'
   description = 'update using name attribute'
   shutdown = true
+  vni = 4096
   step "TestStep :: #{stepinfo}" do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VrfLib.update_vrf_manifest_by_name_attribute(vrf_name,
-                                                            description, shutdown))
+                                                            description, shutdown, vni))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     on(agent, puppet_agent_cmd, acceptable_exit_codes: [2])
@@ -303,7 +313,8 @@ test_name "TestCase :: #{testheader}" do
       UtilityLib.search_pattern_in_output(stdout,
                                           { 'ensure'      => 'present',
                                             'description' => "#{description}",
-                                            'shutdown'    => "#{shutdown}" },
+                                            'shutdown'    => "#{shutdown}",
+                                            'vni'         => "#{vni}" },
                                           test[:present], self, logger)
     end
 
@@ -315,7 +326,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /#{description}/, /shutdown/],
+                                                   /#{description}/, /shutdown/, /vni #{vni}/],
                                           test[:present], self, logger)
     end
 

--- a/tests/beaker_tests/vrf/test_vrf_provider_nondefaults.rb
+++ b/tests/beaker_tests/vrf/test_vrf_provider_nondefaults.rb
@@ -120,7 +120,8 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /description #{description}/, /shutdown/, /vni #{vni}/],
+                                                   /description #{description}/, /shutdown/,
+                                                   /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -155,7 +156,8 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /description #{description}/, /shutdown/, /vni #{vni}/],
+                                                   /description #{description}/, /shutdown/,
+                                                   /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -284,7 +286,8 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /#{description}/, /shutdown/, /vni #{vni}/],
+                                                   /#{description}/, /shutdown/,
+                                                   /vni #{vni}/],
                                           test[:present], self, logger)
     end
 
@@ -326,7 +329,8 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a vegas shell cmd.
     on(agent, show_vrf_cmd) do
       UtilityLib.search_pattern_in_output(stdout, [/vrf context #{vrf_name}/,
-                                                   /#{description}/, /shutdown/, /vni #{vni}/],
+                                                   /#{description}/, /shutdown/,
+                                                   /vni #{vni}/],
                                           test[:present], self, logger)
     end
 

--- a/tests/beaker_tests/vrf/vrflib.rb
+++ b/tests/beaker_tests/vrf/vrflib.rb
@@ -40,14 +40,16 @@ module VrfLib
   # @param name [String] Name of the vrf.
   # @param description [String] String for the description attribute
   # @param shutdown [Boolean] Boolean for the shutdown attribute
+  # @param name [String] Name of the vrf
   # @result none [None] Returns no object.
-  def self.create_vrf_manifest_nondefaults(name, description, shutdown)
+  def self.create_vrf_manifest_nondefaults(name, description, shutdown, vni)
     manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
     node default {
       cisco_vrf { '#{name}':
         ensure       => present,
         description  => '#{description}',
         shutdown     => #{shutdown},
+        vni          => #{vni},
       }
     }
     EOF"
@@ -75,7 +77,7 @@ module VrfLib
   # @param description [String] String for the description attribute
   # @param shutdown [Boolean] Boolean for the shutdown attribute
   # @result none [None] Returns no object.
-  def self.update_vrf_manifest_by_name_attribute(name, description, shutdown)
+  def self.update_vrf_manifest_by_name_attribute(name, description, shutdown, vni)
     manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
     node default {
       cisco_vrf { 'any_#{name}':
@@ -83,6 +85,7 @@ module VrfLib
         name                     => '#{name}',
         description              => '#{description}',
         shutdown                 => #{shutdown},
+        vni                      => #{vni},
       }
     }
     EOF"


### PR DESCRIPTION
1. pass beaker test
 Total Suite Time: 98.02 seconds
      Average Test Time: 98.02 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1
I found the non_default test the non_default value, default value. idempotence and title patten test.
So I add the vni as a property in corresponding place.

2. pass static analysis