### PR TITLE
adding port_channel from puppetlabs netdev_stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### NetDev Resources
 - `network_trunk` provider.
+- `port_channel` provider.
 - `search_domain` provider.
 - `snmp_notification` provider.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
   * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
   * [`cisco_portchannel_global`](#type-cisco_portchannel_global)
-  * 
+  * [`port_channel (netdev_stdlib)`](#type-port_channel)
+
 * RADIUS Types
   * [`radius (netdev_stdlib)`](#type-radius)
   * [`radius_global (netdev_stdlib)`](#type-radius_global)
@@ -294,6 +295,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`network_snmp`](#type-network_snmp)
 * [`ntp_config`](#type-ntp_config)
 * [`ntp_server`](#type-ntp_server)
+* [`port_channel`](#type-port_channel)
 * [`radius`](#type-radius)
 * [`radius_global`](#type-radius_global)
 * [`radius_server`](#type-radius_server)
@@ -1954,6 +1956,25 @@ Determines whether or not the config should be present on the device. Valid valu
 
 ##### `name`
 Hostname or address of the NTP server.  Valid value is a string.
+
+### Type: port_channel
+
+#### Parameters
+
+##### `ensure`
+Determines whether or not the config should be present on the device. Valid values are 'present' and 'absent'.
+
+##### `id`
+Channel group ID. eg 100. Valid value is an integer.
+
+##### `interfaces`
+Array of Physical Interfaces that are part of the port channel. An array of valid interface names.
+
+##### `minimum_links`
+Number of active links required for port channel to be up. Valid value is an integer.
+
+##### `name`
+Name of the port channel. eg port-channel100. Valid value is a string.
 
 ### Type: radius
 

--- a/examples/demo_netdev_port_channel.pp
+++ b/examples/demo_netdev_port_channel.pp
@@ -1,0 +1,24 @@
+# Manifest to demo cisco_interface provider
+#
+# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::demo_netdev_port_channel {
+  port_channel { 'port-channel100':
+    ensure        => 'present',
+    id            => '100',
+    interfaces    => ['ethernet1/8', 'ethernet1/9'],
+    minimum_links => '3',
+  }
+}

--- a/lib/puppet/provider/port_channel/nxapi.rb
+++ b/lib/puppet/provider/port_channel/nxapi.rb
@@ -1,0 +1,75 @@
+# The NXAPI provider for network_interface
+#
+# October, 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.type(:port_channel).provide(:nxapi, parent: Puppet::Type.type(:cisco_interface_portchannel).provider(:nxapi)) do
+  @doc = 'port channel'
+
+  mk_resource_methods
+
+  def self.instances
+    interfaces = []
+    Cisco::Interface.interfaces.each do |interface_name, i|
+      interface = {
+        interface:     interface_name,
+        channel_group: i.send(:channel_group),
+      }
+      interfaces.push(interface) if i.send(:channel_group)
+    end
+    portchannels = []
+    Cisco::InterfacePortChannel.interfaces.each do |port_channel, p|
+      id_number = port_channel[/\d+/].to_i
+      interfaces_in_port = []
+
+      interfaces.each do |interface|
+        if interface[:channel_group] == id_number
+          interfaces_in_port.push(interface[:interface])
+        end
+      end
+      portchannel = {
+        name:          port_channel,
+        interface:     port_channel,
+        minimum_links: p.send(:lacp_min_links),
+        id:            id_number,
+        interfaces:    interfaces_in_port,
+        ensure:        :present,
+      }
+      portchannels << new(portchannel)
+    end
+    portchannels
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @nu.destroy
+      @nu = nil
+      @property_hash[:ensure] = :absent
+    else
+      if @property_hash.empty?
+        @nu = Cisco::InterfacePortChannel.new(@resource[:name])
+      end
+      @nu.lacp_min_links = @resource[:minimum_links] if @resource[:minimum_links]
+      # loop through interfaces
+      if @resource[:interfaces]
+        @resource[:interfaces].each do |i|
+          bla = Cisco::Interface.interfaces[i]
+          bla.channel_group = @resource[:id] if @resource[:id]
+        end
+      end
+    end
+  end
+end

--- a/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
@@ -1,0 +1,216 @@
+###############################################################################
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+# TestCase Name:
+# -------------
+# port_channel_provider_defaults.rb
+#
+# TestCase Prerequisites:
+# -----------------------
+# This is a Puppet port_channel resource testcase for Puppet Agent
+# on Nexus devices.
+# The test case assumes the following prerequisites are already satisfied:
+#   - Host configuration file contains agent and master information.
+#   - SSH is enabled on the N9K Agent.
+#   - Puppet master/server is started.
+#   - Puppet agent certificate has been signed on the Puppet master/server.
+#
+# TestCase:
+# ---------
+# This port_channel resource test verifies default values for all
+# properties.
+#
+# The following exit_codes are validated for Puppet, Vegas shell and
+# Bash shell commands.
+#
+# Vegas and Bash Shell Commands:
+# 0   - successful command execution
+# > 0 - failed command execution.
+#
+# Puppet Commands:
+# 0 - no changes have occurred
+# 1 - errors have occurred,
+# 2 - changes have occurred
+# 4 - failures have occurred and
+# 6 - changes and failures have occurred.
+#
+# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
+#
+# The test cases use RegExp pattern matching on stdout or output IO
+# instance attributes to verify resource properties.
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# -----------------------------
+# Common settings and variables
+# -----------------------------
+testheader = 'Resource port_channel'
+
+# Define PUPPETMASTER_MANIFESTPATH.
+
+# The 'tests' hash is used to define all of the test data values and expected
+# results. It is also used to pass optional flags to the test methods when
+# necessary.
+
+# 'tests' hash
+# Top-level keys set by caller:
+# tests[:master] - the master object
+# tests[:agent] - the agent object
+# tests[:show_cmd] - the common show command to use for test_show_run
+#
+tests = {
+  master: master,
+  agent:  agent,
+}
+
+# tests[id] keys set by caller and used by test_harness_common:
+#
+# tests[id] keys set by caller:
+# tests[id][:desc] - a string to use with logs & debugs
+# tests[id][:manifest] - the complete manifest, as used by test_harness_common
+# tests[id][:resource] - a hash of expected states, used by test_resource
+# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
+# tests[id][:ensure] - (Optional) set to :present or :absent before calling
+# tests[id][:code] - (Optional) override the default exit code in some tests.
+#
+# These keys are local use only and not used by test_harness_common:
+#
+# tests[id][:manifest_props] - This is essentially a master list of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the list
+# tests[id][:resource_props] - This is essentially a master hash of properties
+#   that permits re-use of the properties for both :present and :absent testing
+#   without destroying the hash
+# tests[id][:title_pattern] - (Optional) defines the manifest title.
+#   Can be used with :af for mixed title/af testing. If mixing, :af values will
+#   be merged with title values and override any duplicates. If omitted,
+#   :title_pattern will be set to 'id'.
+#
+
+tests['default_properties'] = {
+  title_pattern:  'port-channel100',
+  manifest_props: "
+    id            => '100',
+    interfaces    => ['ethernet1/8'],
+    minimum_links => '1',
+  ",
+  code:           [0, 2],
+  resource_props: {
+    'id'            => '100',
+    'interfaces'    => "['ethernet1/8']",
+    'minimum_links' => '1',
+  },
+}
+
+tests['non_default_properties'] = {
+  title_pattern:  'port-channel100',
+  manifest_props: "
+    id            => '100',
+    interfaces    => ['ethernet1/8', 'ethernet1/9'],
+    minimum_links => '3',
+  ",
+  resource_props: {
+    'id'            => '100',
+    'interfaces'    => "['ethernet1/8', 'ethernet1/9']",
+    'minimum_links' => '3',
+  },
+}
+
+#################################################################
+# HELPER FUNCTIONS
+#################################################################
+
+# Full command string for puppet resource command
+def puppet_resource_cmd
+  cmd = PUPPET_BINPATH +
+        'resource port_channel port-channel100'
+  get_namespace_cmd(agent, cmd, options)
+end
+
+def build_manifest_portchannel(tests, id)
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+    tests[id][:resource] = {}
+  else
+    state = 'ensure => present,'
+    manifest = tests[id][:manifest_props]
+    tests[id][:resource] = tests[id][:resource_props]
+  end
+
+  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+  logger.debug(
+    "build_manifest_portchannel :: title_pattern:\n" +
+             tests[id][:title_pattern])
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  node 'default' {
+    port_channel { 'port-channel100':
+      #{state}
+      #{manifest}
+    }
+  }
+EOF"
+end
+
+def test_harness_portchannel(tests, id)
+  tests[id][:ensure] = :present if tests[id][:ensure].nil?
+  tests[id][:resource_cmd] = puppet_resource_cmd
+  tests[id][:desc] += " [ensure => #{tests[id][:ensure]}]"
+
+  # Build the manifest for this test
+  build_manifest_portchannel(tests, id)
+
+  # test_harness_common(tests, id)
+  test_manifest(tests, id)
+  test_resource(tests, id)
+  test_idempotence(tests, id)
+
+  tests[id][:ensure] = nil
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{testheader}" do
+  # -------------------------------------------------------------------
+  device = platform
+  logger.info("#### This device is of type: #{device} #####")
+  resource_absent_cleanup(agent, 'port_channel',
+                          'Setup switch for port_channel provider test')
+  logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+
+  id = 'default_properties'
+
+  tests[id][:desc] = '1.1 Default Properties'
+  test_harness_portchannel(tests, id)
+
+  tests[id][:desc] = '1.2 Default Properties'
+  tests[id][:ensure] = :absent
+  test_harness_portchannel(tests, id)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
+  id = 'non_default_properties'
+  tests[id][:desc] = '2.1 Non Default Properties'
+  test_harness_portchannel(tests, id)
+
+  tests[id][:desc] = '2.2 Non Default Properties (absent)'
+  tests[id][:ensure] = :absent
+  test_harness_portchannel(tests, id)
+end
+
+logger.info("TestCase :: #{testheader} :: End")


### PR DESCRIPTION
tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb passed in 101.50 seconds
      Test Suite: tests @ 2016-01-29 14:58:44 +0000

      - Host Configuration Summary -

              - Test Case Summary for suite 'tests' -
       Total Suite Time: 101.50 seconds
      Average Test Time: 101.50 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases: