### PR TITLE
Tighten up testbed setups for vdc, vlan_mapping, service_vni

### DIFF
--- a/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
+++ b/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
@@ -83,15 +83,15 @@ testheader = 'Resource cisco_interface: vlan_mapping properties'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:config_bridge_domain] - the bridge-domain configuration
-# tests[:config_switchport] - the interface switchport configuration
+# tests[:bridge_domain] - the bridge-domain configuration
+# tests[:switchport_mode] - the interface switchport mode type
 #
 tests = {
-  master:               master,
-  agent:                agent,
-  testheader:           testheader,
-  config_bridge_domain: 'system bridge-domain 100-113 ; bridge-domain 100',
-  config_switchport:    'switchport ; switchport mode trunk',
+  master:          master,
+  agent:           agent,
+  testheader:      testheader,
+  bridge_domain:   '199',
+  switchport_mode: 'trunk',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:

--- a/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
+++ b/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
@@ -82,15 +82,15 @@ testheader = 'Resource cisco_interface_service_vni'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:config_bridge_domain] - the bridge-domain configuration
+# tests[:encap_prof_global] - the encap profile vni global configuration
 #
 tests = {
-  master:                   master,
-  agent:                    agent,
-  testheader:               testheader,
-  sid:                      22,
-  config_encap_prof_global: 'encapsulation profile vni vni_500_5000 ; '\
-                            'dot1q 500 vni 5000',
+  master:            master,
+  agent:             agent,
+  testheader:        testheader,
+  sid:               22,
+  encap_prof_global: 'encapsulation profile vni vni_500_5000 ; '\
+                     'dot1q 500 vni 5000',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -68,8 +68,6 @@ testheader = 'Resource cisco_vdc properties'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:config_bridge_domain] - the bridge-domain configuration
-# tests[:config_switchport] - the interface switchport configuration
 #
 tests = {
   master:     master,


### PR DESCRIPTION
This started off as a fix for bridge-domain but morphed into additional cleanups.

1. bridge-domain setup will fail if there's currently a bridge-domain config present on the testbed; so I had to check the current state and clean it up before adding the domain for the test.
2. This led to creating a specific config_bridge_domain helper method, which led to similar helper methods for the other mt_full_env setups. This area could probably still use some work but my commit gets it closer.