### PR TITLE
Beaker test lib facter helper methods

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -531,6 +531,11 @@ end
 def platform
   return @cisco_hardware unless @cisco_hardware.nil?
   pi = on(agent, facter_cmd('-p cisco.hardware.type')).stdout.chomp
+  # The following kind of string info is returned for Nexus.
+  # - Nexus9000 C9396PX Chassis
+  # - Nexus7000 C7010 (10 Slot) Chassis
+  # - Nexus 6001 Chassis
+  # - NX-OSv Chassis
   case pi
   when /Nexus\s?300/
     @cisco_hardware = 'n3k'

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -532,15 +532,15 @@ def platform
   return @cisco_hardware unless @cisco_hardware.nil?
   pi = on(agent, facter_cmd('-p cisco.hardware.type')).stdout.chomp
   case pi
-  when /Nexus.*300/
+  when /Nexus\s?300/
     @cisco_hardware = 'n3k'
-  when /Nexus.*500/
+  when /Nexus\s?500/
     @cisco_hardware = 'n5k'
-  when /Nexus.*600/
+  when /Nexus\s?600/
     @cisco_hardware = 'n6k'
-  when /Nexus.*700/
+  when /Nexus\s?700/
     @cisco_hardware = 'n7k'
-  when /Nexus.*900/
+  when /Nexus\s?900/
     @cisco_hardware = 'n9k'
   when /NX-OSv/
     @cisco_hardware = 'n9k'

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -517,7 +517,7 @@ def facter_cmd(cmd)
   get_namespace_cmd(agent, FACTER_BINPATH + cmd, options)
 end
 
-# Used to cash the operation system information
+# Used to cache the operation system information
 @cisco_os = nil
 # Use facter to return cisco operating system information
 def operating_system
@@ -525,7 +525,7 @@ def operating_system
   @cisco_os = on(agent, facter_cmd('os.name')).stdout.chomp
 end
 
-# Used to cash the cisco hardware type
+# Used to cache the cisco hardware type
 @cisco_hardware = nil
 # Use facter to return cisco hardware type
 def platform


### PR DESCRIPTION
New set of simple beaker test lib api's to use `facter` to query for the cisco OS and cisco hardware information.  This is needed to branch test code based on the following.

* Cisco OS Example: `nexus` vs `xr`
* Cisco Hardware Information Example: `n3k`, `n9k`, `n7k` etc...

Note, beaker does have a built in `fact_on` method but I chose not to use this method primarily due to the fact that for custom cisco facts we have to prepend `sudo` to the command and the api does not allow this.

These api's are needed to unblock several teams that are writing test cases for the various platforms, however I am investigating methods to remove the hardcoded path to the `facter` binary (would be useful for `puppet` binary as well).  I would like to handle that in a subsequent PR.