### PR TITLE
Initial commit interface_channel_group provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `cisco_ace` type and provider
 - `cisco_acl` type and provider
 - `cisco_evpn_vni` type and provider.
+- `cisco_interface_channel_group` type and provider
 - `cisco_interface_portchannel` type and provider
 - `cisco_interface_service_vni` type and provider
 - `cisco_portchannel_global` type and provider
@@ -46,7 +47,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `table_map`, `table_map_filter`
   - `suppress_inactive`
 - Extended `cisco_interface` with the following attributes:
-  - `channel_group`
   - `ipv4_address_secondary`, `ipv4_netmask_length_secondary`
   - `ipv4_arp_timeout`
   - `ipv4_pim_sparse_mode`

--- a/README.md
+++ b/README.md
@@ -936,11 +936,6 @@ are 'present' and 'absent'.
 ###### `interface`
 Name of the interface on the network element. Valid value is a string.
 
-###### `channel_group`
-channel_group is an aggregation of multiple physical interfaces that creates a logical interface. Valid values are 1 to 4096 and 'default'.
-
-Note: On some platforms a normal side-effect of adding the channel-group property is that an independent port-channel interface will be created; however, removing the channel-group configuration by itself will not also remove the port-channel interface. Therefore, the port-channel interface itself may be explicitly removed by using the `cisco_interface` provider with `ensure => absent`.
-
 ###### `description`
 Description of the interface. Valid values are a string or the keyword 'default'.
 
@@ -1055,6 +1050,32 @@ Enable/Disable autostate on the SVI interface. Valid values are 'true',
 
 ###### `svi_management`
 Enable/Disable management on the SVI interface. Valid values are 'true', 'false', and 'default'.
+
+--
+### Type: cisco_interface
+
+Manages a Cisco Network Interface Channel-group
+
+#### Parameters
+
+##### Basic interface channel-group config attributes
+
+###### `ensure`
+Determine whether the interface config should be present or not. Valid values are 'present' and 'absent'.
+
+###### `interface`
+Name of the interface where the service resides. Valid value is a string.
+
+###### `channel_group`
+channel_group is an aggregation of multiple physical interfaces that creates a logical interface. Valid values are 1 to 4096 and 'default'.
+
+Note: On some platforms a normal side-effect of adding the channel-group property is that an independent port-channel interface will be created; however, removing the channel-group configuration by itself will not also remove the port-channel interface. Therefore, the port-channel interface itself may be explicitly removed by using the `cisco_interface` provider with `ensure => absent`.
+
+###### `description`
+Description of the interface. Valid values are a string or the keyword 'default'.
+
+###### `shutdown`
+Shutdown state of the interface. Valid values are 'true', 'false', and 'default'.
 
 --
 ### Type: cisco_interface_service_vni

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The following resources include cisco types and providers along with cisco provi
 
 * Interface Types
   * [`cisco_interface`](#type-cisco_interface)
+  * [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
   * [`cisco_interface_ospf`](#type-cisco_interface_ospf)
   * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
   * [`cisco_interface_service_vni`](#type-cisco_interface_service_vni)
@@ -194,6 +195,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_interface_ospf`](#type-cisco_interface_ospf)
 
 * Portchannel Types
+  * [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
   * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
   * [`cisco_portchannel_global`](#type-cisco_portchannel_global)
   * 
@@ -256,6 +258,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`cisco_bgp_neighbor`](#type-cisco_bgp_neighbor)
 * [`cisco_bgp_neighbor_af`](#type-cisco_bgp_neighbor_af)
 * [`cisco_interface`](#type-cisco_interface)
+* [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
 * [`cisco_interface_ospf`](#type-cisco_interface_ospf)
 * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
 * [`cisco_interface_service_vni`](#type-cisco_interface_service_vni)

--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,7 @@ Enable/Disable autostate on the SVI interface. Valid values are 'true',
 Enable/Disable management on the SVI interface. Valid values are 'true', 'false', and 'default'.
 
 --
-### Type: cisco_interface
+### Type: cisco_interface_channel_group
 
 Manages a Cisco Network Interface Channel-group
 

--- a/lib/puppet/provider/cisco_interface/nxapi.rb
+++ b/lib/puppet/provider/cisco_interface/nxapi.rb
@@ -43,7 +43,6 @@ Puppet::Type.type(:cisco_interface).provide(:nxapi) do
     :switchport_mode,
     :vrf,
     :access_vlan,
-    :channel_group,
     :description,
     :encapsulation_dot1q,
     :ipv4_address,

--- a/lib/puppet/provider/cisco_interface_channel_group/nxapi.rb
+++ b/lib/puppet/provider/cisco_interface_channel_group/nxapi.rb
@@ -1,0 +1,140 @@
+#
+# The NXAPI provider for cisco_interface_channel_group.
+#
+# January 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_interface_channel_group).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_interface_channel_group.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  # Property symbol arrays for method auto-generation. There are separate arrays
+  # because the boolean-based methods are processed slightly different.
+  # Note: channel_group should always process first.
+  INTF_CG_NON_BOOL_PROPS = [
+    :channel_group,
+    :description,
+  ]
+  INTF_CG_BOOL_PROPS = [
+    :shutdown
+  ]
+  INTF_CG_ALL_PROPS = INTF_CG_NON_BOOL_PROPS + INTF_CG_BOOL_PROPS
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
+                                            INTF_CG_NON_BOOL_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@nu',
+                                            INTF_CG_BOOL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    @nu = Cisco::InterfaceChannelGroup.interfaces[@property_hash[:name]]
+    @property_flush = {}
+  end
+
+  def self.properties_get(intf_name, nu_obj)
+    debug "Checking instance, #{intf_name}."
+    current_state = {
+      interface: intf_name,
+      name:      intf_name,
+      ensure:    :present,
+    }
+    # Call node_utils getter for each property
+    INTF_CG_NON_BOOL_PROPS.each do |prop|
+      current_state[prop] = nu_obj.send(prop)
+    end
+    INTF_CG_BOOL_PROPS.each do |prop|
+      val = nu_obj.send(prop)
+      if val.nil?
+        current_state[prop] = nil
+      else
+        current_state[prop] = val ? :true : :false
+      end
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    all_intf = []
+    Cisco::InterfaceChannelGroup.interfaces.each do |intf_name, nu_obj|
+      begin
+        all_intf << properties_get(intf_name, nu_obj)
+      end
+    end
+    all_intf
+  end # self.instances
+
+  def self.prefetch(resources)
+    all_intf = instances
+    resources.keys.each do |name|
+      provider = all_intf.find { |intf| intf.instance_name == name }
+      resources[name].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def instance_name
+    interface
+  end
+
+  def properties_set(new_interface=false)
+    INTF_CG_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_interface
+      unless @property_flush[prop].nil?
+        @nu.send("#{prop}=", @property_flush[prop]) if
+          @nu.respond_to?("#{prop}=")
+      end
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @nu.destroy
+      @nu = nil
+    else
+      # Create/Update
+      if @nu.nil?
+        new_interface = true
+        @nu = Cisco::InterfaceChannelGroup.new(@resource[:interface])
+      end
+      properties_set(new_interface)
+    end
+  end
+end # Puppet::Type

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -108,13 +108,6 @@ Puppet::Type.newtype(:cisco_interface) do
 
   ensurable
 
-  newproperty(:channel_group) do
-    desc "channel_group is an aggregation of multiple physical interfaces
-          that creates a logical interface. Valid values are 1 to 4096."
-
-    munge { |value| value == 'default' ? :default : value.to_i }
-  end # property channel_group
-
   newproperty(:description) do
     desc "Description of the interface. Valid values are string, keyword
          'default'."

--- a/lib/puppet/type/cisco_interface_channel_group.rb
+++ b/lib/puppet/type/cisco_interface_channel_group.rb
@@ -1,0 +1,87 @@
+# Manages a Cisco Network Interface Channel Group.
+#
+# January 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_interface_channel_group) do
+  @doc = "Manages a Cisco Network Interface Channel Group.
+
+  Any resource dependency should be run before the interface resource.
+
+  cisco_interface {'<interface>':
+    ..attributes..
+  }
+
+  <interface> is the complete name of the interface.
+
+  Example:
+  cisco_interface_channel_group {'Ethernet1/15':
+    channel_group   => 201,
+    description     => 'my channel group',
+    shutdown        => true,
+  }
+  "
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  def self.title_patterns
+    identity = ->(x) { x }
+    [
+      [
+        /^(\S+)/,
+        [
+          [:interface, identity]
+        ],
+      ]
+    ]
+  end
+
+  newparam(:interface, namevar: :true) do
+    desc 'Name of the interface on the network element. Valid values are string.'
+    munge(&:downcase)
+  end
+
+  ##############
+  # Attributes #
+  ##############
+
+  ensurable
+
+  newproperty(:channel_group) do
+    desc "channel_group is an aggregation of multiple physical interfaces
+          that creates a logical interface. Valid values are 1 to 4096."
+
+    munge { |value| value == 'default' ? :default : value.to_i }
+  end # property channel_group
+
+  newproperty(:description) do
+    desc "Description of the interface. Valid values are string, keyword
+         'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property description
+
+  newproperty(:shutdown) do
+    desc 'Shutdown state of the interface.'
+
+    newvalues(:true, :false, :default)
+  end # property shutdown
+end # Puppet::Type.newtype

--- a/tests/beaker_tests/cisco_interface/routedintf_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_interface/routedintf_provider_negatives.rb
@@ -638,36 +638,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_interface resource absence on agent :: #{result}")
   end
 
-  # TBD: CHANNEL-GROUP NEGATIVE TEST DOES NOT RETURN EXIT CODE [1]
-  #
-  # # @step [Step] Requests manifest from the master server to the agent.
-  # step 'TestStep :: Get negative test resource manifest from master' do
-  #   # Expected exit_code is 0 since this is a bash shell cmd.
-  #   on(master, RoutedIntfLib.create_channel_group_manifest_negative)
-
-  #   # Expected exit_code is 1 since this is a puppet agent cmd with error.
-  #   cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-  #     'agent -t', options)
-  #   on(agent, cmd_str, acceptable_exit_codes: [1])
-
-  #   logger.info("Get negative test resource manifest from master :: #{result}")
-  # end
-
-  # # @step [Step] Checks cisco_interface resource on agent using resource cmd.
-  # step 'TestStep :: Check cisco_interface resource absence on agent' do
-  #   # Expected exit_code is 0 since this is a puppet resource cmd.
-  #   # Flag is set to true to check for absence of RegExp pattern in stdout.
-  #   cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-  #     "resource cisco_interface '#{test_intf}'", options)
-  #   on(agent, cmd_str) do
-  #     search_pattern_in_output(stdout,
-  #                              { 'channel_group' => RoutedIntfLib::CHANNEL_GROUP_NEGATIVE },
-  #                              true, self, logger)
-  #   end
-  #
-  #   logger.info("Check cisco_interface resource absence on agent :: #{result}")
-  # end
-
   # @step [Step] Checks interface instance on agent using switch show cli cmds.
   step 'TestStep :: Check interface instance absence on agent' do
     # Expected exit_code is 0 since this is a vegas shell cmd.

--- a/tests/beaker_tests/cisco_interface/routedintf_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_interface/routedintf_provider_nondefaults.rb
@@ -334,35 +334,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check interface instance absence on agent :: #{result}")
   end
 
-  # @step [Step] Requests manifest from the master server to the agent.
-  step 'TestStep :: Get resource present manifest from master' do
-    # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master,
-       RoutedIntfLib.create_routedintf_manifest_channel_group)
-
-    # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
-    on(agent, cmd_str, acceptable_exit_codes: [2])
-
-    logger.info("Get resource present manifest from master :: #{result}")
-  end
-
-  # @step [Step] Checks cisco_interface resource on agent using resource cmd.
-  step 'TestStep :: Check cisco_interface resource presence on agent' do
-    # Expected exit_code is 0 since this is a puppet resource cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{test_intf}'", options)
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'ensure'        => 'present',
-                                 'channel_group' => '200' },
-                               false, self, logger)
-    end
-    logger.info("Check cisco_interface resource presence on agent :: #{result}")
-  end
-
   # Remove any stale config from test interface
   interface_cleanup(agent, test_intf)
 

--- a/tests/beaker_tests/cisco_interface/routedintflib.rb
+++ b/tests/beaker_tests/cisco_interface/routedintflib.rb
@@ -81,18 +81,6 @@ EOF"
     manifest_str
   end
 
-  def self.create_routedintf_manifest_channel_group
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-node default {
-    cisco_interface { 'ethernet1/4':
-      ensure                       => present,
-      switchport_mode              => disabled,
-      channel_group                => 200,
-  }}
-EOF"
-    manifest_str
-  end
-
   # Method to create a manifest for RoutedINTF resource attribute 'ensure' where
   # 'ensure' is set to present and 'switchport_mode' is set to access.
   # @param none [None] No input parameters exist.
@@ -419,21 +407,6 @@ node default {
       shutdown                     => false,
       switchport_mode              => disabled,
       vrf                          => #{RoutedIntfLib::VRF_NEGATIVE},
-    }
-}
-EOF"
-    manifest_str
-  end
-
-  # Method to create a manifest for RoutedINTF resource attribute 'channel-group'.
-  # @param none [None] No input parameters exist.
-  # @result none [None] Returns no object.
-  def self.create_channel_group_manifest_negative
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-node default {
-    cisco_interface { 'ethernet1/4':
-      ensure                       => present,
-      channel_group                => #{RoutedIntfLib::CHANNEL_GROUP_NEGATIVE},
     }
 }
 EOF"

--- a/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
+++ b/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
@@ -19,17 +19,13 @@
 #
 # TestCase Prerequisites:
 # -----------------------
-# This is a Puppet VRF resource testcase for Puppet Agent on
+# This is a Puppet cisco_interface_channel_group testcase for Puppet Agent on
 # Nexus devices.
 # The test case assumes the following prerequisites are already satisfied:
 #   - Host configuration file contains agent and master information.
 #   - SSH is enabled on the N9K Agent.
 #   - Puppet master/server is started.
 #   - Puppet agent certificate has been signed on the Puppet master/server.
-#
-# TestCase:
-# ---------
-# This VRF resource test verifies default values for all properties.
 #
 # The following exit_codes are validated for Puppet, Vegas shell and
 # Bash shell commands.
@@ -155,9 +151,6 @@ def test_harness_interface_channel_group(tests, id)
   return unless platform_supports_test(tests, id)
 
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
-
-  # Workaround for (ioctl) facter bug on n7k ***
-  tests[id][:code] = [0, 2] if platform[/n7k/]
 
   # Build the manifest for this test
   build_manifest_interface_channel_group(tests, id)

--- a/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
+++ b/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
@@ -1,0 +1,187 @@
+###############################################################################
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# test_interface_channel_group.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet VRF resource testcase for Puppet Agent on
+# Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+#   - Host configuration file contains agent and master information.
+#   - SSH is enabled on the N9K Agent.
+#   - Puppet master/server is started.
+#   - Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This VRF resource test verifies default values for all properties.
+#
+# The following exit_codes are validated for Puppet, Vegas shell and
+# Bash shell commands.
+#
+# Vegas and Bash Shell Commands:
+# 0   - successful command execution
+# > 0 - failed command execution.
+#
+# Puppet Commands:
+# 0 - no changes have occurred
+# 1 - errors have occurred,
+# 2 - changes have occurred
+# 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The test cases use RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+# -----------------------------
+# Common settings and variables
+# -----------------------------
+testheader = 'Resource cisco_interface_channel_group'
+
+# The 'tests' hash is used to define all of the test data values and expected
+# results. It is also used to pass optional flags to the test methods when
+# necessary.
+
+# 'tests' hash
+# Top-level keys set by caller:
+# tests[:master] - the master object
+# tests[:agent] - the agent object
+# tests[:platform] - a regexp pattern to match against supported platforms.
+#                    This key can be overridden by a tests[id][:platform] key
+#
+tests = {
+  master: master,
+  agent:  agent,
+}
+
+# tests[id] keys set by caller and used by test_harness_common:
+#
+# tests[id] keys set by caller:
+# tests[id][:platform] - a regexp pattern to match against supported platforms.
+#                        This key overrides a tests[:platform] key
+# tests[id][:desc] - a string to use with logs & debugs
+# tests[id][:manifest] - the complete manifest, as used by test_harness_common
+# tests[id][:resource] - a hash of expected states, used by test_resource
+# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+# tests[id][:ensure] - (Optional) set to :present or :absent before calling
+# tests[id][:code] - (Optional) override the default exit code in some tests.
+#
+# These keys are local use only and not used by test_harness_common:
+#
+# tests[id][:manifest_props] - This is essentially a master list of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the list
+# tests[id][:resource_props] - This is essentially a master hash of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the hash
+# tests[id][:title_pattern] - (Optional) defines the manifest title.
+#
+intf = 'ethernet1/1'
+tests['default_properties'] = {
+  desc:           '1.1 Default Properties',
+  title_pattern:  intf,
+  code:           [0, 2],
+  manifest_props: {
+    channel_group: 'default',
+    description:   'default',
+    shutdown:      'default',
+  },
+  resource:       {
+    'channel_group' => 'false',
+    'shutdown'      => 'true',
+  },
+}
+
+tests['non_default_properties'] = {
+  desc:           '2.1 Non Default Properties commands',
+  title_pattern:  intf,
+  manifest_props: {
+    channel_group: 201,
+    description:   'chan group desc',
+    shutdown:      'false',
+  },
+  resource:       {
+    'channel_group' => '201',
+    'description'   => 'chan group desc',
+    'shutdown'      => 'false',
+  },
+}
+
+# Create actual manifest for a given test scenario.
+def build_manifest_interface_channel_group(tests, id)
+  manifest = prop_hash_to_manifest(tests[id][:manifest_props])
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+    tests[id][:resource] = { 'ensure' => 'absent' }
+  else
+    state = 'ensure => present,'
+  end
+
+  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  \nnode default {
+  cisco_interface_channel_group { '#{tests[id][:title_pattern]}':
+    #{state}\n#{manifest}
+  }\n}\nEOF"
+
+  cmd = PUPPET_BINPATH +
+        "resource cisco_interface_channel_group '#{tests[id][:title_pattern]}'"
+  tests[id][:resource_cmd] = get_namespace_cmd(agent, cmd, options)
+end
+
+# Wrapper for interface_channel_group specific settings prior to calling the
+# common test_harness.
+def test_harness_interface_channel_group(tests, id)
+  return unless platform_supports_test(tests, id)
+
+  tests[id][:ensure] = :present if tests[id][:ensure].nil?
+
+  # Workaround for (ioctl) facter bug on n7k ***
+  tests[id][:code] = [0, 2] if platform[/n7k/]
+
+  # Build the manifest for this test
+  build_manifest_interface_channel_group(tests, id)
+
+  test_harness_common(tests, id)
+  tests[id][:ensure] = nil
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{testheader}" do
+  interface_cleanup(agent, intf)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+  id = 'default_properties'
+  test_harness_interface_channel_group(tests, id)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
+  test_harness_interface_channel_group(tests, 'non_default_properties')
+
+  # -------------------------------------------------------------------
+  interface_cleanup(agent, intf)
+end
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -330,12 +330,14 @@ end
 
 # Helper to nuke a single interface. This is needed to remove all
 # configurations from the interface.
-def interface_cleanup(agent, intf, stepinfo='Pre Clean:')
-  logger.debug("#{stepinfo} Interface cleanup #{intf}")
-
-  # exit codes: 0 = no changes, 2 = changes have occurred
-  clean = "conf t ; default interface #{intf}"
-  on(agent, get_vshell_cmd(clean), acceptable_exit_codes: [0, 2])
+def interface_cleanup(agent, intf, stepinfo='Interface Pre Clean:')
+  step "TestStep :: #{stepinfo}" do
+    cmd = "resource cisco_command_config 'interface_cleanup' "\
+          "command='default interface #{intf}'"
+    cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+    logger.info("  * #{stepinfo} Set '#{intf}' to default state")
+    on(agent, cmd, acceptable_exit_codes: [0, 2])
+  end
 end
 
 # Helper to remove all IP address configs from all interfaces. This is


### PR DESCRIPTION
- moved channel_group property out of interface provider, into new interface_channel_group provider
- channel-group causes problems in nxos when it is present on an interface; e.g. you cannot change switchport modes, etc
- moving it into its own provider allows the manifest to explicitly remove it while allowing new (non-channel-group) properties to be added to the interface