### PR TITLE
cisco_interface_ospf beaker fixes (all Nexus platforms)

### DIFF
--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_defaults.rb
@@ -62,21 +62,18 @@ require File.expand_path('../ospfintflib.rb', __FILE__)
 result = 'PASS'
 testheader = 'OSPFINTF Resource :: All Attributes Defaults'
 
+if ethernet_info_get.nil? || ethernet_info_get[:slot].nil?
+  msg = 'Unable to find suitable ethernet module required for this test.'
+  prereq_skip(testheader, self, msg)
+end
+interface = "ethernet#{ethernet_info_get[:slot]}/1"
+
 # @test_name [TestCase] Executes defaults testcase for OSPFINTF Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    cmd_str = get_vshell_cmd('conf t ; no feature ospf')
-    on(agent, cmd_str)
-
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config section ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/feature ospf/],
-                               true, self, logger)
-    end
+    resource_absent_cleanup(agent, 'cisco_interface_ospf',
+                            'Setup switch for cisco_ospf provider test')
 
     logger.info("Setup switch for provider test :: #{result}")
   end
@@ -84,7 +81,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_present)
+    on(master, OspfIntfLib.create_ospfintf_manifest_present(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -109,7 +106,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',
@@ -125,30 +122,10 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_intf_ospf resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
-  step 'TestStep :: Check ospfintf instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [
-                                 /router ospf test/,
-                                 %r{interface Ethernet1/4},
-                                 /ip ospf cost 1/,
-                                 /ip ospf dead-interval 40/,
-                                 /ip router ospf test area 0.0.0.1/,
-                               ],
-                               false, self, logger)
-    end
-
-    logger.info("Check ospfintf instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_absent)
+    on(master, OspfIntfLib.create_ospfintf_manifest_absent(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -163,7 +140,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',
@@ -177,26 +154,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_intf_ospf resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
-  step 'TestStep :: Check ospfintf instance absence on agent' do
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [
-                                 /router ospf test/,
-                                 %r{interface Ethernet1/4},
-                                 /ip ospf cost 1/,
-                                 /ip ospf dead-interval 40/,
-                                 /ip router ospf test area 0.0.0.1/,
-                               ],
-                               true, self, logger)
-    end
-
-    logger.info("Check ospfintf instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
@@ -60,18 +60,27 @@ require File.expand_path('../ospfintflib.rb', __FILE__)
 result = 'PASS'
 testheader = 'OSPFINTF Resource :: All Attributes Negatives'
 
-if ethernet_info_get.nil? || ethernet_info_get[:slot].nil?
-  msg = 'Unable to find suitable ethernet module required for this test.'
-  prereq_skip(testheader, self, msg)
+# Local tests hash and helper method used to dynamically find an available
+# interface for cisco_interface_ospf tests.
+tests = { intf_type: 'ethernet', agent: agent, testheader: testheader }
+def find_ospf_interface(tests)
+  if tests[:ethernet]
+    intf = tests[:ethernet]
+  else
+    intf = find_interface(tests)
+    # cache for later tests
+    tests[:ethernet] = intf
+  end
+  intf
 end
-interface = "ethernet#{ethernet_info_get[:slot]}/1"
+interface = find_ospf_interface(tests)
 
 # @test_name [TestCase] Executes negatives testcase for OSPFINTF Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_interface_ospf',
-                            'Setup switch for cisco_ospf provider test')
+                            'Setup switch for cisco_interface_ospf provider test')
 
     logger.info("Setup switch for provider test :: #{result}")
   end
@@ -94,7 +103,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\"", options)
+      "resource cisco_interface_ospf '#{interface} test'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'cost' => OspfIntfLib::COST_NEGATIVE },
@@ -108,7 +117,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
+      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -132,7 +141,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\"", options)
+      "resource cisco_interface_ospf '#{interface} test'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'hello_interval' => OspfIntfLib::HELLOINTERVAL_NEGATIVE },
@@ -146,7 +155,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
+      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -170,7 +179,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\"", options)
+      "resource cisco_interface_ospf '#{interface} test'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'dead_interval' => OspfIntfLib::DEADINTERVAL_NEGATIVE },
@@ -184,7 +193,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
+      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -208,7 +217,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\"", options)
+      "resource cisco_interface_ospf '#{interface} test'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'passive_interface' => OspfIntfLib::PASSIVEINTF_NEGATIVE },
@@ -222,7 +231,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
+      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
@@ -60,21 +60,18 @@ require File.expand_path('../ospfintflib.rb', __FILE__)
 result = 'PASS'
 testheader = 'OSPFINTF Resource :: All Attributes Negatives'
 
+if ethernet_info_get.nil? || ethernet_info_get[:slot].nil?
+  msg = 'Unable to find suitable ethernet module required for this test.'
+  prereq_skip(testheader, self, msg)
+end
+interface = "ethernet#{ethernet_info_get[:slot]}/1"
+
 # @test_name [TestCase] Executes negatives testcase for OSPFINTF Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    cmd_str = get_vshell_cmd('conf t ; no feature ospf')
-    on(agent, cmd_str)
-
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config section ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/feature ospf/],
-                               true, self, logger)
-    end
+    resource_absent_cleanup(agent, 'cisco_interface_ospf',
+                            'Setup switch for cisco_ospf provider test')
 
     logger.info("Setup switch for provider test :: #{result}")
   end
@@ -82,7 +79,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_cost_negative)
+    on(master, OspfIntfLib.create_ospfintf_manifest_cost_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -97,7 +94,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'cost' => OspfIntfLib::COST_NEGATIVE },
@@ -109,18 +106,9 @@ test_name "TestCase :: #{testheader}" do
 
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/ip ospf cost #{OspfIntfLib::COST_NEGATIVE}/],
-                               true, self, logger)
-    end
-
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test' ensure=absent", options)
+      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -129,7 +117,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_hellointerval_negative)
+    on(master, OspfIntfLib.create_ospfintf_manifest_hellointerval_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -144,7 +132,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'hello_interval' => OspfIntfLib::HELLOINTERVAL_NEGATIVE },
@@ -156,18 +144,9 @@ test_name "TestCase :: #{testheader}" do
 
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/ip ospf hello-interval #{OspfIntfLib::HELLOINTERVAL_NEGATIVE}/],
-                               true, self, logger)
-    end
-
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test' ensure=absent", options)
+      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -176,7 +155,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_deadinterval_negative)
+    on(master, OspfIntfLib.create_ospfintf_manifest_deadinterval_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -191,7 +170,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'dead_interval' => OspfIntfLib::DEADINTERVAL_NEGATIVE },
@@ -203,18 +182,9 @@ test_name "TestCase :: #{testheader}" do
 
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/ip ospf dead-interval #{OspfIntfLib::DEADINTERVAL_NEGATIVE}/],
-                               true, self, logger)
-    end
-
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test' ensure=absent", options)
+      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -223,7 +193,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, OspfIntfLib.create_ospfintf_manifest_passiveintf_negative)
+    on(master, OspfIntfLib.create_ospfintf_manifest_passiveintf_negative(interface))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -238,7 +208,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test'", options)
+      "resource cisco_interface_ospf \"#{interface} test\"", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'passive_interface' => OspfIntfLib::PASSIVEINTF_NEGATIVE },
@@ -250,18 +220,9 @@ test_name "TestCase :: #{testheader}" do
 
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config ospf')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/ip ospf passive-interface #{OspfIntfLib::PASSIVEINTF_NEGATIVE}/],
-                               true, self, logger)
-    end
-
     # Cleanup partially configured resource.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf 'ethernet1/4 test' ensure=absent", options)
+      "resource cisco_interface_ospf \"#{interface} test\" ensure=absent", options)
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintflib.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintflib.rb
@@ -45,18 +45,18 @@ module OspfIntfLib
   # 'ensure' is set to present.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_present
+  def self.create_ospfintf_manifest_present(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => '1',
     cost                     => '1',
@@ -73,20 +73,20 @@ EOF"
   # @param area is used to set the area for the manifest
   # @param intf is used to optionally specify the interface to use
   # @result manifest_str is the newly constructed manifest
-  def self.create_ospfintf_area_manifest(area, intf='ethernet1/4')
+  def self.create_ospfintf_area_manifest(area, intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { '#{intf}':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { '#{intf} test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
-    area                     => '#{area}',
+    area                     => \"#{area}\",
   }
 }
 EOF"
@@ -97,10 +97,10 @@ EOF"
   # 'ensure' is set to absent.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_absent
+  def self.create_ospfintf_manifest_absent(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => absent,
   }
 
@@ -116,18 +116,18 @@ EOF"
   # ensure, cost, dead_interval, hello_interval, area and passive_interface.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_nondefaults
+  def self.create_ospfintf_manifest_nondefaults(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => '100',
     cost                     => '100',
@@ -143,18 +143,18 @@ EOF"
   # Method to create a manifest for OSPFINTF resource attribute 'cost'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_cost_negative
+  def self.create_ospfintf_manifest_cost_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => 1,
     cost                     => #{OspfIntfLib::COST_NEGATIVE},
@@ -167,18 +167,18 @@ EOF"
   # Method to create a manifest for OSPFINTF resource attribute 'hello_interval'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_hellointerval_negative
+  def self.create_ospfintf_manifest_hellointerval_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => '1',
     hello_interval           => #{OspfIntfLib::HELLOINTERVAL_NEGATIVE},
@@ -191,18 +191,18 @@ EOF"
   # Method to create a manifest for OSPFINTF resource attribute 'dead_interval'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_deadinterval_negative
+  def self.create_ospfintf_manifest_deadinterval_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => '1',
     dead_interval            => #{OspfIntfLib::DEADINTERVAL_NEGATIVE},
@@ -215,18 +215,18 @@ EOF"
   # Method to create a manifest for OSPFINTF resource attribute 'passive_intf'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_ospfintf_manifest_passiveintf_negative
+  def self.create_ospfintf_manifest_passiveintf_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   cisco_ospf { 'test':
     ensure                   => present,
   }
 
-  cisco_interface { 'ethernet1/4':
+  cisco_interface { \"#{intf}\":
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { 'ethernet1/4 test':
+  cisco_interface_ospf { \"#{intf} test\":
     ensure                   => present,
     area                     => '1',
     passive_interface        => #{OspfIntfLib::PASSIVEINTF_NEGATIVE},

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintflib.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintflib.rb
@@ -52,7 +52,7 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
@@ -80,11 +80,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => \"#{area}\",
   }
@@ -100,7 +100,7 @@ EOF"
   def self.create_ospfintf_manifest_absent(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => absent,
   }
 
@@ -123,11 +123,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => '100',
     cost                     => '100',
@@ -150,11 +150,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => 1,
     cost                     => #{OspfIntfLib::COST_NEGATIVE},
@@ -174,11 +174,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => '1',
     hello_interval           => #{OspfIntfLib::HELLOINTERVAL_NEGATIVE},
@@ -198,11 +198,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => '1',
     dead_interval            => #{OspfIntfLib::DEADINTERVAL_NEGATIVE},
@@ -222,11 +222,11 @@ node default {
     ensure                   => present,
   }
 
-  cisco_interface { \"#{intf}\":
+  cisco_interface { '#{intf}':
     switchport_mode          => disabled,
   }
 
-  cisco_interface_ospf { \"#{intf} test\":
+  cisco_interface_ospf { '#{intf} test':
     ensure                   => present,
     area                     => '1',
     passive_interface        => #{OspfIntfLib::PASSIVEINTF_NEGATIVE},

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -287,7 +287,6 @@ def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
   step "TestStep :: #{stepinfo}" do
     # set each resource to ensure=absent
     get_current_resource_instances(agent, res_name).each do |title|
-      puts "resource name: #{res_name}"
       case res_name
       # Anchors needed to ensure only cisco_interface matches.
       when /^cisco_interface$/

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -480,6 +480,16 @@ def mt_full_interface
   "ethernet#{slot}/1" unless slot.nil?
 end
 
+# Return ethernet slot and port information from the first line module found.
+def ethernet_info_get
+  info = {}
+  cmd = get_vshell_cmd('sh mod')
+  out = on(agent, cmd, pty: true).stdout[/^(\d+)\s+([1-9]+)\s.*(Eth|Sup)/i]
+  info[:slot] = out.nil? ? nil : Regexp.last_match[1]
+  info[:ports] = out.nil? ? nil : Regexp.last_match[2]
+  info
+end
+
 # Return the default vdc name
 def default_vdc_name
   cmd = get_vshell_cmd('sh run vdc')


### PR DESCRIPTION
Fixes to `cisco_interface_ospf` beaker tests that enable them to run across all Nexus platforms.

- Removed `vsh` commands used to validate configuration commands.
- New utilitylib method to return existing slot and port information for existing line card modules.  Allows us to avoide hard coding interfaces.
- Tests are skipped if no suitable line card is found.

Beaker tests run and pass on `n6|7|9k`