### PR TITLE
Demo Interface manifest fixes

### DIFF
--- a/examples/demo_interface.pp
+++ b/examples/demo_interface.pp
@@ -15,6 +15,26 @@
 # limitations under the License.
 
 class ciscopuppet::demo_interface {
+  cisco_acl { 'ipv4 v4acl1':
+    before => Cisco_interface['Ethernet1/1'],
+    ensure => 'present',
+  }
+
+  cisco_acl { 'ipv4 v4acl2':
+    before => Cisco_interface['Ethernet1/1'],
+    ensure => 'present',
+  }
+
+  cisco_acl { 'ipv6 v6acl1':
+    before => Cisco_interface['Ethernet1/1'],
+    ensure => 'present',
+  }
+
+  cisco_acl { 'ipv6 v6acl2':
+    before => Cisco_interface['Ethernet1/1'],
+    ensure => 'present',
+  }
+
   cisco_interface { 'Ethernet1/1' :
     shutdown                       => true,
     switchport_mode                => disabled,
@@ -42,14 +62,14 @@ class ciscopuppet::demo_interface {
     channel_group   => 200,
   }
 
-  cisco_interface { 'Ethernet1/2':
+  cisco_interface { 'Ethernet1/3':
     description     => 'default',
     shutdown        => 'default',
     access_vlan     => 'default',
     switchport_mode => access,
   }
 
-  cisco_interface { 'Ethernet1/3':
+  cisco_interface { 'Ethernet1/4':
     switchport_mode               => trunk,
     switchport_trunk_allowed_vlan => '20, 30',
     switchport_trunk_native_vlan  => 40,

--- a/examples/demo_interface.pp
+++ b/examples/demo_interface.pp
@@ -45,8 +45,9 @@ class ciscopuppet::demo_interface {
     ipv4_netmask_length_secondary  => 24,
     ipv4_pim_sparse_mode           => false,
     mtu                            => 1600,
-    speed                          => 100,
-    duplex                         => 'full',
+    # Removed because of too many differences between platforms and linecards
+    # speed                          => 100,
+    # duplex                         => 'full',
     vrf                            => 'test',
     ipv4_acl_in                    => 'v4acl1',
     ipv4_acl_out                   => 'v4acl2',
@@ -83,8 +84,9 @@ class ciscopuppet::demo_interface {
 
   network_interface { 'ethernet1/9':
     description => 'default',
-    duplex      => 'auto',
-    speed       => '100m',
+    # Removed because of too many differences between platforms and linecards
+    # duplex      => 'auto',
+    # speed       => '100m',
   }
   #  Requires F3 or newer linecards
   # cisco_interface { 'Ethernet9/1':


### PR DESCRIPTION
### Fixes

* Create acl dependencies before setting `ip_acl` properties
* Removed `speed` and `duplex` from demo manifest due to too many differences between platforms and linecards
* Use different interfaces for `channel_group` and `switchport mode access` testing

### Testing

* 3k - passes
* 5k - **Needs testing**
* 6k - **Needs testing**
* 7k - passes
* 9k - passes