### PR TITLE
Puppet & Beaker implementation for Cisco pim, pim_grouplist & pim_rp_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,54 @@ Specifies the reference bandwidth used to assign OSPF cost.
 Valid values are an integer, in Mbps, or the keyword 'default'.
 
 --
+### Type: cisco_pim
+Manages configuration of an Protocol Independent Multicast (PIM) instance.
+
+#### Parameters
+
+##### `afi`
+Address Family Identifier (AFI). Required. Valid values are ipv4 and ipv6.
+
+##### `vrf`
+Name of the resource instance. Required. Valid values are string. The name 'default' is a valid VRF representing the global vrf.
+
+##### `ssm_range`
+Configure group ranges for Source Specific Multicast (SSM). Valid values are multicast addresses or the keyword ‘none’.
+
+--
+### Type: cisco_pim_grouplist
+Manages configuration of an Protocol Independent Multicast (PIM) static route processor (RP) address for a multicast group range.
+
+#### Parameters
+
+##### `afi`
+Address Family Identifier (AFI). Required. Valid values are ipv4 and ipv6.
+
+##### `vrf`
+Name of the resource instance. Required. Valid values are string. The name 'default' is a valid VRF representing the global vrf.
+
+##### `rp_addr`
+IP address of a router which is the route processor (RP) for a group range.. Required. Valid values are unicast addresses.
+
+##### `group`
+Specifies a group range for a static route processor (RP) address. Required. Valid values are multicast addresses.
+
+--
+### Type: cisco_pim_rp_address
+Manages configuration of an Protocol Independent Multicast (PIM) static route processor (RP) address instance.
+
+#### Parameters
+
+##### `afi`
+Address Family Identifier (AFI). Required. Valid values are ipv4 and ipv6.
+
+##### `vrf`
+Name of the resource instance. Required. Valid values are string. The name 'default' is a valid VRF representing the global vrf.
+
+##### `rp_addr`
+Configures a Protocol Independent Multicast (PIM) static route processor (RP) address. Required. Valid values are unicast addresses.
+
+--
 ### Type: cisco_portchannel_global
 Manages configuration of a portchannel global parameters
 

--- a/README.md
+++ b/README.md
@@ -1266,7 +1266,7 @@ Manages configuration of an Protocol Independent Multicast (PIM) instance.
 #### Parameters
 
 ##### `afi`
-Address Family Identifier (AFI). Required. Valid values are ipv4 and ipv6.
+Address Family Identifier (AFI). Required. Valid value is ipv4.
 
 ##### `vrf`
 Name of the resource instance. Required. Valid values are string. The name 'default' is a valid VRF representing the global vrf.

--- a/examples/demo_all.pp
+++ b/examples/demo_all.pp
@@ -36,6 +36,7 @@ class ciscopuppet::demo_all {
   include ciscopuppet::demo_ntp
   include ciscopuppet::demo_ospf
   include ciscopuppet::demo_patching
+  include ciscopuppet::demo_pim
   include ciscopuppet::demo_portchannel
   include ciscopuppet::demo_radius
   include ciscopuppet::demo_snmp

--- a/examples/demo_pim.pp
+++ b/examples/demo_pim.pp
@@ -1,0 +1,38 @@
+# Manifest to demo radius providers
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_pim {
+
+    cisco_pim { 'ipv4' :
+      ensure         => present,
+      vrf            => 'default',
+      ssm_range      => '224.0.0.0/8 225.0.0.0/8'
+    }
+
+    cisco_pim_rp_address { 'ipv4' :
+      ensure          => present,
+      vrf             => 'default',
+      rp_addr         => '1.1.1.1'
+    }
+
+    cisco_pim_grouplist { 'ipv4' :
+      ensure          => present,
+      vrf             => 'default',
+      rp_addr         => '11.11.11.11',
+      group           => '224.0.0.0/8',
+    }
+
+}

--- a/examples/demo_pim.pp
+++ b/examples/demo_pim.pp
@@ -1,6 +1,6 @@
 # Manifest to demo radius providers
 #
-# Copyright (c) 2015 Cisco and/or its affiliates.
+# Copyright (c) 2016 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/cisco_pim/nxapi.rb
+++ b/lib/puppet/provider/cisco_pim/nxapi.rb
@@ -1,0 +1,120 @@
+#
+# The NXAPI provider for cisco_pim.
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_pim).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_pim.'
+
+  confine feature: :cisco_node_utils
+
+  mk_resource_methods
+
+  PIM_ALL_PROPS = [
+    :ssm_range
+  ]
+
+  # Dynamic method generation for getters & setters
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@pim',
+                                            PIM_ALL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    afi = @property_hash[:afi]
+    vrf = @property_hash[:vrf]
+    @pim = Cisco::Pim.pims[afi][vrf] unless afi.nil? && vrf.nil?
+    @property_flush = {}
+  end
+
+  def self.properties_get(afi, vrf, inst)
+    current_state = {
+      name:   "#{afi} #{vrf}",
+      afi:    afi,
+      vrf:    vrf,
+      ensure: :present,
+    }
+    # Call node_utils getter for each property
+    PIM_ALL_PROPS.each do |prop|
+      current_state[prop] = inst.send(prop)
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    pim_instances = []
+    Cisco::Pim.pims.each do |afi, vrfs|
+      vrfs.each do |vrf, pim_inst|
+        pim_instances << properties_get(afi, vrf, pim_inst)
+      end
+    end
+    pim_instances
+  end # self.instances
+
+  def self.prefetch(resources)
+    pim_instances = instances
+    resources.keys.each do |name|
+      provider = pim_instances.find do |pim|
+        pim.afi.to_s == resources[name][:afi].to_s &&
+        pim.vrf == resources[name][:vrf]
+      end
+      resources[name].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def properties_set(new_pim_instance=false)
+    PIM_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_pim_instance
+      next if @property_flush[prop].nil?
+      @pim.send("#{prop}=", @property_flush[prop]) if
+        @pim.respond_to?("#{prop}=")
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @pim.destroy
+      @pim = nil
+    else
+      if @pim.nil?
+        # create new
+        new_pim_instance = true
+        @pim = Cisco::Pim.new(@resource[:afi], @resource[:vrf])
+      end
+      properties_set(new_pim_instance)
+    end
+  end
+end

--- a/lib/puppet/provider/cisco_pim/nxapi.rb
+++ b/lib/puppet/provider/cisco_pim/nxapi.rb
@@ -31,13 +31,20 @@ Puppet::Type.type(:cisco_pim).provide(:nxapi) do
 
   mk_resource_methods
 
-  PIM_ALL_PROPS = [
+  PIM_NON_BOOL_PROPS = [
     :ssm_range
   ]
 
+  PIM_BOOL_PROPS = [
+  ]
+
+  PIM_ALL_PROPS = PIM_NON_BOOL_PROPS + PIM_BOOL_PROPS
+
   # Dynamic method generation for getters & setters
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@pim',
-                                            PIM_ALL_PROPS)
+                                            PIM_NON_BOOL_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@pim',
+                                            PIM_BOOL_PROPS)
 
   def initialize(value={})
     super(value)

--- a/lib/puppet/provider/cisco_pim_grouplist/nxapi.rb
+++ b/lib/puppet/provider/cisco_pim_grouplist/nxapi.rb
@@ -1,0 +1,131 @@
+#
+# The NXAPI provider for cisco_pim_grouplist.
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_pim_grouplist).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_pim_grouplist.'
+
+  confine feature: :cisco_node_utils
+
+  mk_resource_methods
+
+  PIM_GROUPLIST_ALL_PROPS = [
+  ]
+
+  # Dynamic method generation for getters & setters
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@pim_grouplists',
+                                            PIM_GROUPLIST_ALL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    afi = @property_hash[:afi]
+    vrf = @property_hash[:vrf]
+    rp_addr = @property_hash[:rp_addr]
+    group = @property_hash[:group]
+    rp_addr_and_group = [rp_addr, group]
+    @pim_grouplists = Cisco::PimGroupList.group_lists[afi][vrf][rp_addr_and_group] unless afi.nil? && vrf.nil? &&
+                                                                                          rp_addr.nil? && group.nil?
+    @property_flush = {}
+  end
+
+  def self.properties_get(afi, vrf, rp_addr, group, inst) # ? Need inst if I have no prop?
+    current_state = {
+      name:    "#{afi} #{vrf} #{rp_addr} #{group}",
+      afi:     afi,
+      vrf:     vrf,
+      rp_addr: rp_addr,
+      group:   group,
+      ensure:  :present,
+    }
+    # Call node_utils getter for each property
+    PIM_GROUPLIST_ALL_PROPS.each do |prop|
+      current_state[prop] = inst.send(prop)
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    pim_group_instances = []
+    Cisco::PimGroupList.group_lists.each do |afi, vrfs|
+      vrfs.each do |vrf, rp_addr_and_groups|
+        rp_addr_and_groups.each do |rp_addr_and_group, pim_group_inst|
+          rp_addr, group = rp_addr_and_group
+          pim_group_instances << properties_get(afi, vrf, rp_addr, group, pim_group_inst)
+        end
+      end
+    end
+    pim_group_instances
+  end # self.instances
+
+  def self.prefetch(resources)
+    pim_group_instances = instances
+    resources.keys.each do |name|
+      provider = pim_group_instances.find do |pim_group|
+        pim_group.afi.to_s == resources[name][:afi].to_s &&
+        pim_group.vrf == resources[name][:vrf] &&
+        pim_group.rp_addr == resources[name][:rp_addr] &&
+        pim_group.group == resources[name][:group]
+      end
+      resources[name].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def properties_set(new_pim_grouplist_instance=false)
+    PIM_GROUPLIST_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_pim_grouplist_instance
+      next if @property_flush[prop].nil?
+      @pim_grouplists.send("#{prop}=", @property_flush[prop]) if
+        @pim_grouplists.respond_to?("#{prop}=")
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @pim_grouplists.destroy
+      @pim_grouplists = nil
+    else
+      if @pim_grouplists.nil?
+        # create new
+        new_pim_grouplist_instance = true
+        @pim_grouplists = Cisco::PimGroupList.new(@resource[:afi], @resource[:vrf],
+                                                  @resource[:rp_addr], @resource[:group])
+      end
+      properties_set(new_pim_grouplist_instance)
+    end
+  end
+end

--- a/lib/puppet/provider/cisco_pim_grouplist/nxapi.rb
+++ b/lib/puppet/provider/cisco_pim_grouplist/nxapi.rb
@@ -45,8 +45,8 @@ Puppet::Type.type(:cisco_pim_grouplist).provide(:nxapi) do
     rp_addr = @property_hash[:rp_addr]
     group = @property_hash[:group]
     rp_addr_and_group = [rp_addr, group]
-    @pim_grouplists = Cisco::PimGroupList.group_lists[afi][vrf][rp_addr_and_group] unless afi.nil? && vrf.nil? &&
-                                                                                          rp_addr.nil? && group.nil?
+    @pim_grouplists = Cisco::PimGroupList.group_lists[afi][vrf][rp_addr_and_group] unless
+                                      afi.nil? && vrf.nil? && rp_addr.nil? && group.nil?
     @property_flush = {}
   end
 

--- a/lib/puppet/provider/cisco_pim_rp_address/nxapi.rb
+++ b/lib/puppet/provider/cisco_pim_rp_address/nxapi.rb
@@ -1,0 +1,124 @@
+#
+# The NXAPI provider for cisco_pim_rp_address.
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_pim_rp_address).provide(:nxapi) do
+  desc 'The NXAPI provider for cisco_pim_rp_address.'
+
+  confine feature: :cisco_node_utils
+
+  mk_resource_methods
+
+  PIM_RP_ADDRESS_ALL_PROPS = [
+  ]
+
+  # Dynamic method generation for getters & setters
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@pim_rps',
+                                            PIM_RP_ADDRESS_ALL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    afi = @property_hash[:afi]
+    vrf = @property_hash[:vrf]
+    rp_addr = @property_hash[:rp_addr]
+    @pim_rps = Cisco::PimRpAddress.rp_addresses[afi][vrf][rp_addr] unless afi.nil? && vrf.nil? && rp_addr.nil?
+    @property_flush = {}
+  end
+
+  def self.properties_get(afi, vrf, rp_addr, inst)
+    current_state = {
+      name:    "#{afi} #{vrf} #{rp_addr}",
+      afi:     afi,
+      vrf:     vrf,
+      rp_addr: rp_addr,
+      ensure:  :present,
+    }
+    # Call node_utils getter for each property
+    PIM_RP_ADDRESS_ALL_PROPS.each do |prop|
+      current_state[prop] = inst.send(prop)
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    pim_rp_address_instances = []
+    Cisco::PimRpAddress.rp_addresses.each do |afi, vrfs|
+      vrfs.each do |vrf, rp_addrs|
+        rp_addrs.each do |rp_addr, pim_rp_address_inst|
+          pim_rp_address_instances << properties_get(afi, vrf, rp_addr, pim_rp_address_inst)
+        end
+      end
+    end
+    pim_rp_address_instances
+  end # self.instances
+
+  def self.prefetch(resources)
+    pim_rp_address_instances = instances
+    resources.keys.each do |name|
+      provider = pim_rp_address_instances.find do |pim_rp_addr|
+        pim_rp_addr.afi.to_s == resources[name][:afi].to_s &&
+        pim_rp_addr.vrf == resources[name][:vrf] &&
+        pim_rp_addr.rp_addr == resources[name][:rp_addr]
+      end
+      resources[name].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def properties_set(new_pim_rp_addr_instance=false)
+    PIM_RP_ADDRESS_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_pim_rp_addr_instance
+      next if @property_flush[prop].nil?
+      @pim_rps.send("#{prop}=", @property_flush[prop]) if
+        @pim_rps.respond_to?("#{prop}=")
+    end
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @pim_rps.destroy
+      @pim_rps = nil
+    else
+      if @pim_rps.nil?
+        # create new
+        new_pim_rp_addr_instance = true
+        @pim_rps = Cisco::PimRpAddress.new(@resource[:afi], @resource[:vrf], @resource[:rp_addr])
+      end
+      properties_set(new_pim_rp_addr_instance)
+    end
+  end
+end

--- a/lib/puppet/type/cisco_pim.rb
+++ b/lib/puppet/type/cisco_pim.rb
@@ -119,7 +119,7 @@ Puppet::Type.newtype(:cisco_pim) do
 
   newparam(:afi, namevar: true) do
     desc 'The Address-Family Indentifier (ipv4|ipv6).'
-    newvalues(:ipv4, :ipv6)
+    newvalues(:ipv4)
   end
 
   newparam(:vrf, namevar: true) do

--- a/lib/puppet/type/cisco_pim.rb
+++ b/lib/puppet/type/cisco_pim.rb
@@ -1,0 +1,154 @@
+#
+# Puppet resource type for pim
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
+
+Puppet::Type.newtype(:cisco_pim) do
+  # ---------------------------------------------------------------
+  # @doc entry to describe the resource and usage
+  # ---------------------------------------------------------------
+  @doc = "Manages configuration of a pim instance
+
+  ~~~puppet
+  cisco_pim {'<string>':
+    ..attributes..
+  }
+  ~~~
+
+  `<string>` is the name of the vrf.
+
+  Example:
+
+  ~~~puppet
+    cisco_pim { 'ipv4 red' :
+      ensure          => present,
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+    }
+  ~~~
+
+  Example Title Patterns
+
+  ~~~puppet
+    cisco_pim { 'newyork' :
+      ensure          => present,
+      afi             => 'ipv4',
+      vrf             => 'default',
+      ssm_range       => default
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim { 'ipv4' :
+      ensure          => present,
+      vrf             => 'default',
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim { 'ipv4 blue' :
+      ensure          => present,
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+    }
+  ~~~
+  "
+
+  ensurable
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse the title to populate the attributes in these patterns.
+  # These attributes may be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    [
+      [
+        /^(ipv4)$/, # TBD ipv6
+        [
+          [:afi, identity]
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+        ],
+      ],
+      [
+        /^(\S+)$/,
+        [
+          [:name, identity]
+        ],
+      ],
+    ]
+  end
+
+  # Overwrites the name method which by default returns only
+  # self[:name].
+  def name
+    "#{self[:afi]} #{self[:vrf]}"
+  end
+
+  # Only needed to satisfy name parameter.
+  newparam(:name) do
+  end
+
+  newparam(:afi, namevar: true) do
+    desc 'The Address-Family Indentifier (ipv4|ipv6).'
+    newvalues(:ipv4, :ipv6)
+  end
+
+  newparam(:vrf, namevar: true) do
+    desc 'BGP vrf name. Valid values are string. ' \
+      "The name 'default' is a valid VRF."
+
+    defaultto('default')
+    newvalues(/^\S+$/)
+  end
+
+  # ---------------------------------------------------------------
+  # Definition of properties.
+  # ---------------------------------------------------------------
+
+  newproperty(:ssm_range) do
+    desc "Sets the ssm range for Pim. Valid
+          values are space-separated String
+          of multicast addresses or the keyword 'none'."
+
+    match_error = 'must be specified an IP Addr format or string "none"'
+    validate do |range|
+      list = range.split(' ')
+      list.each do |value|
+        fail "SSM Range '#{value}' #{match_error}" unless
+               value == 'none' || IPAddr.new(value)
+      end
+    end
+    munge do |range|
+      range
+    end
+  end
+end

--- a/lib/puppet/type/cisco_pim_grouplist.rb
+++ b/lib/puppet/type/cisco_pim_grouplist.rb
@@ -1,0 +1,184 @@
+#
+# Puppet resource type for pim
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
+
+Puppet::Type.newtype(:cisco_pim_grouplist) do
+  # ---------------------------------------------------------------
+  # @doc entry to describe the resource and usage
+  # ---------------------------------------------------------------
+  @doc = "Manages configuration of a pim_grouplist instance
+
+  ~~~puppet
+  cisco_pim_grouplist {'<string>':
+    ..attributes..
+  }
+  ~~~
+
+  `<string>` is the name of the vrf.
+
+  Example:
+
+  ~~~
+  Example Title Patterns
+
+  ~~~puppet
+    cisco_pim_grouplist { 'ipv4' :
+      ensure          => present,
+      vrf             => 'blue',
+      rp_addr         => '1.1.1.1',
+      group           => '224.0.0.0/8',
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_grouplist { 'ipv4 blue' :
+      ensure          => present,
+      rp_address      => '1.1.1.1',
+      group           => '224.0.0.0/8',
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_grouplist { 'ipv4 blue 1.1.1.1' :
+      ensure          => present,
+      group           => '224.0.0.0/8'
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_grouplist { 'ipv4 blue 1.1.1.1 224.0.0.0/8' :
+      ensure          => present,
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_grouplist { 'newyork' :
+      ensure          => present,
+      afi             => 'ipv4'
+      vrf             => 'default',
+      rp_addr         => '1.1.1.1',
+      group           => '224.0.0.0/8'
+    }
+  ~~~
+  "
+  ensurable
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse the title to populate the attributes in these patterns.
+  # These attributes may be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    [
+      [
+        /^(ipv4)$/, # TBD ipv6
+        [
+          [:afi, identity]
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+          [:rp_addr, identity],
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+          [:rp_addr, identity],
+          [:group, identity],
+        ],
+      ],
+      [
+        /^(\S+)$/,
+        [
+          [:name, identity]
+        ],
+      ],
+    ]
+  end
+
+  # Overwrites the name method which by default returns only
+  # self[:name].
+  def name
+    "#{self[:afi]} #{self[:vrf]} #{self[:rp_addr]} #{self[:group]}"
+  end
+
+  # Only needed to satisfy name parameter.
+  newparam(:name) do
+  end
+
+  newparam(:afi, namevar: true) do
+    desc 'The Address-Family Indentifier (ipv4|ipv6).'
+    newvalues(:ipv4, :ipv6)
+  end
+
+  newparam(:vrf, namevar: true) do
+    desc 'Vrf name. Valid values are string. ' \
+      "The name 'default' is a valid VRF."
+
+    defaultto('default')
+    newvalues(/^\S+$/)
+  end
+
+  newparam(:rp_addr, namevar: true) do
+    desc 'The RP Address of a PIM Instance. ' \
+         ' A valid IP address must be used.'
+
+    validate do |ip|
+      begin
+        IPAddr.new(ip) unless ip.empty?
+      rescue
+        raise 'Rp Address is not a valid IP address.'
+      end
+    end
+  end
+
+  newparam(:group, namevar: true) do
+    desc 'The Grouplist of a PIM Instance. ' \
+         ' A valid Grouplist address must be used.'
+
+    validate do |ip|
+      begin
+        IPAddr.new(ip) unless ip.empty?
+      rescue
+        raise 'Grouplist is not a valid IP address.'
+      end
+    end
+  end
+end

--- a/lib/puppet/type/cisco_pim_rp_address.rb
+++ b/lib/puppet/type/cisco_pim_rp_address.rb
@@ -140,7 +140,7 @@ Puppet::Type.newtype(:cisco_pim_rp_address) do
 
     validate do |ip|
       begin
-        IPAddr.new(ip) unless ip.empty?
+        IPAddr.new(ip)
       rescue
         raise 'Rp Address is not a valid IP address.'
       end

--- a/lib/puppet/type/cisco_pim_rp_address.rb
+++ b/lib/puppet/type/cisco_pim_rp_address.rb
@@ -1,0 +1,149 @@
+#
+# Puppet resource type for pim
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
+
+Puppet::Type.newtype(:cisco_pim_rp_address) do
+  # ---------------------------------------------------------------
+  # @doc entry to describe the resource and usage
+  # ---------------------------------------------------------------
+  @doc = "Manages configuration of a pim_rp_address instance
+
+  ~~~puppet
+  cisco_pim_rp_address {'<string>':
+    ..attributes..
+  }
+  ~~~
+
+  `<string>` is the name of the vrf.
+
+  Example:
+
+  ~~~puppet
+    cisco_pim_rp_address { 'ipv4' :
+      ensure              => present,
+      vrf                 => 'default',
+      rp_addr             => '1.1.1.1',
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_rp_address { 'ipv4 blue' :
+      ensure          => present,
+      rp_addr         => '1.1.1.1',
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_rp_address { 'ipv4 blue 1.1.1.1' :
+      ensure          => present,
+    }
+  ~~~
+
+  ~~~puppet
+    cisco_pim_rp_address { 'newyork' :
+      ensure              => present,
+      afi                 => 'ipv4'
+      vrf                 => 'default',
+      rp_addr          => '1.1.1.1',
+    }
+  ~~~
+  "
+  ensurable
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse the title to populate the attributes in these patterns.
+  # These attributes may be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    [
+      [
+        /^(ipv4)$/, # TBD ipv6
+        [
+          [:afi, identity]
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+        ],
+      ],
+      [
+        /^(\S+)\s+(\S+)\s+(\S+)$/,
+        [
+          [:afi, identity],
+          [:vrf, identity],
+          [:rp_addr, identity],
+        ],
+      ],
+      [
+        /^(\S+)$/,
+        [
+          [:name, identity]
+        ],
+      ],
+    ]
+  end
+
+  # Overwrites the name method which by default returns only
+  # self[:name].
+  def name
+    "#{self[:afi]} #{self[:vrf]} #{self[:rp_addr]}"
+  end
+
+  # Only needed to satisfy name parameter.
+  newparam(:name) do
+  end
+
+  newparam(:afi, namevar: true) do
+    desc 'The Address-Family Indentifier (ipv4|ipv6).'
+    newvalues(:ipv4, :ipv6)
+  end
+
+  newparam(:vrf, namevar: true) do
+    desc 'Vrf name. Valid values are string. ' \
+      "The name 'default' is a valid VRF."
+
+    defaultto('default')
+    newvalues(/^\S+$/)
+  end
+
+  newparam(:rp_addr, namevar: true) do
+    desc 'The RP Address of a PIM Instance. ' \
+         ' A valid IP address must be used.'
+
+    validate do |ip|
+      begin
+        IPAddr.new(ip) unless ip.empty?
+      rescue
+        raise 'Rp Address is not a valid IP address.'
+      end
+    end
+  end
+end

--- a/tests/beaker_tests/cisco_pim/test_cisco_pim.rb
+++ b/tests/beaker_tests/cisco_pim/test_cisco_pim.rb
@@ -73,9 +73,8 @@ testheader = 'Resource cisco_pim'
 # tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
-  master:   master,
-  agent:    agent,
-  show_cmd: 'show run pim all',
+  master: master,
+  agent:  agent,
 }
 # tests[id] keys set by caller and used by test_harness_common:
 #
@@ -190,9 +189,7 @@ def test_harness_cisco_pim(tests, id)
   # Build the manifest for this test
   build_manifest_cisco_pim(tests, id)
 
-  test_manifest(tests, id)
-  test_resource(tests, id)
-  test_idempotence(tests, id)
+  test_harness_common(tests, id)
   tests[id][:ensure] = nil
 end
 

--- a/tests/beaker_tests/cisco_pim/test_cisco_pim.rb
+++ b/tests/beaker_tests/cisco_pim/test_cisco_pim.rb
@@ -1,0 +1,238 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# test-pim.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet PIM resource testcase for Puppet Agent on
+# Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+#   - Host configuration file contains agent and master information.
+#   - SSH is enabled on the N9K Agent.
+#   - Puppet master/server is started.
+#   - Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This PIM resource test verifies default values for all properties.
+#
+# The following exit_codes are validated for Puppet, Vegas shell and
+# Bash shell commands.
+#
+# Vegas and Bash Shell Commands:
+# 0   - successful command execution
+# > 0 - failed command execution.
+#
+# Puppet Commands:
+# 0 - no changes have occurred
+# 1 - errors have occurred,
+# 2 - changes have occurred
+# 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The test cases use RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# -----------------------------
+# Common settings and variables
+# -----------------------------
+testheader = 'Resource cisco_pim'
+
+# Define PUPPETMASTER_MANIFESTPATH.
+# UtilityLib.set_manifest_path(master, self)
+
+# The 'tests' hash is used to define all of the test data values and expected
+# results. It is also used to pass optional flags to the test methods when
+# necessary.
+
+# 'tests' hash
+# Top-level keys set by caller:
+# tests[:master] - the master object
+# tests[:agent] - the agent object
+# tests[:show_cmd] - the common show command to use for test_show_run
+#
+tests = {
+  master:   master,
+  agent:    agent,
+  show_cmd: 'show run pim all',
+}
+# tests[id] keys set by caller and used by test_harness_common:
+#
+# tests[id] keys set by caller:
+# tests[id][:desc] - a string to use with logs & debugs
+# tests[id][:manifest] - the complete manifest, as used by test_harness_common
+# tests[id][:resource] - a hash of expected states, used by test_resource
+# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
+# tests[id][:ensure] - (Optional) set to :present or :absent before calling
+# tests[id][:code] - (Optional) override the default exit code in some tests.
+#
+# These keys are local use only and not used by test_harness_common:
+#
+# tests[id][:manifest_props] - This is essentially a master list of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the list
+# tests[id][:resource_props] - This is essentially a master hash of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the hash
+# tests[id][:title_pattern] - (Optional) defines the manifest title.
+#   Can be used with :pim for mixed title/pim testing. If mixing, :pim values will
+#   be merged with title values and override any duplicates. If omitted,
+#   :title_pattern will be set to 'id'.
+#
+tests['title_patterns'] = {
+  manifest_props: "
+    ssm_range   => '224.0.0.0/8 225.0.0.0/8',
+  ",
+  resource_props: {
+    'ensure'    => 'present',
+    'ssm_range' => '224.0.0.0/8 225.0.0.0/8',
+  },
+}
+
+tests['non_default_properties_S1'] = {
+  desc:           ' 1.1 Non default properties',
+  title_pattern:  'ipv4 red',
+  manifest_props: "
+      ssm_range   => '224.0.0.0/8',
+  ",
+  resource_props: {
+    'ensure'    => 'present',
+    'ssm_range' => '224.0.0.0/8',
+  },
+}
+
+tests['non_default_properties_S2'] = {
+  desc:           ' 1.2 Non default properties',
+  title_pattern:  'ipv4 black',
+  manifest_props: "
+      ssm_range   => '230.0.0.0/8',
+  ",
+  resource_props: {
+    'ensure'    => 'present',
+    'ssm_range' => '230.0.0.0/8',
+  },
+}
+
+tests['non_default_properties_S3'] = {
+  desc:           ' 1.3 Non default properties',
+  title_pattern:  'ipv4 default',
+  manifest_props: "
+      ssm_range   => 'none',
+  ",
+  resource_props: {
+    'ensure'    => 'present',
+    'ssm_range' => 'none',
+  },
+}
+#################################################################
+# HELPER FUNCTIONS
+#################################################################
+# Full command string for puppet resource with neighbor AF
+def puppet_resource_cmd(pim)
+  cmd = PUPPET_BINPATH + \
+        "resource cisco_pim '#{pim.values.join(' ')}'"
+  get_namespace_cmd(agent, cmd, options)
+end
+
+def build_manifest_cisco_pim(tests, id)
+  manifest = prop_hash_to_manifest(tests[id][:pim])
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+    tests[id][:resource] = { 'ensure' => 'absent' }
+  else
+    state = 'ensure => present,'
+    manifest += tests[id][:manifest_props]
+    tests[id][:resource] = tests[id][:resource_props]
+  end
+
+  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+  logger.debug("build_manifest_cisco_pim :: title_pattern:\n" +
+               tests[id][:title_pattern])
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node 'default' {
+    cisco_pim { '#{tests[id][:title_pattern]}':
+      #{state}
+      #{manifest}
+    }
+  }
+EOF"
+end
+
+def test_harness_cisco_pim(tests, id)
+  pim = pim_title_pattern_munge(tests, id)
+  logger.info("\n--------\nTest Case Pim ID: #{pim}")
+
+  tests[id][:ensure] = :present if tests[id][:ensure].nil?
+  tests[id][:resource_cmd] = puppet_resource_cmd(pim)
+
+  # Build the manifest for this test
+  build_manifest_cisco_pim(tests, id)
+
+  test_manifest(tests, id)
+  test_resource(tests, id)
+  test_idempotence(tests, id)
+  tests[id][:ensure] = nil
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{testheader}" do
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
+  node_feature_cleanup(agent, 'pim')
+  id = 'non_default_properties_S1'
+  test_harness_cisco_pim(tests, id)
+
+  # -----------------------------------
+  id = 'non_default_properties_S2'
+  test_harness_cisco_pim(tests, id)
+
+  # -----------------------------------
+  id = 'non_default_properties_S3'
+  test_harness_cisco_pim(tests, id)
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Title Pattern Testing")
+  node_feature_cleanup(agent, 'pim')
+  id = 'title_patterns'
+
+  tests[id][:desc] = '2.1 Title Patterns'
+  tests[id][:title_pattern] = 'newyork'
+  tests[id][:pim] = { afi: 'ipv4', vrf: 'green' }
+  test_harness_cisco_pim(tests, id)
+  # -----------------------------------
+  tests[id][:desc] = '2.2 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4'
+  tests[id][:pim] = { vrf: 'yellow' }
+  test_harness_cisco_pim(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '2.3 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4 black'
+  tests[id][:pim] = {}
+  test_harness_cisco_pim(tests, id)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/cisco_pim_grouplist/test_cisco_grouplist.rb
+++ b/tests/beaker_tests/cisco_pim_grouplist/test_cisco_grouplist.rb
@@ -1,0 +1,194 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# test-pimrpaddress.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet PIM rp address resource testcase for Puppet Agent on
+# Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+#   - Host configuration file contains agent and master information.
+#   - SSH is enabled on the N9K Agent.
+#   - Puppet master/server is started.
+#   - Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This PIM rp address resource test verifies default values for all properties.
+#
+# The following exit_codes are validated for Puppet, Vegas shell and
+# Bash shell commands.
+#
+# Vegas and Bash Shell Commands:
+# 0   - successful command execution
+# > 0 - failed command execution.
+#
+# Puppet Commands:
+# 0 - no changes have occurred
+# 1 - errors have occurred,
+# 2 - changes have occurred
+# 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The test cases use RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# -----------------------------
+# Common settings and variables
+# -----------------------------
+testheader = 'Resource cisco_pim_grouplist'
+
+# Define PUPPETMASTER_MANIFESTPATH.
+# UtilityLib.set_manifest_path(master, self)
+
+# The 'tests' hash is used to define all of the test data values and expected
+# results. It is also used to pass optional flags to the test methods when
+# necessary.
+
+# 'tests' hash
+# Top-level keys set by caller:
+# tests[:master] - the master object
+# tests[:agent] - the agent object
+# tests[:show_cmd] - the common show command to use for test_show_run
+#
+tests = {
+  master:   master,
+  agent:    agent,
+  show_cmd: 'show run pim all',
+}
+# tests[id] keys set by caller and used by test_harness_common:
+#
+# tests[id] keys set by caller:
+# tests[id][:desc] - a string to use with logs & debugs
+# tests[id][:manifest] - the complete manifest, as used by test_harness_common
+# tests[id][:resource] - a hash of expected states, used by test_resource
+# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
+# tests[id][:ensure] - (Optional) set to :present or :absent before calling
+# tests[id][:code] - (Optional) override the default exit code in some tests.
+#
+# These keys are local use only and not used by test_harness_common:
+#
+# tests[id][:manifest_props] - This is essentially a master list of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the list
+# tests[id][:resource_props] - This is essentially a master hash of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the hash
+# tests[id][:title_pattern] - (Optional) defines the manifest title.
+#   Can be used with :pim for mixed title/pim testing. If mixing, :pim values will
+#   be merged with title values and override any duplicates. If omitted,
+#   :title_pattern will be set to 'id'.
+#
+tests['title_patterns'] = {
+  manifest_props: '',
+  resource_props: { 'ensure' => 'present' },
+}
+#################################################################
+# HELPER FUNCTIONS
+#################################################################
+# Full command string for puppet resource with neighbor AF
+def puppet_resource_cmd(pim_group)
+  cmd = PUPPET_BINPATH + \
+        "resource cisco_pim_grouplist '#{pim_group.values.join(' ')}'"
+  get_namespace_cmd(agent, cmd, options)
+end
+
+def build_manifest_cisco_pim_grouplist(tests, id)
+  manifest = prop_hash_to_manifest(tests[id][:pim_group])
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+    tests[id][:resource] = { 'ensure' => 'absent' }
+  else
+    state = 'ensure => present,'
+    tests[id][:resource] = tests[id][:resource_props]
+  end
+
+  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+  logger.debug("build_manifest_cisco_pim_grouplist :: title_pattern:\n" +
+               tests[id][:title_pattern])
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node 'default' {
+    cisco_pim_grouplist { '#{tests[id][:title_pattern]}':
+      #{state}
+      #{manifest}
+    }
+  }
+EOF"
+end
+
+def test_harness_cisco_pim_grouplist(tests, id)
+  pim_group = pim_group_title_pattern_munge(tests, id)
+  logger.info("\n--------\nTest Case Pim ID: #{pim_group}")
+
+  tests[id][:ensure] = :present if tests[id][:ensure].nil?
+  tests[id][:resource_cmd] = puppet_resource_cmd(pim_group)
+
+  # Build the manifest for this test
+  build_manifest_cisco_pim_grouplist(tests, id)
+
+  test_manifest(tests, id)
+  test_resource(tests, id)
+  test_idempotence(tests, id)
+  tests[id][:ensure] = nil
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{testheader}" do
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Title Pattern Testing")
+  resource_absent_cleanup(agent, 'cisco_pim_grouplist',
+                          'Setup switch for cisco_pim_grouplist provider test')
+  # -----------------------------------
+  id = 'title_patterns'
+  tests[id][:desc] = '3.1 Title Patterns'
+  tests[id][:title_pattern] = 'newyork'
+  tests[id][:pim_group] = { afi: 'ipv4', vrf: 'red',
+          rp_addr: '22.22.22.22', group: '224.0.0.0/8' }
+  test_harness_cisco_pim_grouplist(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '3.2 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4'
+  tests[id][:pim_group] = { vrf: 'red', rp_addr: '33.33.33.33',
+                            group: '225.0.0.0/8' }
+  test_harness_cisco_pim_grouplist(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '3.3 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4 red'
+  tests[id][:pim_group] = { rp_addr: '44.44.44.44',
+                            group:   '226.0.0.0/8' }
+  test_harness_cisco_pim_grouplist(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '3.4 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4 default 55.55.55.55 227.0.0.0/8'
+  tests[id][:pim_group] = {}
+  test_harness_cisco_pim_grouplist(tests, id)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/cisco_pim_grouplist/test_cisco_grouplist.rb
+++ b/tests/beaker_tests/cisco_pim_grouplist/test_cisco_grouplist.rb
@@ -147,10 +147,7 @@ def test_harness_cisco_pim_grouplist(tests, id)
 
   # Build the manifest for this test
   build_manifest_cisco_pim_grouplist(tests, id)
-
-  test_manifest(tests, id)
-  test_resource(tests, id)
-  test_idempotence(tests, id)
+  test_harness_common(tests, id)
   tests[id][:ensure] = nil
 end
 

--- a/tests/beaker_tests/cisco_pim_rp_address/test_cisco_pim_rp_address.rb
+++ b/tests/beaker_tests/cisco_pim_rp_address/test_cisco_pim_rp_address.rb
@@ -149,9 +149,7 @@ def test_harness_cisco_pim_rp_address(tests, id)
   # Build the manifest for this test
   build_manifest_cisco_pim_rp_address(tests, id)
 
-  test_manifest(tests, id)
-  test_resource(tests, id)
-  test_idempotence(tests, id)
+  test_harness_common(tests, id)
   tests[id][:ensure] = nil
 end
 

--- a/tests/beaker_tests/cisco_pim_rp_address/test_cisco_pim_rp_address.rb
+++ b/tests/beaker_tests/cisco_pim_rp_address/test_cisco_pim_rp_address.rb
@@ -1,0 +1,193 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# test-pimrpaddress.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet PIM rp address resource testcase for Puppet Agent on
+# Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+#   - Host configuration file contains agent and master information.
+#   - SSH is enabled on the N9K Agent.
+#   - Puppet master/server is started.
+#   - Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This PIM rp address resource test verifies default values for all properties.
+#
+# The following exit_codes are validated for Puppet, Vegas shell and
+# Bash shell commands.
+#
+# Vegas and Bash Shell Commands:
+# 0   - successful command execution
+# > 0 - failed command execution.
+#
+# Puppet Commands:
+# 0 - no changes have occurred
+# 1 - errors have occurred,
+# 2 - changes have occurred
+# 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The test cases use RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# -----------------------------
+# Common settings and variables
+# -----------------------------
+testheader = 'Resource cisco_pim_rp_address'
+
+# Define PUPPETMASTER_MANIFESTPATH.
+# UtilityLib.set_manifest_path(master, self)
+
+# The 'tests' hash is used to define all of the test data values and expected
+# results. It is also used to pass optional flags to the test methods when
+# necessary.
+
+# 'tests' hash
+# Top-level keys set by caller:
+# tests[:master] - the master object
+# tests[:agent] - the agent object
+# tests[:show_cmd] - the common show command to use for test_show_run
+#
+tests = {
+  master:   master,
+  agent:    agent,
+  show_cmd: 'show run pim all',
+}
+# tests[id] keys set by caller and used by test_harness_common:
+#
+# tests[id] keys set by caller:
+# tests[id][:desc] - a string to use with logs & debugs
+# tests[id][:manifest] - the complete manifest, as used by test_harness_common
+# tests[id][:resource] - a hash of expected states, used by test_resource
+# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
+# tests[id][:ensure] - (Optional) set to :present or :absent before calling
+# tests[id][:code] - (Optional) override the default exit code in some tests.
+#
+# These keys are local use only and not used by test_harness_common:
+#
+# tests[id][:manifest_props] - This is essentially a master list of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the list
+# tests[id][:resource_props] - This is essentially a master hash of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the hash
+# tests[id][:title_pattern] - (Optional) defines the manifest title.
+#   Can be used with :pim_rp for mixed title/pim_rp testing. If mixing, :pim_rp values will
+#   be merged with title values and override any duplicates. If omitted,
+#   :title_pattern will be set to 'id'.
+#
+
+tests['title_patterns'] = {
+  manifest_props: '',
+  resource_props: { 'ensure' => 'present' },
+}
+#################################################################
+# HELPER FUNCTIONS
+#################################################################
+# Full command string for puppet resource with neighbor AF
+def puppet_resource_cmd(pim_rp)
+  cmd = PUPPET_BINPATH + \
+        "resource cisco_pim_rp_address '#{pim_rp.values.join(' ')}'"
+  get_namespace_cmd(agent, cmd, options)
+end
+
+def build_manifest_cisco_pim_rp_address(tests, id)
+  manifest = prop_hash_to_manifest(tests[id][:pim_rp])
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+    tests[id][:resource] = { 'ensure' => 'absent' }
+  else
+    state = 'ensure => present,'
+    tests[id][:resource] = tests[id][:resource_props]
+  end
+
+  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+  logger.debug("build_manifest_cisco_pim_rp_address :: title_pattern:\n" +
+               tests[id][:title_pattern])
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node 'default' {
+    cisco_pim_rp_address { '#{tests[id][:title_pattern]}':
+      #{state}
+      #{manifest}
+    }
+  }
+EOF"
+end
+
+def test_harness_cisco_pim_rp_address(tests, id)
+  pim_rp = pim_rp_title_pattern_munge(tests, id)
+  logger.info("\n--------\nTest Case Pim ID: #{pim_rp}")
+
+  tests[id][:ensure] = :present if tests[id][:ensure].nil?
+  tests[id][:resource_cmd] = puppet_resource_cmd(pim_rp)
+
+  # Build the manifest for this test
+  build_manifest_cisco_pim_rp_address(tests, id)
+
+  test_manifest(tests, id)
+  test_resource(tests, id)
+  test_idempotence(tests, id)
+  tests[id][:ensure] = nil
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{testheader}" do
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Title Pattern Testing")
+  resource_absent_cleanup(agent, 'cisco_pim_rp_address',
+                          'Setup switch for cisco_pim_rp_address provider test')
+  # -----------------------------------
+  id = 'title_patterns'
+  tests[id][:desc] = '1.1 Title Patterns'
+  tests[id][:title_pattern] = 'newyork'
+  tests[id][:pim_rp] = { afi: 'ipv4',
+                     vrf: 'red', rp_addr: '2.2.2.2' }
+  test_harness_cisco_pim_rp_address(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '1.2 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4'
+  tests[id][:pim_rp] = { vrf: 'red', rp_addr: '3.3.3.3' }
+  test_harness_cisco_pim_rp_address(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '1.3 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4 green'
+  tests[id][:pim_rp] = { rp_addr: '4.4.4.4' }
+  test_harness_cisco_pim_rp_address(tests, id)
+
+  # -----------------------------------
+  tests[id][:desc] = '1.4 Title Patterns'
+  tests[id][:title_pattern] = 'ipv4 red 5.5.5.5'
+  tests[id][:pim_rp] = {}
+  test_harness_cisco_pim_rp_address(tests, id)
+end
+
+logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -393,6 +393,63 @@ def af_title_pattern_munge(tests, id, provider=nil)
   t
 end
 
+# If a [:title] exists merge it with the [:pim] values to create a complete pim.
+def pim_title_pattern_munge(tests, id)
+  title = tests[id][:title_pattern]
+  pim = tests[id][:pim]
+
+  if title.nil?
+    puts 'no title'
+    return pim
+  end
+
+  tests[id][:pim] = {} if pim.nil?
+  t = {}
+
+  t[:afi], t[:vrf] = title.split
+  t.merge!(tests[id][:pim])
+  t[:vrf] = 'default' if t[:vrf].nil?
+  t
+end
+
+# If a [:title] exists merge it with the [:pim_rp] values to create a complete pim.
+def pim_rp_title_pattern_munge(tests, id)
+  title = tests[id][:title_pattern]
+  pim_rp = tests[id][:pim_rp]
+
+  if title.nil?
+    puts 'no title'
+    return pim_rp
+  end
+
+  tests[id][:pim_rp] = {} if pim_rp.nil?
+  t = {}
+
+  t[:afi], t[:vrf], t[:rp_addr] = title.split
+  t.merge!(tests[id][:pim_rp])
+  t[:vrf] = 'default' if t[:vrf].nil?
+  t
+end
+
+# If a [:title] exists merge it with the [:pim_group] values to create a complete pim.
+def pim_group_title_pattern_munge(tests, id)
+  title = tests[id][:title_pattern]
+  pim_group = tests[id][:pim_group]
+
+  if title.nil?
+    puts 'no title'
+    return pim_group
+  end
+
+  tests[id][:pim_group] = {} if pim_group.nil?
+  t = {}
+
+  t[:afi], t[:vrf], t[:rp_addr], t[:group] = title.split
+  t.merge!(tests[id][:pim_group])
+  t[:vrf] = 'default' if t[:vrf].nil?
+  t
+end
+
 # setup_mt_full_env
 # Check and set up prerequisites for Multi-Tenancy Full (MT-full) testing.
 # MT-full currently requires an F3 line module. This method will update


### PR DESCRIPTION
# Description:
Puppet Type, Provider & Beaker Tests implementation for Cisco pim, pim_grouplist & pim_rp_address

# Rubocop:
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/type/cisco_pim.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/type/cisco_pim_rp_address.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/type/cisco_pim_grouplist.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/provider/cisco_pim/nxapi.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/provider/cisco_pim_rp_address/nxapi.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module$ rubocop lib/puppet/provider/cisco_pim_grouplist/nxapi.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ rubocop cisco_pim/test_cisco_pim.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ rubocop cisco_pim_rp_address/test_cisco_pim_rp_address.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ rubocop cisco_pim_grouplist/test_cisco_grouplist.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ rubocop lib/utilitylib.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$

# Beaker Tests:
Cisco_pim:
-------------

```
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ /home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim/test_cisco_pim.rb
Beaker!
      wWWWw
      |o o|
      | O |  2.28.0!
      |(")|
     / \X/ \
    |   V   |
    |   |   |
{
    "project": "Beaker",
    "department": "unknown",
    "created_by": "rtpfe1",
    "host_tags": {},
    "openstack_api_key": null,
    "openstack_username": null,
    "openstack_auth_url": "/tokens",
    "openstack_tenant": null,
    "openstack_keyname": null,
    "openstack_network": null,
    "openstack_region": null,
    "jenkins_build_url": null,
    "validate": false,
    "configure": false,
    "log_level": "info",
    "trace_limit": 10,
    "master-start-curl-retries": 120,
    "masterless": false,
    "options_file": null,
    "type": "pe",
    "provision": true,
    "preserve_hosts": "never",
    "root_keys": false,
    "quiet": false,
    "project_root": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/gems/beaker-2.28.0/lib/beaker",
    "xml_dir": "junit",
    "xml_file": "beaker_junit.xml",
    "xml_time": "beaker_times.xml",
    "xml_time_enabled": false,
    "xml_stylesheet": "junit.xsl",
    "default_log_prefix": "beaker_logs",
    "log_dir": "log",
    "log_sut_event": "sut.log",
    "color": true,
    "dry_run": false,
    "tag_includes": [],
    "tag_excludes": [],
    "timeout": 900,
    "fail_mode": "slow",
    "accept_all_exit_codes": false,
    "timesync": false,
    "disable_iptables": false,
    "set_env": true,
    "repo_proxy": false,
    "package_proxy": false,
    "add_el_extras": false,
    "epel_url": "http://mirrors.kernel.org/fedora-epel",
    "epel_arch": "i386",
    "epel_7_pkg": "epel-release-7-5.noarch.rpm",
    "epel_6_pkg": "epel-release-6-8.noarch.rpm",
    "epel_5_pkg": "epel-release-5-4.noarch.rpm",
    "consoleport": 443,
    "pe_dir": "/opt/enterprise/dists",
    "pe_version_file": "LATEST",
    "pe_version_file_win": "LATEST-win",
    "host_env": {},
    "host_name_prefix": null,
    "ssh_env_file": "~/.ssh/environment",
    "profile_d_env_file": "/etc/profile.d/beaker_env.sh",
    "dot_fog": "/home/rtpfe1/.fog",
    "ec2_yaml": "config/image_templates/ec2.yaml",
    "help": false,
    "collect_perf_data": "none",
    "puppetdb_port_ssl": 8081,
    "puppetdb_port_nonssl": 8080,
    "puppetserver_port": 8140,
    "nodeclassifier_port": 4433,
    "aws_keyname_modifier": "9224522052",
    "ssh": {
        "config": false,
        "paranoid": false,
        "auth_methods": [
            "publickey"
        ],
        "port": 22,
        "forward_agent": true,
        "keys": [
            "/home/rtpfe1/.ssh/id_rsa"
        ],
        "user_known_hosts_file": "/home/rtpfe1/.ssh/known_hosts"
    },
    "hosts_file": "/home/rtpfe1/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests/hosts.cfg",
    "pre_suite": [
        "presuite/presuite_certcheck.rb"
    ],
    "tests": [
        "cisco_pim/test_cisco_pim.rb"
    ],
    "command_line": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim/test_cisco_pim.rb",
    "HOSTS": {
        "agent-lab11-nx": {
            "roles": [
                "agent"
            ],
            "platform": "cisco-7-x86_64",
            "ip": "10.122.197.125",
            "vrf": "management",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "devops",
                "password": "devopspassword"
            },
            "user": "devops",
            "host_tags": {}
        },
        "agent-lab11-pm": {
            "roles": [
                "master",
                "default"
            ],
            "platform": "ubuntu-1404-x86_64",
            "ip": "agent-lab11-pm.cisco.com",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "root",
                "password": "rtpfe1"
            },
            "user": "root",
            "host_tags": {}
        }
    },
    "home": "/home/rtpfe1",
    "helper": [],
    "load_path": [],
    "post_suite": [],
    "install": [],
    "modules": [],
    "logger": "#<Beaker::Logger:0x00000004aaf308>",
    "timestamp": "2016-01-25 13:47:54 -0500",
    "beaker_version": "2.28.0"
}
Beaker::Hypervisor, found some none boxes to create
Begin presuite/presuite_certcheck.rb

TestCase :: Resource :: Presuite

  * TestStep :: Check for Puppet Agent cert on master
    Check for Puppet Agent cert on master :: PASS


  TestCase :: Resource :: Presuite :: PASS
  TestCase :: Resource :: Presuite :: PASS
TestCase :: Resource :: Presuite :: End
presuite/presuite_certcheck.rb passed in 2.55 seconds
      Test Suite: pre_suite @ 2016-01-25 13:47:55 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'pre_suite' -
       Total Suite Time: 2.55 seconds
      Average Test Time: 2.55 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

Begin cisco_pim/test_cisco_pim.rb

TestCase :: Resource cisco_pim

  ------------------------------------------------------------
  Section 1. Non Default Property Testing

  * TestStep :: feature cleanup

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red"}

  * TestStep ::  1.1 Non default properties :: MANIFEST
   1.1 Non default properties :: MANIFEST     :: PASS

  * TestStep ::  1.1 Non default properties :: RESOURCE
     1.1 Non default properties :: RESOURCE     :: PASS

  * TestStep ::  1.1 Non default properties :: IDEMPOTENCE
     1.1 Non default properties :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"black"}

  * TestStep ::  1.2 Non default properties :: MANIFEST
   1.2 Non default properties :: MANIFEST     :: PASS

  * TestStep ::  1.2 Non default properties :: RESOURCE
     1.2 Non default properties :: RESOURCE     :: PASS

  * TestStep ::  1.2 Non default properties :: IDEMPOTENCE
     1.2 Non default properties :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"default"}

  * TestStep ::  1.3 Non default properties :: MANIFEST
   1.3 Non default properties :: MANIFEST     :: PASS

  * TestStep ::  1.3 Non default properties :: RESOURCE
     1.3 Non default properties :: RESOURCE     :: PASS

  * TestStep ::  1.3 Non default properties :: IDEMPOTENCE
     1.3 Non default properties :: IDEMPOTENCE  :: PASS

  ------------------------------------------------------------
  Section 2. Title Pattern Testing

  * TestStep :: feature cleanup

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"green"}

  * TestStep :: 2.1 Title Patterns :: MANIFEST
  2.1 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 2.1 Title Patterns :: RESOURCE
    2.1 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 2.1 Title Patterns :: IDEMPOTENCE
    2.1 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"yellow"}

  * TestStep :: 2.2 Title Patterns :: MANIFEST
  2.2 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 2.2 Title Patterns :: RESOURCE
    2.2 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 2.2 Title Patterns :: IDEMPOTENCE
    2.2 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"black"}

  * TestStep :: 2.3 Title Patterns :: MANIFEST
  2.3 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 2.3 Title Patterns :: RESOURCE
    2.3 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 2.3 Title Patterns :: IDEMPOTENCE
    2.3 Title Patterns :: IDEMPOTENCE  :: PASS
TestCase :: Resource cisco_pim :: End
cisco_pim/test_cisco_pim.rb passed in 147.83 seconds
      Test Suite: tests @ 2016-01-25 13:47:57 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 147.83 seconds
      Average Test Time: 147.83 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to agent-lab11-nx has been terminated
Warning: ssh connection to agent-lab11-pm has been terminated
Beaker completed successfully, thanks.
```

Cisco_pim_rp_address:
----------------------------

rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ /home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim_rp_address/test_cisco_pim_rp_address.rb
Beaker!
      wWWWw
      |o o|
      | O |  2.28.0!
      |(")|
     / \X/ \
    |   V   |
    |   |   |
{
    "project": "Beaker",
    "department": "unknown",
    "created_by": "rtpfe1",
    "host_tags": {},
    "openstack_api_key": null,
    "openstack_username": null,
    "openstack_auth_url": "/tokens",
    "openstack_tenant": null,
    "openstack_keyname": null,
    "openstack_network": null,
    "openstack_region": null,
    "jenkins_build_url": null,
    "validate": false,
    "configure": false,
    "log_level": "info",
    "trace_limit": 10,
    "master-start-curl-retries": 120,
    "masterless": false,
    "options_file": null,
    "type": "pe",
    "provision": true,
    "preserve_hosts": "never",
    "root_keys": false,
    "quiet": false,
    "project_root": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/gems/beaker-2.28.0/lib/beaker",
    "xml_dir": "junit",
    "xml_file": "beaker_junit.xml",
    "xml_time": "beaker_times.xml",
    "xml_time_enabled": false,
    "xml_stylesheet": "junit.xsl",
    "default_log_prefix": "beaker_logs",
    "log_dir": "log",
    "log_sut_event": "sut.log",
    "color": true,
    "dry_run": false,
    "tag_includes": [],
    "tag_excludes": [],
    "timeout": 900,
    "fail_mode": "slow",
    "accept_all_exit_codes": false,
    "timesync": false,
    "disable_iptables": false,
    "set_env": true,
    "repo_proxy": false,
    "package_proxy": false,
    "add_el_extras": false,
    "epel_url": "http://mirrors.kernel.org/fedora-epel",
    "epel_arch": "i386",
    "epel_7_pkg": "epel-release-7-5.noarch.rpm",
    "epel_6_pkg": "epel-release-6-8.noarch.rpm",
    "epel_5_pkg": "epel-release-5-4.noarch.rpm",
    "consoleport": 443,
    "pe_dir": "/opt/enterprise/dists",
    "pe_version_file": "LATEST",
    "pe_version_file_win": "LATEST-win",
    "host_env": {},
    "host_name_prefix": null,
    "ssh_env_file": "~/.ssh/environment",
    "profile_d_env_file": "/etc/profile.d/beaker_env.sh",
    "dot_fog": "/home/rtpfe1/.fog",
    "ec2_yaml": "config/image_templates/ec2.yaml",
    "help": false,
    "collect_perf_data": "none",
    "puppetdb_port_ssl": 8081,
    "puppetdb_port_nonssl": 8080,
    "puppetserver_port": 8140,
    "nodeclassifier_port": 4433,
    "aws_keyname_modifier": "0865288188",
    "ssh": {
        "config": false,
        "paranoid": false,
        "auth_methods": [
            "publickey"
        ],
        "port": 22,
        "forward_agent": true,
        "keys": [
            "/home/rtpfe1/.ssh/id_rsa"
        ],
        "user_known_hosts_file": "/home/rtpfe1/.ssh/known_hosts"
    },
    "hosts_file": "/home/rtpfe1/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests/hosts.cfg",
    "pre_suite": [
        "presuite/presuite_certcheck.rb"
    ],
    "tests": [
        "cisco_pim_rp_address/test_cisco_pim_rp_address.rb"
    ],
    "command_line": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim_rp_address/test_cisco_pim_rp_address.rb",
    "HOSTS": {
        "agent-lab11-nx": {
            "roles": [
                "agent"
            ],
            "platform": "cisco-7-x86_64",
            "ip": "10.122.197.125",
            "vrf": "management",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "devops",
                "password": "devopspassword"
            },
            "user": "devops",
            "host_tags": {}
        },
        "agent-lab11-pm": {
            "roles": [
                "master",
                "default"
            ],
            "platform": "ubuntu-1404-x86_64",
            "ip": "agent-lab11-pm.cisco.com",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "root",
                "password": "rtpfe1"
            },
            "user": "root",
            "host_tags": {}
        }
    },
    "home": "/home/rtpfe1",
    "helper": [],
    "load_path": [],
    "post_suite": [],
    "install": [],
    "modules": [],
    "logger": "#<Beaker::Logger:0x000000045c7368>",
    "timestamp": "2016-01-25 13:51:19 -0500",
    "beaker_version": "2.28.0"
}
Beaker::Hypervisor, found some none boxes to create
Begin presuite/presuite_certcheck.rb

TestCase :: Resource :: Presuite

  * TestStep :: Check for Puppet Agent cert on master
    Check for Puppet Agent cert on master :: PASS


  TestCase :: Resource :: Presuite :: PASS
  TestCase :: Resource :: Presuite :: PASS
TestCase :: Resource :: Presuite :: End
presuite/presuite_certcheck.rb passed in 2.58 seconds
      Test Suite: pre_suite @ 2016-01-25 13:51:19 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'pre_suite' -
       Total Suite Time: 2.58 seconds
      Average Test Time: 2.58 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

Begin cisco_pim_rp_address/test_cisco_pim_rp_address.rb

TestCase :: Resource cisco_pim_rp_address

  ------------------------------------------------------------
  Section 1. Title Pattern Testing

  * TestStep :: Setup switch for cisco_pim_rp_address provider test

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"2.2.2.2"}

  * TestStep :: 1.1 Title Patterns :: MANIFEST
  1.1 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 1.1 Title Patterns :: RESOURCE
    1.1 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 1.1 Title Patterns :: IDEMPOTENCE
    1.1 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"3.3.3.3"}

  * TestStep :: 1.2 Title Patterns :: MANIFEST
  1.2 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 1.2 Title Patterns :: RESOURCE
    1.2 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 1.2 Title Patterns :: IDEMPOTENCE
    1.2 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"green", :rp_addr=>"4.4.4.4"}

  * TestStep :: 1.3 Title Patterns :: MANIFEST
  1.3 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 1.3 Title Patterns :: RESOURCE
    1.3 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 1.3 Title Patterns :: IDEMPOTENCE
    1.3 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"5.5.5.5"}

  * TestStep :: 1.4 Title Patterns :: MANIFEST
  1.4 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 1.4 Title Patterns :: RESOURCE
    1.4 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 1.4 Title Patterns :: IDEMPOTENCE
    1.4 Title Patterns :: IDEMPOTENCE  :: PASS
TestCase :: Resource cisco_pim_rp_address :: End
cisco_pim_rp_address/test_cisco_pim_rp_address.rb passed in 78.18 seconds
      Test Suite: tests @ 2016-01-25 13:51:22 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 78.18 seconds
      Average Test Time: 78.18 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to agent-lab11-nx has been terminated
Warning: ssh connection to agent-lab11-pm has been terminated
Beaker completed successfully, thanks.

Cisco_pim_grouplist:
---------------------------

rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests$ /home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim_grouplist/test_cisco_grouplist.rb
Beaker!
      wWWWw
      |o o|
      | O |  2.28.0!
      |(")|
     / \X/ \
    |   V   |
    |   |   |
{
    "project": "Beaker",
    "department": "unknown",
    "created_by": "rtpfe1",
    "host_tags": {},
    "openstack_api_key": null,
    "openstack_username": null,
    "openstack_auth_url": "/tokens",
    "openstack_tenant": null,
    "openstack_keyname": null,
    "openstack_network": null,
    "openstack_region": null,
    "jenkins_build_url": null,
    "validate": false,
    "configure": false,
    "log_level": "info",
    "trace_limit": 10,
    "master-start-curl-retries": 120,
    "masterless": false,
    "options_file": null,
    "type": "pe",
    "provision": true,
    "preserve_hosts": "never",
    "root_keys": false,
    "quiet": false,
    "project_root": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/gems/beaker-2.28.0/lib/beaker",
    "xml_dir": "junit",
    "xml_file": "beaker_junit.xml",
    "xml_time": "beaker_times.xml",
    "xml_time_enabled": false,
    "xml_stylesheet": "junit.xsl",
    "default_log_prefix": "beaker_logs",
    "log_dir": "log",
    "log_sut_event": "sut.log",
    "color": true,
    "dry_run": false,
    "tag_includes": [],
    "tag_excludes": [],
    "timeout": 900,
    "fail_mode": "slow",
    "accept_all_exit_codes": false,
    "timesync": false,
    "disable_iptables": false,
    "set_env": true,
    "repo_proxy": false,
    "package_proxy": false,
    "add_el_extras": false,
    "epel_url": "http://mirrors.kernel.org/fedora-epel",
    "epel_arch": "i386",
    "epel_7_pkg": "epel-release-7-5.noarch.rpm",
    "epel_6_pkg": "epel-release-6-8.noarch.rpm",
    "epel_5_pkg": "epel-release-5-4.noarch.rpm",
    "consoleport": 443,
    "pe_dir": "/opt/enterprise/dists",
    "pe_version_file": "LATEST",
    "pe_version_file_win": "LATEST-win",
    "host_env": {},
    "host_name_prefix": null,
    "ssh_env_file": "~/.ssh/environment",
    "profile_d_env_file": "/etc/profile.d/beaker_env.sh",
    "dot_fog": "/home/rtpfe1/.fog",
    "ec2_yaml": "config/image_templates/ec2.yaml",
    "help": false,
    "collect_perf_data": "none",
    "puppetdb_port_ssl": 8081,
    "puppetdb_port_nonssl": 8080,
    "puppetserver_port": 8140,
    "nodeclassifier_port": 4433,
    "aws_keyname_modifier": "2975885342",
    "ssh": {
        "config": false,
        "paranoid": false,
        "auth_methods": [
            "publickey"
        ],
        "port": 22,
        "forward_agent": true,
        "keys": [
            "/home/rtpfe1/.ssh/id_rsa"
        ],
        "user_known_hosts_file": "/home/rtpfe1/.ssh/known_hosts"
    },
    "hosts_file": "/home/rtpfe1/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests/hosts.cfg",
    "pre_suite": [
        "presuite/presuite_certcheck.rb"
    ],
    "tests": [
        "cisco_pim_grouplist/test_cisco_grouplist.rb"
    ],
    "command_line": "/home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_pim_grouplist/test_cisco_grouplist.rb",
    "HOSTS": {
        "agent-lab11-nx": {
            "roles": [
                "agent"
            ],
            "platform": "cisco-7-x86_64",
            "ip": "10.122.197.125",
            "vrf": "management",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "devops",
                "password": "devopspassword"
            },
            "user": "devops",
            "host_tags": {}
        },
        "agent-lab11-pm": {
            "roles": [
                "master",
                "default"
            ],
            "platform": "ubuntu-1404-x86_64",
            "ip": "agent-lab11-pm.cisco.com",
            "ssh": {
                "auth_methods": [
                    "password"
                ],
                "user": "root",
                "password": "rtpfe1"
            },
            "user": "root",
            "host_tags": {}
        }
    },
    "home": "/home/rtpfe1",
    "helper": [],
    "load_path": [],
    "post_suite": [],
    "install": [],
    "modules": [],
    "logger": "#<Beaker::Logger:0x00000003643180>",
    "timestamp": "2016-01-25 13:53:15 -0500",
    "beaker_version": "2.28.0"
}
Beaker::Hypervisor, found some none boxes to create
Begin presuite/presuite_certcheck.rb

TestCase :: Resource :: Presuite

  * TestStep :: Check for Puppet Agent cert on master
    Check for Puppet Agent cert on master :: PASS


  TestCase :: Resource :: Presuite :: PASS
  TestCase :: Resource :: Presuite :: PASS
TestCase :: Resource :: Presuite :: End
presuite/presuite_certcheck.rb passed in 2.21 seconds
      Test Suite: pre_suite @ 2016-01-25 13:53:15 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'pre_suite' -
       Total Suite Time: 2.21 seconds
      Average Test Time: 2.21 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

Begin cisco_pim_grouplist/test_cisco_grouplist.rb

TestCase :: Resource cisco_pim_grouplist

  ------------------------------------------------------------
  Section 1. Title Pattern Testing

  * TestStep :: Setup switch for cisco_pim_grouplist provider test

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"22.22.22.22", :group=>"224.0.0.0/8"}

  * TestStep :: 3.1 Title Patterns :: MANIFEST
  3.1 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 3.1 Title Patterns :: RESOURCE
    3.1 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 3.1 Title Patterns :: IDEMPOTENCE
    3.1 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"33.33.33.33", :group=>"225.0.0.0/8"}

  * TestStep :: 3.2 Title Patterns :: MANIFEST
  3.2 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 3.2 Title Patterns :: RESOURCE
    3.2 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 3.2 Title Patterns :: IDEMPOTENCE
    3.2 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"red", :rp_addr=>"44.44.44.44", :group=>"226.0.0.0/8"}

  * TestStep :: 3.3 Title Patterns :: MANIFEST
  3.3 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 3.3 Title Patterns :: RESOURCE
    3.3 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 3.3 Title Patterns :: IDEMPOTENCE
    3.3 Title Patterns :: IDEMPOTENCE  :: PASS

  --------
  Test Case Pim ID: {:afi=>"ipv4", :vrf=>"default", :rp_addr=>"55.55.55.55", :group=>"227.0.0.0/8"}

  * TestStep :: 3.4 Title Patterns :: MANIFEST
  3.4 Title Patterns :: MANIFEST     :: PASS

  * TestStep :: 3.4 Title Patterns :: RESOURCE
    3.4 Title Patterns :: RESOURCE     :: PASS

  * TestStep :: 3.4 Title Patterns :: IDEMPOTENCE
    3.4 Title Patterns :: IDEMPOTENCE  :: PASS
TestCase :: Resource cisco_pim_grouplist :: End
cisco_pim_grouplist/test_cisco_grouplist.rb passed in 77.90 seconds
      Test Suite: tests @ 2016-01-25 13:53:17 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 77.90 seconds
      Average Test Time: 77.90 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to agent-lab11-nx has been terminated
Warning: ssh connection to agent-lab11-pm has been terminated
Beaker completed successfully, thanks.
rtpfe1@agent-lab11-ws:~/trial_sync_beaker/cisco-network-puppet-module/tests/beaker_tests