### PR TITLE
Rubocop 0.35.1 passes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development, :unit_tests do
   gem 'puppetlabs_spec_helper',  require: false
   gem 'puppet-lint',             require: false
   gem 'pry',                     require: false
-  gem 'rubocop', '= 0.34.2',     require: false
+  gem 'rubocop', '= 0.35.1',     require: false
   gem 'simplecov',               require: false
 end
 

--- a/docs/template-beaker-router.rb
+++ b/docs/template-beaker-router.rb
@@ -124,7 +124,7 @@ tests['non_default_properties_M'] = {
     maximum_paths => '5',
   ",
   resource_props: {
-    'maximum_paths' => '5',
+    'maximum_paths' => '5'
   },
 }
 
@@ -135,7 +135,7 @@ tests['non_default_properties_S'] = {
     shutdown => 'true',
   ",
   resource_props: {
-    'shutdown' => 'true',
+    'shutdown' => 'true'
   },
 }
 

--- a/docs/template-provider-router.rb
+++ b/docs/template-provider-router.rb
@@ -41,10 +41,10 @@ Puppet::Type.type(:cisco_X__RESOURCE_NAME__X).provide(:nxapi) do
   # Property symbol arrays for method auto-generation. There are separate arrays
   # because the boolean-based methods are processed slightly different.
   X__CONSTANT_NAME__X_NON_BOOL_PROPS = [
-    :X__PROPERTY_INT__X,
+    :X__PROPERTY_INT__X
   ]
   X__CONSTANT_NAME__X_BOOL_PROPS = [
-    :X__PROPERTY_BOOL__X,
+    :X__PROPERTY_BOOL__X
   ]
   X__CONSTANT_NAME__X_ALL_PROPS =
     X__CONSTANT_NAME__X_NON_BOOL_PROPS + X__CONSTANT_NAME__X_BOOL_PROPS

--- a/docs/template-type-router.rb
+++ b/docs/template-type-router.rb
@@ -58,7 +58,7 @@ Puppet::Type.newtype(:cisco_X__RESOURCE_NAME__X) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/lib/puppet/provider/cisco_snmp_community/nxapi.rb
+++ b/lib/puppet/provider/cisco_snmp_community/nxapi.rb
@@ -82,7 +82,7 @@ Puppet::Type.type(:cisco_snmp_community).provide(:nxapi) do
 
   def group=(set_value)
     return if set_value.nil?
-    set_value = Cisco::SnmpCommunity.default_group if (set_value == :default)
+    set_value = Cisco::SnmpCommunity.default_group if set_value == :default
     @snmp_community.group = set_value
     @property_hash[:group] = set_value
   end
@@ -96,7 +96,7 @@ Puppet::Type.type(:cisco_snmp_community).provide(:nxapi) do
 
   def acl=(set_value)
     return if set_value.nil?
-    set_value = Cisco::SnmpCommunity.default_acl if (set_value == :default)
+    set_value = Cisco::SnmpCommunity.default_acl if set_value == :default
     @snmp_community.acl = set_value
     @property_hash[:acl] = set_value
   end

--- a/lib/puppet/provider/cisco_snmp_server/nxapi.rb
+++ b/lib/puppet/provider/cisco_snmp_server/nxapi.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def location=(set_value)
     return if set_value.nil?
-    set_value = @snmp_server.default_location if (set_value == :default)
+    set_value = @snmp_server.default_location if set_value == :default
     @snmp_server.location = set_value
   end
 
@@ -77,7 +77,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def contact=(set_value)
     return if set_value.nil?
-    set_value = @snmp_server.default_contact if (set_value == :default)
+    set_value = @snmp_server.default_contact if set_value == :default
     @snmp_server.contact = set_value
     @property_hash[:contact] = set_value
   end
@@ -93,7 +93,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
   def aaa_user_cache_timeout=(set_value)
     return if set_value.nil?
     set_value = @snmp_server.default_aaa_user_cache_timeout if
-      (set_value == :default)
+      set_value == :default
     @snmp_server.aaa_user_cache_timeout = set_value
     @property_hash[:aaa_user_cache_timeout] = set_value
   end
@@ -108,7 +108,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def packet_size=(set_value)
     return if set_value.nil?
-    set_value = @snmp_server.default_packet_size if (set_value == :default)
+    set_value = @snmp_server.default_packet_size if set_value == :default
     @snmp_server.packet_size = set_value
     @property_hash[:packet_size] = set_value
   end
@@ -126,7 +126,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def global_enforce_priv=(set_value)
     @property_hash[:global_enforce_priv] = set_value
-    if (set_value == :default)
+    if set_value == :default
       @snmp_server.global_enforce_priv = @snmp_server.default_global_enforce_priv
     else
       @snmp_server.global_enforce_priv = (set_value == :true)
@@ -146,7 +146,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def protocol=(set_value)
     @property_hash[:protocol] = set_value
-    if (set_value == :default)
+    if set_value == :default
       @snmp_server.protocol = @snmp_server.default_protocol
     else
       @snmp_server.protocol = (set_value == :true)
@@ -166,7 +166,7 @@ Puppet::Type.type(:cisco_snmp_server).provide(:nxapi) do
 
   def tcp_session_auth=(set_value)
     @property_hash[:tcp_session_auth] = set_value
-    if (set_value == :default)
+    if set_value == :default
       @snmp_server.tcp_session_auth = @snmp_server.default_tcp_session_auth
     else
       @snmp_server.tcp_session_auth = (set_value == :true)

--- a/lib/puppet/provider/cisco_vrf/nxapi.rb
+++ b/lib/puppet/provider/cisco_vrf/nxapi.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:cisco_vrf).provide(:nxapi) do
     :vni,
   ]
   VRF_BOOL_PROPS = [
-    :shutdown,
+    :shutdown
   ]
   VRF_ALL_PROPS = VRF_NON_BOOL_PROPS + VRF_BOOL_PROPS
 

--- a/lib/puppet/provider/ntp_config/nxapi.rb
+++ b/lib/puppet/provider/ntp_config/nxapi.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:ntp_config).provide(:nxapi) do
   mk_resource_methods
 
   NTP_CONFIG_PROPS = {
-    source_interface: :source_interface,
+    source_interface: :source_interface
   }
 
   def initialize(value={})

--- a/lib/puppet/provider/ntp_server/nxapi.rb
+++ b/lib/puppet/provider/ntp_server/nxapi.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:ntp_server).provide(:nxapi) do
   mk_resource_methods
 
   NTP_SERVER_ALL_PROPS = [
-    :prefer,
+    :prefer
   ]
 
   def initialize(value={})

--- a/lib/puppet/provider/radius/nxapi.rb
+++ b/lib/puppet/provider/radius/nxapi.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:radius).provide(:nxapi) do
     debug "Checking instance, Radius #{name}"
 
     current_state = {
-      name:   'default',
+      name: 'default'
     }
 
     new(current_state)

--- a/lib/puppet/provider/syslog_settings/nxapi.rb
+++ b/lib/puppet/provider/syslog_settings/nxapi.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:syslog_settings).provide(:nxapi) do
   mk_resource_methods
 
   SYSLOG_SETTINGS_PROPS = {
-    time_stamp_units: :timestamp,
+    time_stamp_units: :timestamp
   }
 
   def initialize(value={})

--- a/lib/puppet/type/cisco_aaa_authentication_login.rb
+++ b/lib/puppet/type/cisco_aaa_authentication_login.rb
@@ -52,7 +52,7 @@ Puppet::Type.newtype(:cisco_aaa_authentication_login) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_aaa_group_tacacs.rb
+++ b/lib/puppet/type/cisco_aaa_group_tacacs.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:cisco_aaa_group_tacacs) do
     patterns << [
       /^(\S+)$/,
       [
-        [:group, identity],
+        [:group, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -111,7 +111,7 @@ Puppet::Type.newtype(:cisco_bgp) do
       [
         /^(\d+|\d+\.\d+)$/,
         [
-          [:asn, identity],
+          [:asn, identity]
         ],
       ],
       [
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:cisco_bgp) do
       [
         /^(\S+)$/,
         [
-          [:name, identity],
+          [:name, identity]
         ],
       ],
     ]

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       [
         /^(\d+|\d+\.\d+)$/,
         [
-          [:asn, identity],
+          [:asn, identity]
         ],
       ],
       [
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
       [
         /^(\S+)$/,
         [
-          [:name, identity],
+          [:name, identity]
         ],
       ],
     ]

--- a/lib/puppet/type/cisco_bgp_neighbor.rb
+++ b/lib/puppet/type/cisco_bgp_neighbor.rb
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
       [
         /^(\d+|\d+\.\d+)$/,
         [
-          [:asn, identity],
+          [:asn, identity]
         ],
       ],
       [
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
       [
         /^(\S+)$/,
         [
-          [:name, identity],
+          [:name, identity]
         ],
       ],
     ]

--- a/lib/puppet/type/cisco_bgp_neighbor_af.rb
+++ b/lib/puppet/type/cisco_bgp_neighbor_af.rb
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor_af) do
       [
         /^(\d+|\d+\.\d+)$/,
         [
-          [:asn, identity],
+          [:asn, identity]
         ],
       ],
       [
@@ -179,7 +179,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor_af) do
       [
         /^(\S+)$/,
         [
-          [:name, identity],
+          [:name, identity]
         ],
       ],
     ]

--- a/lib/puppet/type/cisco_command_config.rb
+++ b/lib/puppet/type/cisco_command_config.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:cisco_command_config) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -75,7 +75,7 @@ Puppet::Type.newtype(:cisco_interface) do
     patterns << [
       /^(\S+)/,
       [
-        [:interface, identity],
+        [:interface, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_ospf.rb
+++ b/lib/puppet/type/cisco_ospf.rb
@@ -46,7 +46,7 @@ Puppet::Type.newtype(:cisco_ospf) do
     patterns << [
       /^(\S+)$/,
       [
-        [:ospf, identity],
+        [:ospf, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_snmp_community.rb
+++ b/lib/puppet/type/cisco_snmp_community.rb
@@ -48,7 +48,7 @@ Puppet::Type.newtype(:cisco_snmp_community) do
     patterns << [
       /^(\S+)$/,
       [
-        [:community, identity],
+        [:community, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_snmp_group.rb
+++ b/lib/puppet/type/cisco_snmp_group.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:cisco_snmp_group) do
     patterns << [
       /^(\S+)$/,
       [
-        [:group, identity],
+        [:group, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_snmp_server.rb
+++ b/lib/puppet/type/cisco_snmp_server.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:cisco_snmp_server) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_tacacs_server.rb
+++ b/lib/puppet/type/cisco_tacacs_server.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:cisco_tacacs_server) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_tacacs_server_host.rb
+++ b/lib/puppet/type/cisco_tacacs_server_host.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:cisco_tacacs_server_host) do
     patterns << [
       /^(\S+)$/,
       [
-        [:host, identity],
+        [:host, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_vlan.rb
+++ b/lib/puppet/type/cisco_vlan.rb
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:cisco_vlan) do
     patterns << [
       /^(\d+)$/,
       [
-        [:vlan, identity],
+        [:vlan, identity]
       ],
     ]
     patterns

--- a/lib/puppet/type/cisco_vrf.rb
+++ b/lib/puppet/type/cisco_vrf.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:cisco_vrf) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity],
+        [:name, identity]
       ],
     ]
     patterns

--- a/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
+++ b/tests/beaker_tests/aaaauthelogin/test_aaaauthelogin_negatives.rb
@@ -95,7 +95,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply non-bool value to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => 42,
+        prop => 42
       },
     }
     create_aaaauthelogin_manifest(tests, id)
@@ -105,7 +105,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.3 Apply invalid symbol to #{prop} property",
       :code           => [1],
       :manifest_props => {
-        prop => :invalid,
+        prop => :invalid
       },
     }
     create_aaaauthelogin_manifest(tests, id)

--- a/tests/beaker_tests/bgpaf/test_bgpaf.rb
+++ b/tests/beaker_tests/bgpaf/test_bgpaf.rb
@@ -205,11 +205,11 @@ tests['non_default_properties_C'] = {
   :desc           => "2.2 Non Default Properties: 'C' commands",
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
-    client_to_client                => false,
+    client_to_client => false,
   ",
 
   :resource_props => {
-    'client_to_client'              => 'false',
+    'client_to_client' => 'false'
   },
 }
 
@@ -260,7 +260,7 @@ tests['non_default_properties_Dampening_false'] = {
     ",
 
   :resource_props => {
-    'dampening_state' => 'false',
+    'dampening_state' => 'false'
   },
 }
 
@@ -270,11 +270,11 @@ tests['non_default_properties_Dampening_routemap'] = {
   :desc           => '2.3.3 Non-Default dampening_routemap',
   :title_pattern  => '2 blue ipv4 unicast',
   :manifest_props => "
-    dampening_routemap              => 'RouteMap',
+    dampening_routemap => 'RouteMap',
     ",
 
   :resource_props => {
-    'dampening_routemap'            => 'RouteMap',
+    'dampening_routemap' => 'RouteMap'
   },
 }
 

--- a/tests/beaker_tests/bgpneighbor/test_bgpneighbor_nondefaults.rb
+++ b/tests/beaker_tests/bgpneighbor/test_bgpneighbor_nondefaults.rb
@@ -50,7 +50,7 @@
 # instance attributes to verify resource properties.
 #
 ###############################################################################
-# rubocop:disable Style/HashSyntax,Style/ExtraSpacing
+# rubocop:disable Style/HashSyntax
 
 # Require UtilityLib.rb and BgpNeighborLib.rb paths.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)

--- a/tests/beaker_tests/bgpneighbor/test_bgpneighbor_titlepattern.rb
+++ b/tests/beaker_tests/bgpneighbor/test_bgpneighbor_titlepattern.rb
@@ -48,7 +48,7 @@
 # instance attributes to verify resource properties.
 #
 ###############################################################################
-# rubocop:disable Style/HashSyntax,Style/ExtraSpacing
+# rubocop:disable Style/HashSyntax
 
 # Require UtilityLib.rb and BgpNeighborLib.rb paths.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
@@ -81,7 +81,7 @@ test_name "TestCase :: #{testheader}" do
         :neighbor => neighbor,
       },
       :resource       => {
-        'ensure' => 'present',
+        'ensure' => 'present'
       },
     }
     resource_cmd_str =
@@ -143,7 +143,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => "1.5 Apply title pattern of 'asn vrf neighbor'",
       :code           => [0],
       :manifest_props => {
-        :ensure => :present,
+        :ensure => :present
       },
     }
     create_bgpneighbor_manifest(tests, id)
@@ -154,7 +154,7 @@ test_name "TestCase :: #{testheader}" do
       :desc           => '1.6 Test neighbor munge function',
       :code           => [0],
       :manifest_props => {
-        :ensure => :present,
+        :ensure => :present
       },
     }
     create_bgpneighbor_manifest(tests, id)

--- a/tests/beaker_tests/bgpneighboraf/test_bgpneighboraf.rb
+++ b/tests/beaker_tests/bgpneighboraf/test_bgpneighboraf.rb
@@ -385,7 +385,7 @@ tests['non_default_properties_ebgp_only'] = {
     as_override => true,
   ",
   :resource_props => {
-    'as_override' => 'true',
+    'as_override' => 'true'
   },
 }
 
@@ -397,7 +397,7 @@ tests['non_default_properties_ibgp_only'] = {
     route_reflector_client => true,
   ",
   :resource_props => {
-    'route_reflector_client' => 'true',
+    'route_reflector_client' => 'true'
   },
 }
 
@@ -409,7 +409,7 @@ tests['non_default_properties_ibgp_only_l2vpn'] = {
     route_reflector_client => true,
   ",
   :resource_props => {
-    'route_reflector_client' => 'true',
+    'route_reflector_client' => 'true'
   },
 }
 
@@ -420,7 +420,7 @@ tests['non_default_properties_vrf_only'] = {
     soo => '3:3',
   ",
   :resource_props => {
-    'soo' => '3:3',
+    'soo' => '3:3'
   },
 }
 
@@ -475,7 +475,7 @@ tests['non_default_misc_maps_part_2'] = {
     advertise_map_non_exist => ['admap', 'non_exist_map'],
   ",
   :resource_props => {
-    'advertise_map_non_exist' => '..admap., .non_exist_map..',
+    'advertise_map_non_exist' => '..admap., .non_exist_map..'
   },
 }
 


### PR DESCRIPTION
```
~/cisco-network-puppet-module$ rubocop
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 215 files
.......................................................................................................................................................................................................................
```