### PR TITLE
Copy relevant git hooks from cisco-network-node-utils

### DIFF
--- a/bin/git/hooks/hook_lib
+++ b/bin/git/hooks/hook_lib
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Shared library for git hooks
+
+# Colors
+DULL=0
+FG_BLACK=30
+FG_RED=31
+FG_GREEN=32
+FG_YELLOW=33
+FG_BLUE=34
+FG_MAGENTA=35
+FG_CYAN=36
+FG_WHITE=37
+FG_NULL=00
+BG_NULL=00
+ESC="["
+RESET="${ESC}0m"
+BOLD="${ESC}1m"
+BLACK="${ESC}${DULL};${FG_BLACK}m"
+RED="${ESC}${DULL};${FG_RED}m"
+GREEN="${ESC}${DULL};${FG_GREEN}m"
+YELLOW="${ESC}${DULL};${FG_YELLOW}m"
+BLUE="${ESC}${DULL};${FG_BLUE}m"
+MAGENTA="${ESC}${DULL};${FG_MAGENTA}m"
+CYAN="${ESC}${DULL};${FG_CYAN}m"
+WHITE="${ESC}${DULL};${FG_WHITE}m"
+
+# Top-level directory of our repository
+export REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+#DEBUG=1
+debug() {
+    [ "$DEBUG" == 1 ] && echo $1
+}
+export -f debug
+
+script_name() {
+    echo -e "*** ${BLUE}Running Git hook script: $*${RESET}..."
+}
+export -f script_name
+
+step_name() {
+    echo -e "\t${BOLD}$*${RESET}"
+}
+export -f step_name
+
+success() {
+    echo -e "\t...[ ${GREEN}OK${RESET} ]"
+}
+export -f success
+
+fail() {
+    local RC=$1
+    local msg=$2
+    echo -e "\t...[ ${RED}FAIL${RESET} ] $msg"
+    exit $RC
+}
+export -f fail
+
+check_rc() {
+    rc=$?
+    [ $rc -eq 0 ] || fail $rc "$*"
+    return $rc
+}
+export -f check_rc
+
+check_rc_optional() {
+    local RC=$?
+    local msg=$1
+    [ $RC -eq 0 ] && return $RC
+    echo -e "\t...[ ${YELLOW}WARNING${RESET} ] $msg"
+    read -p "Continue anyway? [y/N] " yn < /dev/tty
+    case $yn in
+      [Yy]* ) return 0;;
+      [Nn]* ) exit $RC;;
+      * ) exit $RC;;
+    esac
+}
+export -f check_rc_optional
+
+get_last_version() {
+    # Get the first subheading in the CHANGELOG, not counting 'Unreleased'
+    VER=$(grep -v "Unreleased" $REPO_DIR/CHANGELOG.md | egrep -m 1 '## \[.*]' | cut -d ' ' -f 2 | tr -d '[]')
+    echo "Detected previous release version as '$VER'"
+}
+export -f get_last_version
+
+add_changelog_diff_link() {
+    local OLD_VERSION=$1
+    local NEW_VERSION=$2
+
+    step_name "Adding link for diffs $OLD_VERSION..$NEW_VERSION in CHANGELOG.md"
+
+    # Automatically add diff link to the CHANGELOG
+    sed -i "/master...develop/ a\
+[$VERSION]: https://github.com/cisco/cisco-network-node-utils/compare/$OLD_VERSION...$NEW_VERSION" $REPO_DIR/CHANGELOG.md
+}
+export -f add_changelog_diff_link
+
+set_gem_version() {
+    local VERSION=$1
+
+    step_name "Updating version.rb to version '$VERSION'"
+
+    sed -i -e "s/VERSION =.*/VERSION = '$VERSION'/" $REPO_DIR/lib/cisco_node_utils/version.rb
+}
+export -f set_gem_version

--- a/bin/git/hooks/hooks-wrapper
+++ b/bin/git/hooks/hooks-wrapper
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Generic git hook. Calls all associated helper scripts.
+#
+# Based on:
+# http://stackoverflow.com/questions/8730514/chaining-git-hooks
+# https://github.com/henrik/dotfiles/blob/master/git_template/hooks/pre-commit
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+
+. "$GIT_DIR"/hooks/hook_lib
+
+# What hook are we supposed to be?
+hookname=`basename $0`
+
+debug "Running wrapper script for '$hookname'..."
+
+exitcodes=()
+
+# Run each hook, passing through STDIN and storing the exit code.
+# We don't want to bail at the first failure, so the user can see everything.
+
+for hook in "$GIT_DIR"/hooks/$hookname-*; do
+    debug "Checking hook '$hook'"
+    test -x "$hook" || continue
+    script_name "${hook##*/}"
+    "$hook" "$@"
+    rc=$?
+    [ "$rc" == 0 ] && success
+    exitcodes+=($rc)
+done
+
+# If any exit code isn't 0, bail.
+for i in "${exitcodes[@]}"; do
+    [ "$i" == 0 ] || fail $i "One or more hook scripts reported an error"
+done
+debug "Wrapper script executed successfully"
+exit 0

--- a/bin/git/hooks/post-merge/update-hooks
+++ b/bin/git/hooks/post-merge/update-hooks
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+. "$GIT_DIR"/hooks/hook_lib
+
+[ -x "$REPO_DIR"/bin/git/update-hooks ] && "$REPO_DIR"/bin/git/update-hooks

--- a/bin/git/hooks/post-rewrite/update-hooks
+++ b/bin/git/hooks/post-rewrite/update-hooks
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+. "$GIT_DIR"/hooks/hook_lib
+
+[ -x "$REPO_DIR"/bin/git/update-hooks ] && "$REPO_DIR"/bin/git/update-hooks

--- a/bin/git/hooks/pre-commit/rubocop
+++ b/bin/git/hooks/pre-commit/rubocop
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+. "$GIT_DIR"/hooks/hook_lib
+
+# Run the rubocop lint checks (only).
+# We don't enforce a full rubocop run here because we want to let people
+# commit work-in-progress code to their local branch. We will do a full
+# rubocop run of all checks as part of the pre-push hook
+
+step_name "Running RuboCop lint checks"
+rubocop --lint
+check_rc "Please fix RuboCop lint failures before committing."
+
+# Do a full rubocop run to warn the user, but don't block a commit by it.
+step_name "Running all RuboCop checks"
+rubocop
+check_rc_optional "Fix all RuboCop failures before pushing upstream"
+
+exit 0

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+. "$GIT_DIR"/hooks/hook_lib
+
+# What are we diffing this commit against?
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# We exploit the fact that the printable range starts at the space character
+# and ends with tilde.
+# Note that the use of brackets around a tr range is ok here, (it's
+# even required, for portability to Solaris 10's /usr/bin/tr), since
+# the square bracket bytes happen to fall in the designated range.
+git diff --cached --name-only --diff-filter=A -z $against |
+        LC_ALL=C tr -d '[ -~]\0' | wc -c
+check_rc "Rename non-ASCII file name(s) before committing"

--- a/bin/git/hooks/pre-push/rubocop
+++ b/bin/git/hooks/pre-push/rubocop
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+[ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
+. "$GIT_DIR"/hooks/hook_lib
+
+rubocop
+check_rc "Please fix RuboCop failures before pushing code upstream."

--- a/bin/git/update-hooks
+++ b/bin/git/update-hooks
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# Based on:
+# http://stackoverflow.com/questions/3462955/putting-git-hooks-into-repository
+# https://github.com/sjungwirth/githooks
+
+# Where hooks are stored in the repo
+SRC_DIR="$(git rev-parse --show-toplevel)/bin/git/hooks"
+
+# Where hooks need to be installed
+HOOK_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+
+. "$SRC_DIR/hook_lib"
+
+usage() {
+    echo "Usage: update-hooks [OPTION]"
+    echo "Update the hooks in the local git repository to match those"
+    echo "under version control."
+    echo
+    echo "Options:"
+    echo "  --dry-run       Do not make any updates"
+    echo "  -v  --verbose   Verbose output, including diffs of updated files"
+    echo "  --[no-]pager    Explicity request or suppress pagination in git diff"
+    echo "  -h  --help      Display this help text"
+}
+
+# Flags that can be set from the command line, with default values
+make_updates=1  # the inverse of --dry-run
+verbose=0
+pager= # default to whatever defaults git has configured
+
+# parse command line options
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        (-h|--help)
+            usage
+            exit 0
+            ;;
+        (-v|--verbose)
+            verbose=1
+            ;;
+        (--pager)
+            pager=--paginate
+            ;;
+        (--no-pager)
+            pager=--no-pager
+            ;;
+        (--dry-run)
+            make_updates=0
+            ;;
+        (*)
+            echo "Unrecognized option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift 1
+done
+
+
+install_hook_wrapper() {
+    local hook=$1
+    # Does the symlink exist?
+    if [ ! -h $HOOK_DIR/$hook ]; then
+        # If a hook already exists and is a file:
+        if [ -f $HOOK_DIR/$hook ]; then
+            step_name "Moving existing '$hook' script to '$hook-local'"
+            if [ $make_updates == 1 ]; then
+                mv $HOOK_DIR/$hook $HOOK_DIR/$hook-local
+            fi
+        fi
+        # create the symlink to our wrapper script
+        step_name "Installing hook wrapper script for '$hook'"
+        if [ $make_updates == 1 ]; then
+            ln -s -f ./hooks-wrapper $HOOK_DIR/$hook
+        fi
+    fi
+}
+
+check_update() {
+    local src=$1
+    local dest=$2
+    if [ ! -e "$dest" ] ; then
+        step_name "Creating new file at '$dest':"
+        if [ $verbose == 1 ]; then
+            git ${pager} diff --color --no-index /dev/null $src
+        fi
+        if [ $make_updates == 1 ]; then
+            cp $src $dest
+        fi
+    else
+        diff $src $dest >> /dev/null
+        if [ $? -ne 0 ] ; then
+            step_name "File '$dest' will be updated: "
+            if [ $verbose == 1 ]; then
+                git ${pager} diff --color --no-index $dest $src
+            fi
+            if [ $make_updates == 1 ]; then
+                cp -f $src $dest
+            fi
+        fi
+    fi
+}
+
+for item in "$SRC_DIR"/*; do
+    if [ ! -d "$item" ]; then
+        # Not a hook subdirectory, just a library file - update it as needed
+        file="${item##*/}"
+        check_update "$SRC_DIR/$file" "$HOOK_DIR/$file"
+        continue
+    fi
+    # Else it's a hook subdirectory.
+    hook="${item##*/}"
+    # First, make sure we have our hook-wrapper script installed for this hook:
+    install_hook_wrapper "$hook"
+    # Now descend into the subdirectory and update the individual scripts:
+    for file in "$item"/*; do
+        # bin/git/hooks/pre-commit/rubocop --> "pre-commit-rubocop"
+        hook_script="${hook}-${file##*/}"
+        check_update "$file" "$HOOK_DIR/$hook_script"
+    done
+done
+


### PR DESCRIPTION
Copying over some of the most useful git hooks from cisco-network-node-utils. Others can be ported over as needed.