### PR TITLE
aaa login exec svc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Cisco Resources
 - `cisco_aaa_authentication_login` type and provider.
 - `cisco_aaa_authorization_login_cfg_svc` type and provider.
+- `cisco_aaa_authorization_login_exec_svc` type and provider.
 - `cisco_aaa_group_tacacs` type and provider.
 - `cisco_acl` type and provider
 - `cisco_vni` type and provider.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The following resources include cisco types and providers along with cisco provi
 * AAA Types
   * [`cisco_aaa_authentication_login`](#type-cisco_aaa_authentication_login)
   * [`cisco_aaa_authorization_login_cfg_svc`](#type-cisco_aaa_authorization_login_cfg_svc)
+  * [`cisco_aaa_authorization_login_exec_svc`](#type-cisco_aaa_authorization_login_exec_svc)
   * [`cisco_aaa_group_tacacs`](#type-cisco_aaa_group_tacacs)
 
 * ACL Types
@@ -232,6 +233,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`cisco_command_config`](#type-cisco_command_config)
 * [`cisco_aaa_authentication_login`](#type-cisco_aaa_authentication_login)
 * [`cisco_aaa_authorization_login_cfg_svc`](#type-cisco_aaa_authorization_login_cfg_svc)
+* [`cisco_aaa_authorization_login_exec_svc`](#type-cisco_aaa_authorization_login_exec_svc)
 * [`cisco_aaa_group_tacacs`](#type-cisco_aaa_group_tacacs)
 * [`cisco_acl`](#type-cisco_acl)
 * [`cisco_bgp`](#type-cisco_bgp)
@@ -343,6 +345,25 @@ Determines whether the config should be present or not on the device. Valid valu
 
 ##### `name`
 Name of the config login service. Valid values are 'console' or 'default'.
+
+##### `groups`
+Tacacs+ groups configured for this service. Valid values are an array of strings, keyword 'default'.
+
+##### `method`
+Authentication methods on this device. Valid values are 'local', 'unselected', 'default'.
+
+--
+### Type: cisco_aaa_authorization_login_exec_svc
+
+Manages configuration for Authorization Login Exec Service.
+
+#### Parameters
+
+##### `ensure`
+Determines whether the config should be present or not on the device. Valid values are 'present' and 'absent'.
+
+##### `name`
+Name of the exec login service. Valid values are 'console' or 'default'.
 
 ##### `groups`
 Tacacs+ groups configured for this service. Valid values are an array of strings, keyword 'default'.

--- a/examples/demo_aaa.pp
+++ b/examples/demo_aaa.pp
@@ -15,22 +15,41 @@
 # limitations under the License.
 
 class ciscopuppet::demo_aaa {
-    cisco_tacacs_server_host { 'testhost':
-      ensure                 => present,
+  cisco_tacacs_server { 'default':
+    ensure              => present,
+    encryption_type     => clear,
+    encryption_password => 'testing123',
+    source_interface    => 'mgmt0',
   }
-    cisco_aaa_group_tacacs { 'test':
-      ensure                 => present,
-      deadtime               => '30',
-      server_hosts           => ['testhost'],
-      source_interface       => 'Ethernet1/1',
-      vrf_name               => 'blue',
-      require                => Cisco_tacacs_server_host['testhost']
+  cisco_tacacs_server_host { '1.1.1.1':
+    ensure              => present,
+    encryption_type     => 'encrypted',
+    encryption_password => 'testing123',
+    require             => Cisco_tacacs_server['default'],
   }
-    cisco_aaa_authentication_login { 'default':
-      ascii_authentication => 'true',
-      chap                 => 'false',
-      error_display        => 'true',
-      mschap               => 'false',
-      mschapv2             => 'false',
+  cisco_aaa_group_tacacs { 'group1':
+    ensure           => present,
+    deadtime         => '30',
+    server_hosts     => ['1.1.1.1'],
+    source_interface => 'mgmt0',
+    vrf_name         => 'management',
+    require          => Cisco_tacacs_server_host['1.1.1.1']
+  }
+  cisco_aaa_authentication_login { 'default':
+    ascii_authentication => 'true',
+    chap                 => 'false',
+    error_display        => 'true',
+    mschap               => 'false',
+    mschapv2             => 'false',
+  }
+  cisco_aaa_authorization_login_cfg_svc { 'default':
+    ensure => 'present',
+    groups => ["group1"],
+    method => 'local',
+  }
+  cisco_aaa_authorization_login_exec_svc { 'default':
+    ensure => 'present',
+    groups => ["group1"],
+    method => 'local',
   }
 }

--- a/lib/puppet/provider/cisco_aaa_authorization_login_exec_svc/nxapi.rb
+++ b/lib/puppet/provider/cisco_aaa_authorization_login_exec_svc/nxapi.rb
@@ -1,0 +1,142 @@
+#
+# The NXAPI provider for cisco_aaa_authorization_login_exec_svc.
+#
+# December 2015
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_aaa_authorization_login_exec_svc).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_aaa_authorization_login_exec_svc.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  AAA_EXEC_PROPS = [:method]
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@aaa_login_svc',
+                                            AAA_EXEC_PROPS)
+
+  def initialize(value={})
+    super(value)
+    # This is a shared node utils object between config and exec services.
+    # The #services method retrieves a hash of all shared services, use the
+    # :commands key to get those services relevant to this provider.
+    all_exec_svc = Cisco::AaaAuthorizationService.services[:commands]
+    @aaa_login_svc = all_exec_svc ? all_exec_svc[@property_hash[:name]] : nil
+    @property_flush = {}
+  end
+
+  def self.instances
+    services = []
+    exec_svcs = Cisco::AaaAuthorizationService.services[:commands]
+    return services if exec_svcs.nil?
+
+    exec_svcs.each do |name, svc|
+      begin
+        services << new(ensure: :present,
+                        name:   name,
+                        groups: svc.groups,
+                        method: svc.method)
+      end
+    end
+    services
+  end # self.instances
+
+  def self.prefetch(resources)
+    services = instances
+    resources.keys.each do |name|
+      provider = services.find { |svc| svc.name == name }
+      resources[name].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def properties_set
+    return unless @resource[:groups] || @resource[:method]
+
+    # groups and method must be set at the same time
+    g = @resource[:groups]
+    g ||= @aaa_login_svc.groups
+    self.groups = g
+    m = @resource[:method]
+    m ||= @aaa_login_svc.method
+    self.method = m
+    @aaa_login_svc.groups_method_set(@property_flush[:groups],
+                                     @property_flush[:method])
+  end
+
+  # can't autogen groups, special array handling
+  def groups
+    return [:default] if @resource[:groups] &&
+                         @resource[:groups][0] == :default &&
+                         @property_hash[:groups] ==
+                         @aaa_login_svc.default_groups
+    @property_hash[:groups]
+  end
+
+  def groups=(set_value)
+    if set_value.is_a?(Array) && set_value[0] == :default
+      set_value = @aaa_login_svc.default_groups
+    end
+    @property_flush[:groups] = set_value.flatten
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @aaa_login_svc.destroy
+      @aaa_login_svc = nil
+    else
+      # Create/Update
+      if @aaa_login_svc.nil?
+        @aaa_login_svc = Cisco::AaaAuthorizationService.new(:commands,
+                                                            @resource[:name])
+      end
+      properties_set
+    end
+    puts_exec
+  end
+
+  def puts_exec
+    debug 'Current state:'
+    if @aaa_login_svc.nil?
+      debug 'No aaa login exec service'
+      return
+    end
+    debug "
+        name: #{@resource[:name]}
+      method: #{@aaa_login_svc.method}
+      groups: #{@aaa_login_svc.groups}
+    "
+  end # puts_exec
+end # Puppet::Type

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -1,0 +1,119 @@
+# Manages execuration for Aaa Authorization Login Exec Service.
+#
+# December 2015
+#
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
+  @doc = "Manages execuration for Authorization Login Exec Service.
+
+~~~puppet
+  cisco_aaa_authorization_login_exec_svc {'[console|default]':
+    ..attributes..
+  }
+~~~
+
+  'console' and 'default' are the only services execurable.
+
+  Example:
+~~~puppet
+    cisco_aaa_authorization_login_exec_svc {'console':
+      ensure    => present,
+      groups    => ['group1', 'group2'],
+      method    => 'local',
+    }
+~~~"
+
+  ensurable
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse out the title to fill in the attributes in these patterns.
+  # These attributes can be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    patterns = []
+
+    patterns << [
+      /^(\S+)$/,
+      [
+        [:name, identity]
+      ],
+    ]
+    patterns
+  end
+
+  newparam(:name, namevar: true) do
+    desc 'Name of the exec login service. Valid values are "console" or "default".'
+
+    validate do |value|
+      fail unless value == 'default' || value == 'console'
+    end
+  end
+
+  ##############
+  # Attributes #
+  ##############
+
+  newproperty(:groups, array_matching: :all) do
+    desc "Tacacs+ groups execured for this service. Valid values are
+          an array of strings, keyword 'default'."
+
+    validate do |val|
+      val.split.each do |group|
+        fail "group #{value} must be a String" unless
+          group.kind_of?(String)
+      end
+    end
+
+    munge do |val|
+      val == 'default' ? :default : val.split
+    end
+
+    def in_sync?(is)
+      (is.size == should.flatten.size && is.sort == should.flatten.sort)
+    end
+  end
+
+  newproperty(:method) do
+    desc "Authentication methods on this device. Valid values are 'local',
+      'unselected', 'default'."
+
+    newvalues(:local, :unselected, :default)
+  end
+
+  ################
+  # Autorequires #
+  ################
+
+  # At a minimum, tacacs_server must be enabled to use these features
+  autorequire(:cisco_tacacs_server) do |rel_catalog|
+    rel_catalog.catalog.resource('Cisco_tacacs_server', 'default')
+  end
+
+  # Autorequire all cisco_aaa_group_tacacs associated with this service
+  autorequire(:cisco_aaa_group_tacacs) do |rel_catalog|
+    groups = []
+    if self[:groups]
+      self[:groups].flatten.each do |group|
+        groups << rel_catalog.catalog.resource('Cisco_aaa_group_tacacs',
+                                               "#{group}")
+      end
+    end
+    groups
+  end
+end

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/aaaloginexecsvclib.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/aaaloginexecsvclib.rb
@@ -1,0 +1,74 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Require UtilityLib.rb path.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Method to create a manifest for aaaloginexecsvc with attributes:
+# @param name [String] Name of the bgp neighbor.
+# @param tests [Hash] a hash that contains the supported attributes
+# @result none [None] Returns no object.
+def create_aaaloginexecsvc_manifest_simple(tests, name)
+  # exec service needs proper supporting configuration, else the
+  # configuration CLI will be locked
+  tests[name][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node default {
+    cisco_aaa_authorization_login_exec_svc { '#{name}':
+#{prop_hash_to_manifest(tests[name][:manifest_props])}
+    }
+    cisco_tacacs_server { 'default':
+      ensure => present,
+    }
+  }
+EOF"
+end
+
+# Method to create a manifest for aaaloginexecsvc with attributes AND
+# all supporting configuration to allow group configuration
+# @param name [String] Name of the bgp neighbor.
+# @param tests [Hash] a hash that contains the supported attributes
+# @result none [None] Returns no object.
+def create_aaaloginexecsvc_manifest_full(tests, name)
+  # exec service needs proper supporting configuration, else the
+  # configuration CLI will be locked
+  tests[name][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node default {
+    cisco_aaa_authorization_login_exec_svc { '#{name}':
+#{prop_hash_to_manifest(tests[name][:manifest_props])}
+    }
+    cisco_tacacs_server { 'default':
+      ensure => present,
+      encryption_type     => clear,
+      encryption_password => 'testing123',
+      source_interface    => 'mgmt0',
+    }
+    cisco_tacacs_server_host { '1.1.1.1':
+      encryption_type     => 'encrypted',
+      encryption_password => 'testing123',
+      require             => Cisco_tacacs_server['default'],
+    }
+    cisco_aaa_authentication_login { 'default':
+      ascii_authentication => true,
+    }
+    cisco_aaa_group_tacacs { 'group1':
+      ensure           => present,
+      vrf_name         => 'management',
+      source_interface => 'mgmt0',
+      server_hosts     => ['1.1.1.1'],
+      require          => Cisco_tacacs_server_host['1.1.1.1'],
+    }
+  }
+EOF"
+end

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
@@ -1,0 +1,134 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaLoginExecSvc-Provider-Defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AaaLoginExecSvc resource testcase for Puppet Agent on Nexus
+# devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a AaaLoginExecSvc resource test that tests for attribute default values
+# when created with 'ensure' => 'present'.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax,Style/ExtraSpacing
+
+# Require UtilityLib.rb and AaaLoginExecSvcLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaloginexecsvclib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AaaLoginExecSvc Resource :: Attribute Defaults'
+id = 'test_exec'
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+def create_aaaloginexecsvc_defaults(tests, id, title, string=false)
+  val = string ? 'default' : :default
+
+  tests[id][:manifest_props] = {
+    :ensure => :present,
+    :groups => val,
+    :method => val,
+    :name   => title,
+  }
+
+  tests[id][:resource] = {
+    'ensure' => 'present',
+    'method' => 'local',
+  }
+
+  create_aaaloginexecsvc_manifest_simple(tests, id)
+  resource_cmd_str =
+    PUPPET_BINPATH +
+    "resource cisco_aaa_authorization_login_exec_svc '#{title}'"
+  tests[id][:resource_cmd] =
+    get_namespace_cmd(agent, resource_cmd_str, options)
+end
+
+test_name "TestCase :: #{testheader}" do
+  stepinfo = 'Setup switch for provider test'
+  resource_absent_cleanup(agent,
+                          'cisco_aaa_authorization_login_exec_svc',
+                          stepinfo)
+  logger.info("TestStep :: #{stepinfo} :: #{result}")
+
+  tests[id] = {}
+  %w(default console).each do |title|
+    tests[id][:desc] =
+      "1.1 Apply default manifest with 'default' as a string in attributes"
+    create_aaaloginexecsvc_defaults(tests, id, title, true)
+    # [0, 2] Tacacs server may or may not already be enabled
+    tests[id][:code] = [0, 2]
+    test_manifest(tests, id)
+
+    tests[id][:desc] =
+      '1.2 Check cisco_aaaloginexecsvc resource present on agent'
+    test_resource(tests, id)
+
+    tests[id][:desc] =
+      "1.3 Apply default manifest with 'default' as a symbol in attributes"
+    create_aaaloginexecsvc_defaults(tests, id, title, false)
+    # should have no change, just reapplying defaults, exit code 0
+    tests[id][:code] = [0]
+    test_manifest(tests, id)
+
+    tests[id][:desc] = '1.4 Test resource absent manifest'
+    tests[id][:manifest_props] = {
+      :ensure => :absent,
+      :name   => title,
+    }
+    tests[id][:code] = nil
+    # can't *actually* remove authorization, that would crater the box,
+    # but check to see if defaults have been restored
+    tests[id][:resource] = { 'ensure' => 'present', 'method' => 'local' }
+    create_aaaloginexecsvc_manifest_simple(tests, id)
+    test_manifest(tests, id)
+
+    tests[id][:desc]  = '1.5 Verify resource absent on agent'
+    test_resource(tests, id)
+  end
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_negative.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_negative.rb
@@ -1,0 +1,84 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaLoginExec-Provider-negative.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a AaaLoginExecSvc resource testcase to test negative values
+# in the manifest
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a AaaLoginExecSvc resource test that tests for various negative values
+# when created with 'ensure' => 'present' to make sure the type validation
+# is working
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax
+
+# Require UtilityLib.rb and AaaLoginExecSvcLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaloginexecsvclib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AaaLoginExecSvc Resource :: Negative Value Test'
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+test_name "TestCase :: #{testheader}" do
+  logger.info('Test Invalid Title Pattern')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_exec_svc')
+
+  id = 'invalid_name'
+  tests[id] = {
+    :desc           => '1.1 Apply id pattern of resource name',
+    :code           => [1],
+    :manifest_props => { :ensure => :present },
+    :resource       => { 'ensure' => 'present' },
+    :stderr_pattern => /Parameter name failed/,
+  }
+  create_aaaloginexecsvc_manifest_simple(tests, id)
+  test_manifest(tests, id)
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
@@ -1,0 +1,129 @@
+################################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+#
+# TestCase Name:
+# -------------
+# AaaLoginExecSvc-Provider-Nondefaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet AaaLoginExecSvc resource testcase for Puppet Agent on Nexus
+# devices.
+# The test case assumes the following prerequisites are already satisfied:
+# A. Host configuration file contains agent and master information.
+# B. SSH is enabled on the Agent.
+# C. Puppet master/server is started.
+# D. Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This is a AaaLoginExecSvc resource test that tests for non-default values of all
+# attributes except password and type when created with 'ensure' => 'present'.
+# Password and type attributes will be tested in another test case as they
+# don't support idempotent.
+#
+# The testcode checks for exit_codes from Puppet Agent, Vegas shell and
+# Bash shell command executions. For Vegas shell and Bash shell command
+# string executions, this is the exit_code convention:
+# 0 - successful command execution, > 0 - failed command execution.
+# For Puppet Agent command string executions, this is the exit_code convention:
+# 0 - no changes have occurred, 1 - errors have occurred,
+# 2 - changes have occurred, 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# Note: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The testcode also uses RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+# rubocop:disable Style/HashSyntax
+
+# Require UtilityLib.rb and AaaLoginExecLib.rb paths.
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../aaaloginexecsvclib.rb', __FILE__)
+
+result = 'PASS'
+testheader = 'AaaLoginExecSvc Resource :: Attribute Non-defaults'
+id = 'test_exec'
+tests = {
+  :master => master,
+  :agent  => agent,
+}
+
+test_name "TestCase :: #{testheader}" do
+  stepinfo = 'Setup switch for provider test'
+  resource_absent_cleanup(agent,
+                          'cisco_aaa_authorization_login_exec_svc',
+                          stepinfo)
+  logger.info("TestStep :: #{stepinfo} :: #{result}")
+
+  tests[id] = {}
+  %w(console default).each do |title|
+    tests[id] = {
+      :manifest_props => {
+        :ensure => 'present',
+        :groups => ['group1'],
+        :method => 'local',
+        :name   => title,
+      },
+      :resource       => {
+        'ensure' => 'present',
+        'groups' => "\\['group1'\\]",
+        'method' => 'local',
+      },
+    }
+    resource_cmd_str =
+      PUPPET_BINPATH +
+      "resource cisco_aaa_authorization_login_exec_svc '#{title}'"
+    tests[id][:resource_cmd] =
+      get_namespace_cmd(agent, resource_cmd_str, options)
+
+    tests[id][:desc] =
+      '1.1 Apply manifest with non-default attributes, and test'
+    create_aaaloginexecsvc_manifest_full(tests, id)
+    # can't test idempotence, tacacs_server password isn't idempotent
+    test_manifest(tests, id)
+    test_resource(tests, id)
+
+    # configuring method unselected for default will lock us out, skip that
+    next if title == 'default'
+
+    tests[id][:desc] =
+      '1.2 Apply manifest with symbol format non-default attributes'
+    tests[id][:manifest_props] = {
+      :ensure => :present,
+      :groups => ['group1'],
+      :method => :unselected,
+      :name   => title,
+    }
+    tests[id][:resource]['method'] = 'unselected'
+
+    create_aaaloginexecsvc_manifest_full(tests, id)
+    tests[id][:code] = [2]
+    test_manifest(tests, id)
+    test_resource(tests, id)
+  end
+
+  resource_absent_cleanup(agent,
+                          'cisco_aaa_authorization_login_exec_svc',
+                          stepinfo)
+
+  # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
+  raise_passfail_exception(result, testheader, self, logger)
+end
+
+logger.info("TestCase :: #{testheader} :: End")


### PR DESCRIPTION
beaker passes, example manifest runs successfully, rubocop passes, etc. this is the same thing as the aaa login config service pull request that just got merged, with all the references to "cfg" changed to "exec". would love to get this committed before the holidays