### PR TITLE
platform_get module function

### DIFF
--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -1,0 +1,47 @@
+#
+# Cisco platform_get puppet manifest function.
+#
+# January, 2016 
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Puppet::Parser::Functions
+  newfunction(:platform_get, :type => :rvalue) do |args|
+    data = lookupvar('cisco') 
+    pi = data['hardware']['type']
+    # The following kind of string info is returned for Nexus.
+    # - Nexus9000 C9396PX Chassis
+    # - Nexus7000 C7010 (10 Slot) Chassis
+    # - Nexus 6001 Chassis
+    # - NX-OSv Chassis
+    case pi
+    when /Nexus\s?3\d\d\d/
+      cisco_hardware = 'n3k'
+    when /Nexus\s?5\d\d\d/
+      cisco_hardware = 'n5k'
+    when /Nexus\s?6\d\d\d/
+      cisco_hardware = 'n6k'
+    when /Nexus\s?7\d\d\d/
+      cisco_hardware = 'n7k'
+    when /Nexus\s?9\d\d\d/
+      cisco_hardware = 'n9k'
+    when /NX-OSv/
+      cisco_hardware = 'n9k'
+    else
+      raise Puppet::ParseError, "Unrecognized platform type: #{pi}\n"
+    end
+    cisco_hardware
+  end
+end

--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -32,6 +32,8 @@ module Puppet
         # - Nexus 6001 Chassis
         # - NX-OSv Chassis
         case pi
+        when /Nexus\s?31\d\d/
+          cisco_hardware = 'n31k'
         when /Nexus\s?3\d\d\d/
           cisco_hardware = 'n3k'
         when /Nexus\s?5\d\d\d/
@@ -40,7 +42,7 @@ module Puppet
           cisco_hardware = 'n6k'
         when /Nexus\s?7\d\d\d/
           cisco_hardware = 'n7k'
-        when /Nexus\s?8\d\d\d/
+        when /Nexus\s?9\d\d\d/
           cisco_hardware = 'n9k'
         when /NX-OSv/
           cisco_hardware = 'n9k'

--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -1,7 +1,7 @@
 #
 # Cisco platform_get puppet manifest function.
 #
-# January, 2016 
+# January, 2016
 #
 # Copyright (c) 2015 Cisco and/or its affiliates.
 #
@@ -17,31 +17,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Puppet::Parser::Functions
-  newfunction(:platform_get, :type => :rvalue) do |args|
-    data = lookupvar('cisco') 
-    pi = data['hardware']['type']
-    # The following kind of string info is returned for Nexus.
-    # - Nexus9000 C9396PX Chassis
-    # - Nexus7000 C7010 (10 Slot) Chassis
-    # - Nexus 6001 Chassis
-    # - NX-OSv Chassis
-    case pi
-    when /Nexus\s?3\d\d\d/
-      cisco_hardware = 'n3k'
-    when /Nexus\s?5\d\d\d/
-      cisco_hardware = 'n5k'
-    when /Nexus\s?6\d\d\d/
-      cisco_hardware = 'n6k'
-    when /Nexus\s?7\d\d\d/
-      cisco_hardware = 'n7k'
-    when /Nexus\s?9\d\d\d/
-      cisco_hardware = 'n9k'
-    when /NX-OSv/
-      cisco_hardware = 'n9k'
-    else
-      raise Puppet::ParseError, "Unrecognized platform type: #{pi}\n"
+module Puppet
+  module Parser
+    # Function platform_get.  Returns platform string.
+    module Functions
+      newfunction(:platform_get, type: :rvalue) do |_args|
+        data = lookupvar('cisco')
+        pi = data['hardware']['type']
+        # The following kind of string info is returned for Nexus.
+        # - Nexus9000 C9396PX Chassis
+        # - Nexus7000 C7010 (10 Slot) Chassis
+        # - Nexus 6001 Chassis
+        # - NX-OSv Chassis
+        case pi
+        when /Nexus\s?3\d\d\d/
+          cisco_hardware = 'n3k'
+        when /Nexus\s?5\d\d\d/
+          cisco_hardware = 'n5k'
+        when /Nexus\s?6\d\d\d/
+          cisco_hardware = 'n6k'
+        when /Nexus\s?7\d\d\d/
+          cisco_hardware = 'n7k'
+        when /Nexus\s?9\d\d\d/
+          cisco_hardware = 'n9k'
+        when /NX-OSv/
+          cisco_hardware = 'n9k'
+        else
+          fail Puppet::ParseError, "Unrecognized platform type: #{pi}\n"
+        end
+        cisco_hardware
+      end
     end
-    cisco_hardware
   end
 end

--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -23,8 +23,7 @@ module Puppet
     module Functions
       newfunction(:platform_get, type: :rvalue) do |_args|
         data = lookupvar('cisco')
-        fail Puppet::ParseError,
-             "Facter fact 'cisco' unavailable on this platform\n#{__FILE__}" if data.nil?
+        return '' if data.nil?
         pi = data['hardware']['type']
         # The following kind of string info is returned for Nexus.
         # - Nexus9000 C9396PX Chassis
@@ -32,8 +31,6 @@ module Puppet
         # - Nexus 6001 Chassis
         # - NX-OSv Chassis
         case pi
-        when /Nexus\s?31\d\d/
-          cisco_hardware = 'n31k'
         when /Nexus\s?3\d\d\d/
           cisco_hardware = 'n3k'
         when /Nexus\s?5\d\d\d/

--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -23,6 +23,8 @@ module Puppet
     module Functions
       newfunction(:platform_get, type: :rvalue) do |_args|
         data = lookupvar('cisco')
+        fail Puppet::ParseError,
+             "Facter fact 'cisco' unavailable on this platform\n#{__FILE__}" if data.nil?
         pi = data['hardware']['type']
         # The following kind of string info is returned for Nexus.
         # - Nexus9000 C9396PX Chassis
@@ -38,12 +40,12 @@ module Puppet
           cisco_hardware = 'n6k'
         when /Nexus\s?7\d\d\d/
           cisco_hardware = 'n7k'
-        when /Nexus\s?9\d\d\d/
+        when /Nexus\s?8\d\d\d/
           cisco_hardware = 'n9k'
         when /NX-OSv/
           cisco_hardware = 'n9k'
         else
-          fail Puppet::ParseError, "Unrecognized platform type: #{pi}\n"
+          fail Puppet::ParseError, "Unrecognized platform type: #{pi}\n#{__FILE__}"
         end
         cisco_hardware
       end


### PR DESCRIPTION
New puppet module custom function that can be called from a manifest to distinguish between platforms using the cisco custom fact `cisco.hardware.type`.  Currently supports various Nexus platforms but can be extended when needed.

Custom Functions Doc: https://docs.puppetlabs.com/guides/custom_functions.html

NOTE: For NX-OSv the function currently returns 'n9k' but if the team feels like 'nxv'  or something along those lines would be better choice I can make the change.

The function can be called in the manifest like this: `$foo = platform_get()`