### PR TITLE
beaker interface and aaa fixes

### DIFF
--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -76,8 +76,13 @@ class ciscopuppet::cisco::demo_interface {
     switchport_trunk_native_vlan  => 40,
   }
 
+  $svi_autostate = platform_get() ? {
+    /(n5k|n6k)/  => undef,
+    default      => false
+  }
+
   cisco_interface { 'Vlan22':
-    svi_autostate    => false,
+    svi_autostate    => $svi_autostate,
     svi_management   => true,
     ipv4_arp_timeout => 300,
   }

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -63,6 +63,12 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Defaults'
 
+# Check platform type and skip if necessary.
+unless /n(3|9)k/.match(platform)
+  msg = "Test not supported on this platform: #{platform}"
+  prereq_skip(testheader, self, msg)
+end
+
 # @test_name [TestCase] Executes defaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -61,6 +61,12 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Negatives'
 
+# Check platform type and skip if necessary.
+unless /n(3|9)k/.match(platform)
+  msg = "Test not supported on this platform: #{platform}"
+  prereq_skip(testheader, self, msg)
+end
+
 # @test_name [TestCase] Executes negatives testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -63,6 +63,12 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes NonDefaults'
 
+# Check platform type and skip if necessary.
+unless /n(3|9)k/.match(platform)
+  msg = "Test not supported on this platform: #{platform}"
+  prereq_skip(testheader, self, msg)
+end
+
 # @test_name [TestCase] Executes nondefaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -276,12 +276,10 @@ tests['SVI_default'] = {
   desc:           '4.1 (SVI) Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_autostate:  'default',
-    svi_management: 'default',
+    svi_management: 'default'
   },
   resource:       {
-    'svi_autostate'  => 'true',
-    'svi_management' => 'false',
+    'svi_management' => 'false'
   },
 }
 
@@ -289,12 +287,34 @@ tests['SVI'] = {
   desc:           '4.2 (SVI) Non Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_autostate:  'false',
-    svi_management: 'true',
+    svi_management: 'true'
   },
   resource:       {
-    'svi_autostate'  => 'false',
-    'svi_management' => 'true',
+    'svi_management' => 'true'
+  },
+}
+
+tests['SVI_autostate_default'] = {
+  desc:           '4.3 (SVI) Default SVI Autostate Property',
+  platform:       'n(3|7|9)k',
+  intf_type:      'vlan',
+  manifest_props: {
+    svi_autostate: 'default'
+  },
+  resource:       {
+    'svi_autostate' => 'true'
+  },
+}
+
+tests['SVI_autostate'] = {
+  desc:           '4.4 (SVI) Non Default SVI Autostate Property',
+  platform:       'n(3|7|9)k',
+  intf_type:      'vlan',
+  manifest_props: {
+    svi_autostate: 'false'
+  },
+  resource:       {
+    'svi_autostate' => 'false'
   },
 }
 
@@ -306,10 +326,10 @@ tests['negotiate'] = {
   sys_def_switchport: false,
   manifest_props:     {
     switchport_mode: 'disabled',
-    negotiate_auto:  'false',
+    # negotiate_auto:  'false',, # TBD: Needs plat awareness
   },
   resource:           {
-    'negotiate_auto' => 'false'
+    # 'negotiate_auto' => 'false'
   },
 }
 
@@ -429,6 +449,7 @@ def test_harness_interface(tests, id)
 
   # Set up system default switchport
   sys_def_switchport?(tests, id)
+  sys_def_switchport_shutdown?(tests, id)
 
   # Set up ACL
   acl?(tests, id)
@@ -467,6 +488,8 @@ test_name "TestCase :: #{testheader}" do
   interface_cleanup(agent, tests[:svi_name])
   test_harness_interface(tests, 'SVI_default')
   test_harness_interface(tests, 'SVI')
+  test_harness_interface(tests, 'SVI_autostate_default')
+  test_harness_interface(tests, 'SVI_autostate')
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 5. MISC Property Testing")


### PR DESCRIPTION
Several updates here.

- Skip svi_autostate test in demo_manifest and beaker tests on `n(5|6)k` platforms. Not supported.
- Skip `tests/beaker_tests/cisco_aaa_group_tacacs` on `n(5|6|7)k` platforms.  Not supported in `release_1.2.0`
- Added missing call to `sys_def_switchport_shutdown?` method inside the test_harness in the interface beaker tests.

**N6K Tests**
```
Beaker::Hypervisor, found some none boxes to create
No tests to run for suite 'pre_suite'
Begin cisco_interface/./test_interface.rb

TestCase :: Resource cisco_interface

------------------------------------------------------------
Section 1. (L3) Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
1.1 (L3) Default Properties [ensure => present]

  * TestStep :: 1.1 (L3) Default Properties [ensure => present] :: MANIFEST    
1.1 (L3) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: RESOURCE    
1.1 (L3) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: IDEMPOTENCE 
1.1 (L3) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1.1

--------
1.2 (L3) Sub-interface [ensure => present]

  * TestStep :: 1.2 (L3) Sub-interface [ensure => present] :: MANIFEST    
1.2 (L3) Sub-interface [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: RESOURCE    
1.2 (L3) Sub-interface :: RESOURCE     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: IDEMPOTENCE 
1.2 (L3) Sub-interface :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
1.3 (L3) Misc Properties [ensure => present]

  * TestStep :: 1.3 (L3) Misc Properties [ensure => present] :: MANIFEST    
1.3 (L3) Misc Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: RESOURCE    
1.3 (L3) Misc Properties :: RESOURCE     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: IDEMPOTENCE 
1.3 (L3) Misc Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_out' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_out' ensure=present

--------
1.4 (L3) ACL Properties [ensure => present]

  * TestStep :: 1.4 (L3) ACL Properties [ensure => present] :: MANIFEST    
1.4 (L3) ACL Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: RESOURCE    
1.4 (L3) ACL Properties :: RESOURCE     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: IDEMPOTENCE 
1.4 (L3) ACL Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. (L2) Access Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

 system default switchport

  * TestStep :: system default switchport shutdown

 system default switchport shutdown

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
2.1 (L2) Access Default [ensure => present]

  * TestStep :: 2.1 (L2) Access Default [ensure => present] :: MANIFEST    
2.1 (L2) Access Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: RESOURCE    
2.1 (L2) Access Default :: RESOURCE     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: IDEMPOTENCE 
2.1 (L2) Access Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
2.2 (L2) Access Properties [ensure => present]

  * TestStep :: 2.2 (L2) Access Properties [ensure => present] :: MANIFEST    
2.2 (L2) Access Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: RESOURCE    
2.2 (L2) Access Properties :: RESOURCE     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: IDEMPOTENCE 
2.2 (L2) Access Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. (L2) Trunk Property Testing

Using interface: ethernet1/1

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
3.1 (L2) Trunk Default [ensure => present]

  * TestStep :: 3.1 (L2) Trunk Default [ensure => present] :: MANIFEST    
3.1 (L2) Trunk Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: RESOURCE    
3.1 (L2) Trunk Default :: RESOURCE     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: IDEMPOTENCE 
3.1 (L2) Trunk Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
3.2 (L2) Trunk [ensure => present]

  * TestStep :: 3.2 (L2) Trunk [ensure => present] :: MANIFEST    
3.2 (L2) Trunk [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: RESOURCE    
3.2 (L2) Trunk :: RESOURCE     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: IDEMPOTENCE 
3.2 (L2) Trunk :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 4. (SVI) Property Testing

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'vlan13' to default state

Using interface: vlan13

--------
4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST    
4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE    
4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE 
4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST    
4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE    
4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE 
4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS
4.3 (SVI) Default SVI Autostate Property :: SVI_autostate_default :: SKIP
Platform type does not match testcase platform regexp: /n(3|7|9)k/
4.4 (SVI) Non Default SVI Autostate Property :: SVI_autostate :: SKIP
Platform type does not match testcase platform regexp: /n(3|7|9)k/

------------------------------------------------------------
Section 5. MISC Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
5.1 negotiate-auto [ensure => present]

  * TestStep :: 5.1 negotiate-auto [ensure => present] :: MANIFEST    
5.1 negotiate-auto [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 5.1 negotiate-auto :: RESOURCE    
5.1 negotiate-auto :: RESOURCE     :: PASS

  * TestStep :: 5.1 negotiate-auto :: IDEMPOTENCE 
5.1 negotiate-auto :: IDEMPOTENCE  :: PASS

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

------------------------------------------------------------
  SKIPPED TESTS SUMMARY
------------------------------------------------------------
4.3 (SVI) Default SVI Autostate Property :: SKIP
4.4 (SVI) Non Default SVI Autostate Property :: SKIP


TestCase :: Resource cisco_interface :: SKIP
Begin cisco_interface/./test_vlan_mapping.rb

TestCase :: Resource cisco_interface: vlan_mapping properties

------------------------------------------------------------
Section 0. Testbed Initialization

  * Check for Compatible Line Module
** PLATFORM PREREQUISITE NOT MET: MT-full tests require f3 or compatible line module


TestCase :: Resource cisco_interface: vlan_mapping properties :: SKIP
      Test Suite: tests @ 2016-02-03 07:56:44 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 629.87 seconds
      Average Test Time: 314.93 seconds
              Attempted: 2
                 Passed: 0
                 Failed: 0
                Errored: 0
                Skipped: 2
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case cisco_interface/./test_interface.rb skip
  Test Case cisco_interface/./test_vlan_mapping.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to n6k-92.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.

```

**N7K Tests**
```
Beaker::Hypervisor, found some none boxes to create
No tests to run for suite 'pre_suite'
Begin cisco_interface/./test_interface.rb

TestCase :: Resource cisco_interface

------------------------------------------------------------
Section 1. (L3) Property Testing

Using interface: ethernet3/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet3/1' to default state

--------
1.1 (L3) Default Properties [ensure => present]

  * TestStep :: 1.1 (L3) Default Properties [ensure => present] :: MANIFEST    
1.1 (L3) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: RESOURCE    
1.1 (L3) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: IDEMPOTENCE 
1.1 (L3) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet3/1.1

--------
1.2 (L3) Sub-interface [ensure => present]

  * TestStep :: 1.2 (L3) Sub-interface [ensure => present] :: MANIFEST    
1.2 (L3) Sub-interface [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: RESOURCE    
1.2 (L3) Sub-interface :: RESOURCE     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: IDEMPOTENCE 
1.2 (L3) Sub-interface :: IDEMPOTENCE  :: PASS

Using interface: ethernet3/1

--------
1.3 (L3) Misc Properties [ensure => present]

  * TestStep :: 1.3 (L3) Misc Properties [ensure => present] :: MANIFEST    
1.3 (L3) Misc Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: RESOURCE    
1.3 (L3) Misc Properties :: RESOURCE     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: IDEMPOTENCE 
1.3 (L3) Misc Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet3/1

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_out' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_out' ensure=present

--------
1.4 (L3) ACL Properties [ensure => present]

  * TestStep :: 1.4 (L3) ACL Properties [ensure => present] :: MANIFEST    
1.4 (L3) ACL Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: RESOURCE    
1.4 (L3) ACL Properties :: RESOURCE     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: IDEMPOTENCE 
1.4 (L3) ACL Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. (L2) Access Property Testing

Using interface: ethernet3/1

  * TestStep :: system default switchport

 system default switchport

  * TestStep :: system default switchport shutdown

 system default switchport shutdown

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet3/1' to default state

--------
2.1 (L2) Access Default [ensure => present]

  * TestStep :: 2.1 (L2) Access Default [ensure => present] :: MANIFEST    
2.1 (L2) Access Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: RESOURCE    
2.1 (L2) Access Default :: RESOURCE     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: IDEMPOTENCE 
2.1 (L2) Access Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet3/1

--------
2.2 (L2) Access Properties [ensure => present]

  * TestStep :: 2.2 (L2) Access Properties [ensure => present] :: MANIFEST    
2.2 (L2) Access Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: RESOURCE    
2.2 (L2) Access Properties :: RESOURCE     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: IDEMPOTENCE 
2.2 (L2) Access Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. (L2) Trunk Property Testing

Using interface: ethernet3/1

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet3/1' to default state

--------
3.1 (L2) Trunk Default [ensure => present]

  * TestStep :: 3.1 (L2) Trunk Default [ensure => present] :: MANIFEST    
3.1 (L2) Trunk Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: RESOURCE    
3.1 (L2) Trunk Default :: RESOURCE     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: IDEMPOTENCE 
3.1 (L2) Trunk Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet3/1

--------
3.2 (L2) Trunk [ensure => present]

  * TestStep :: 3.2 (L2) Trunk [ensure => present] :: MANIFEST    
3.2 (L2) Trunk [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: RESOURCE    
3.2 (L2) Trunk :: RESOURCE     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: IDEMPOTENCE 
3.2 (L2) Trunk :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 4. (SVI) Property Testing

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'vlan13' to default state

Using interface: vlan13

--------
4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST    
4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE    
4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE 
4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST    
4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE    
4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE 
4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.3 (SVI) Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: RESOURCE    
4.3 (SVI) Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE 
4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.4 (SVI) Non Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE    
4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE 
4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 5. MISC Property Testing

Using interface: ethernet3/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet3/1' to default state

--------
5.1 negotiate-auto [ensure => present]

  * TestStep :: 5.1 negotiate-auto [ensure => present] :: MANIFEST    
5.1 negotiate-auto [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 5.1 negotiate-auto :: RESOURCE    
5.1 negotiate-auto :: RESOURCE     :: PASS

  * TestStep :: 5.1 negotiate-auto :: IDEMPOTENCE 
5.1 negotiate-auto :: IDEMPOTENCE  :: PASS

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet3/1' to default state
TestCase :: Resource cisco_interface :: End
cisco_interface/./test_interface.rb passed in 591.74 seconds
Begin cisco_interface/./test_vlan_mapping.rb

TestCase :: Resource cisco_interface: vlan_mapping properties

------------------------------------------------------------
Section 0. Testbed Initialization

  * Check for Compatible Line Module
** PLATFORM PREREQUISITE NOT MET: MT-full tests require f3 or compatible line module


TestCase :: Resource cisco_interface: vlan_mapping properties :: SKIP
      Test Suite: tests @ 2016-02-03 08:17:08 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 592.10 seconds
      Average Test Time: 296.05 seconds
              Attempted: 2
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 1
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case cisco_interface/./test_vlan_mapping.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to n7k-j.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.
```

**N9K Tests**
```
Beaker::Hypervisor, found some none boxes to create
No tests to run for suite 'pre_suite'
Begin cisco_interface/./test_interface.rb

TestCase :: Resource cisco_interface

------------------------------------------------------------
Section 1. (L3) Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
1.1 (L3) Default Properties [ensure => present]

  * TestStep :: 1.1 (L3) Default Properties [ensure => present] :: MANIFEST    
1.1 (L3) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: RESOURCE    
1.1 (L3) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: IDEMPOTENCE 
1.1 (L3) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1.1

--------
1.2 (L3) Sub-interface [ensure => present]

  * TestStep :: 1.2 (L3) Sub-interface [ensure => present] :: MANIFEST    
1.2 (L3) Sub-interface [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: RESOURCE    
1.2 (L3) Sub-interface :: RESOURCE     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: IDEMPOTENCE 
1.2 (L3) Sub-interface :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
1.3 (L3) Misc Properties [ensure => present]

  * TestStep :: 1.3 (L3) Misc Properties [ensure => present] :: MANIFEST    
1.3 (L3) Misc Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: RESOURCE    
1.3 (L3) Misc Properties :: RESOURCE     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: IDEMPOTENCE 
1.3 (L3) Misc Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_out' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_out' ensure=present

--------
1.4 (L3) ACL Properties [ensure => present]

  * TestStep :: 1.4 (L3) ACL Properties [ensure => present] :: MANIFEST    
1.4 (L3) ACL Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: RESOURCE    
1.4 (L3) ACL Properties :: RESOURCE     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: IDEMPOTENCE 
1.4 (L3) ACL Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. (L2) Access Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

 system default switchport

  * TestStep :: system default switchport shutdown

 system default switchport shutdown

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
2.1 (L2) Access Default [ensure => present]

  * TestStep :: 2.1 (L2) Access Default [ensure => present] :: MANIFEST    
2.1 (L2) Access Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: RESOURCE    
2.1 (L2) Access Default :: RESOURCE     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: IDEMPOTENCE 
2.1 (L2) Access Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
2.2 (L2) Access Properties [ensure => present]

  * TestStep :: 2.2 (L2) Access Properties [ensure => present] :: MANIFEST    
2.2 (L2) Access Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: RESOURCE    
2.2 (L2) Access Properties :: RESOURCE     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: IDEMPOTENCE 
2.2 (L2) Access Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. (L2) Trunk Property Testing

Using interface: ethernet1/1

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
3.1 (L2) Trunk Default [ensure => present]

  * TestStep :: 3.1 (L2) Trunk Default [ensure => present] :: MANIFEST    
3.1 (L2) Trunk Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: RESOURCE    
3.1 (L2) Trunk Default :: RESOURCE     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: IDEMPOTENCE 
3.1 (L2) Trunk Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
3.2 (L2) Trunk [ensure => present]

  * TestStep :: 3.2 (L2) Trunk [ensure => present] :: MANIFEST    
3.2 (L2) Trunk [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: RESOURCE    
3.2 (L2) Trunk :: RESOURCE     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: IDEMPOTENCE 
3.2 (L2) Trunk :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 4. (SVI) Property Testing

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'vlan13' to default state

Using interface: vlan13

--------
4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST    
4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE    
4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE 
4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST    
4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE    
4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE 
4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.3 (SVI) Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: RESOURCE    
4.3 (SVI) Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE 
4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.4 (SVI) Non Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE    
4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE 
4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 5. MISC Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
5.1 negotiate-auto [ensure => present]

  * TestStep :: 5.1 negotiate-auto [ensure => present] :: MANIFEST    
5.1 negotiate-auto [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 5.1 negotiate-auto :: RESOURCE    
5.1 negotiate-auto :: RESOURCE     :: PASS

  * TestStep :: 5.1 negotiate-auto :: IDEMPOTENCE 
5.1 negotiate-auto :: IDEMPOTENCE  :: PASS

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state
TestCase :: Resource cisco_interface :: End
cisco_interface/./test_interface.rb passed in 433.68 seconds
Begin cisco_interface/./test_vlan_mapping.rb

TestCase :: Resource cisco_interface: vlan_mapping properties

------------------------------------------------------------
Section 0. Testbed Initialization

  * Check for Compatible Line Module
** PLATFORM PREREQUISITE NOT MET: MT-full tests require f3 or compatible line module


TestCase :: Resource cisco_interface: vlan_mapping properties :: SKIP
      Test Suite: tests @ 2016-02-03 08:29:06 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 434.02 seconds
      Average Test Time: 217.01 seconds
              Attempted: 2
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 1
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case cisco_interface/./test_vlan_mapping.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to dt-n9k5-1.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.

```