### PR TITLE
adding snmp_notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `cisco_vxlan_global` type and provider.
 
 #### NetDev Resources
-- `search_domain` provider.
 - `network_trunk` provider.
+- `search_domain` provider.
+- `snmp_notification` provider.
 
 ### Added
 - Extended `cisco_bgp` with the following attributes:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_snmp_user`](#type-cisco_snmp_user)
   * [`network_snmp (netdev_stdlib)`](#type-network_snmp)
   * [`snmp_community (netdev_stdlib)`](#type-snmp_community)
+  * [`snmp_notification (netdev_stdlib)`](#type-snmp_notification)
   * [`snmp_user (netdev_stdlib)`](#type-snmp_user)
 
 * SYSLOG Types
@@ -252,6 +253,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`radius_server`](#type-radius_server)
 * [`search_domain`](#type-search_domain)
 * [`snmp_community`](#type-snmp_community)
+* [`snmp_notification`](#type-snmp_notification)
 * [`snmp_user`](#type-snmp_user)
 * [`syslog_server`](#type-syslog_server)
 * [`syslog_setting`](#type-syslog_setting)
@@ -1492,6 +1494,15 @@ keyword 'default'.
 ##### `acl`
 Assigns an Access Control List (ACL) to an SNMP community to filter SNMP
 requests. Valid values are a string or the keyword 'default'.
+
+### Type: snmp_notification
+Manages an SNMP notification on a Cisco SNMP server.
+
+#### Parameters
+
+##### `enable`
+Determine whether the trap should be on or off. Valid
+values are true and false.
 
 ### Type: snmp_user
 

--- a/examples/demo_netdev_snmp.pp
+++ b/examples/demo_netdev_snmp.pp
@@ -32,4 +32,7 @@ class ciscopuppet::demo_netdev_snmp {
     localized_key   => true,
   }
 
+  snmp_notification { 'vtp vlandelete':
+    enable => 'true',
+  }
 }

--- a/lib/puppet/provider/snmp_notification/nxapi.rb
+++ b/lib/puppet/provider/snmp_notification/nxapi.rb
@@ -1,0 +1,64 @@
+# The NXAPI provider for snmp_notification.
+#
+# October, 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+
+Puppet::Type.type(:snmp_notification).provide(:nxapi) do
+  desc 'The Cisco NXAPI provider for snmp_notification.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @snmpnotification = Cisco::SnmpNotification.notifications[name]
+    @property_flush = {}
+    debug 'Created provider instance of snmp_notification'
+  end
+
+  def self.instances
+    snmpnotification = []
+    Cisco::SnmpNotification.notifications.each do |name, v|
+      snmpnotification << new(
+        name:   name,
+        enable: v.enable,
+      )
+    end
+    snmpnotification
+  end
+
+  def self.prefetch(resources)
+    snmpnotification = instances
+
+    resources.keys.each do |id|
+      provider = snmpnotification.find { |instance| instance.name == id }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end
+
+  def exists?
+    true
+  end
+
+  def flush
+    enable = @resource[:enable] == :true ? true : false
+    @snmpnotification.enable = enable if @resource[:enable]
+  end
+end

--- a/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
@@ -1,0 +1,150 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# snmp_notification_provider_defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet ROUTEDINTF resource testcase for Puppet Agent on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Populating the HOSTS configuration file with the agent and master
+# information.
+# B. Enabling SSH connection prerequisites on the N9K switch based Agent.
+# C. Starting of Puppet master server on master.
+# D. Sending to and signing of Puppet agent certificate request on master.
+#
+# TestCase:
+# ---------
+# This is a snmp resource test that tests for default values for
+# snmp_notification.
+#
+# There are 2 sections to the testcase: Setup, group of teststeps.
+# The 1st step is the Setup teststep that cleans up the switch state.
+# Steps 2-4 deal with snmp_notification resource creation and its
+# verification using Puppet Agent and the switch running-config.
+# Steps 5-7 deal with snmp_notification resource deletion and its
+# verification using Puppet Agent and the switch running-config.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+# 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes of Result object from on() method invocation.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../snmp_notificationlib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'SNMP Resource :: All Attributes Defaults'
+
+# @test_name [TestCase] Executes defaults testcase for ROUTEDINTF Resource.
+test_name "TestCase :: #{testheader}" do
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider' do
+    # Define PUPPETMASTER_MANIFESTPATH constant using puppet config cmd.
+    UtilityLib.set_manifest_path(master, self)
+
+    logger.info('Setup switch for provider')
+
+    # Make sure radius server is not configured before test starts.
+    on(master, SnmpNotificationLib.create_absent)
+
+    # Expected exit_code is 0,2 since server may or may not be configured.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+  end
+
+  step 'TestStep :: Setup switch for provider test' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, SnmpNotificationLib.create_defaults)
+
+    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
+    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to true to check for absence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd("sh run snmp all | include \"snmp-server enable traps\"")
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [
+                                            /no snmp-server enable traps aaa server-state-change/
+                                          ],
+                                          false, self, logger)
+    end
+
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, SnmpNotificationLib.create_non_defaults)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      'agent -t', options)
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks snmp_notification resource on agent using resource cmd.
+  step 'TestStep :: Check snmp_notification resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
+      "resource snmp_notification 'aaa server-state-change'", options)
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          { 'enable' => 'true' },
+                                          false, self, logger)
+    end
+
+    logger.info("Check snmp_notification resource presence on agent :: #{result}")
+  end
+
+  step 'TestStep :: Check snmp_notification instance presence on agent' do
+    # Expected exit_code is 0 since this is a vegas shell cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = UtilityLib.get_vshell_cmd("sh run snmp all | include \"snmp-server enable traps\"")
+    on(agent, cmd_str) do
+      UtilityLib.search_pattern_in_output(stdout,
+                                          [
+                                            /snmp-server enable traps aaa server-state-change/
+                                          ],
+                                          false, self, logger)
+    end
+
+    logger.info("Check snmp_notification instance presence on agent :: #{result}")
+  end
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  UtilityLib.raise_passfail_exception(result, testheader, self, logger)
+end
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/netdev_stdlib/snmp_notificationlib.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notificationlib.rb
@@ -1,0 +1,72 @@
+###############################################################################
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# SNMP notification Utility Library:
+# ---------------------
+# snmp_notificationlib.rb
+#
+# This is the utility library for the snmp_notification provider Beaker test cases
+# that contains the common methods used across the snmp_notification testsuite's
+# cases. The library is implemented as a module with related methods and
+# constants defined inside it for use as a namespace. All of the methods are
+# defined as module methods.
+#
+# Every Beaker network vlan test case that runs an instance of Beaker::TestCase
+# requires SnmpNotificationLib module.
+#
+# The module has a single set of methods:
+# A. Methods to create manifests for snmp_notification Puppet provider test cases.
+###############################################################################
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# A library to assist testing snmp_notification resource
+module SnmpNotificationLib
+  # A. Methods to create manifests for snmp_notification Puppet provider test cases.
+
+  def self.create_absent
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'aaa server-state-change':
+    enable => false,
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  def self.create_defaults
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'aaa server-state-change':
+    enable => false,
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  def self.create_non_defaults
+    manifest_str = "cat <<EOF >#{UtilityLib::PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'aaa server-state-change':
+    enable => true,
+  }
+}
+EOF"
+    manifest_str
+  end
+end


### PR DESCRIPTION
TestCase :: SNMP Resource :: All Attributes Defaults :: End
tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb passed in 32.57 seconds
      Test Suite: tests @ 2015-12-10 11:31:50 +0000

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 32.57 seconds
      Average Test Time: 32.57 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to master has been terminated
Warning: ssh connection to n9kv1 has been terminated
