### PR TITLE
vlan beaker fixes

### DIFF
--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
@@ -64,6 +64,21 @@ require File.expand_path('../accessvlanlib.rb', __FILE__)
 result = 'PASS'
 testheader = 'ACCESSVLAN Resource :: All Attributes Defaults'
 
+# Local tests hash and helper method used to dynamically find an available
+# interface for tests that require an interface.
+tests = { intf_type: 'ethernet', agent: agent, testheader: testheader }
+def find_ospf_interface(tests)
+  if tests[:ethernet]
+    intf = tests[:ethernet]
+  else
+    intf = find_interface(tests)
+    # cache for later tests
+    tests[:ethernet] = intf
+  end
+  intf
+end
+int = find_ospf_interface(tests)
+
 # @test_name [TestCase] Executes defaults testcase for ACCESSVLAN Resource.
 test_name "TestCase :: #{testheader}" do
   resource_absent_cleanup(agent, 'cisco_vlan', 'VLAN CLEAN :: ')
@@ -71,7 +86,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_absent)
+    on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
@@ -79,21 +94,13 @@ test_name "TestCase :: #{testheader}" do
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [%r{interface Ethernet1/4}],
-                               false, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_present)
+    on(master, AccessVlanLib.create_accessvlan_manifest_present(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -108,14 +115,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface 'ethernet1/4'", options)
+      "resource cisco_interface '#{int}'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
                                  'access_vlan'                  => '128',
                                  'ipv4_proxy_arp'               => 'false',
                                  'ipv4_redirects'               => 'true',
-                                 'negotiate_auto'               => 'true',
+                                 # 'negotiate_auto'               => 'true', # TBD: Needs plat awareness
                                  'shutdown'                     => 'false',
                                  'switchport_autostate_exclude' => 'false',
                                  'switchport_mode'              => 'access',
@@ -126,24 +133,10 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_interface resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks interface instance on agent using switch show cli cmds.
-  step 'TestStep :: Check interface instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/switchport access vlan 128/],
-                               false, self, logger)
-    end
-
-    logger.info("Check interface instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_absent)
+    on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -159,14 +152,14 @@ test_name "TestCase :: #{testheader}" do
     # Presence of AccessVLAN 1 implies absence of AccessVLAN 128.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface 'ethernet1/4'", options)
+      "resource cisco_interface '#{int}'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
                                  'access_vlan'                  => '1',
                                  'ipv4_proxy_arp'               => 'false',
                                  'ipv4_redirects'               => 'true',
-                                 'negotiate_auto'               => 'true',
+                                 # 'negotiate_auto'               => 'true', # TBD: Needs plat awareness
                                  'shutdown'                     => 'false',
                                  'switchport_autostate_exclude' => 'false',
                                  'switchport_mode'              => 'access',
@@ -175,20 +168,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_interface resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks interface instance on agent using switch show cli cmds.
-  step 'TestStep :: Check interface instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/switchport access vlan 128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check interface instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
@@ -64,6 +64,21 @@ require File.expand_path('../accessvlanlib.rb', __FILE__)
 result = 'PASS'
 testheader = 'ACCESSVLAN Resource :: All Attributes NonDefaults'
 
+# Local tests hash and helper method used to dynamically find an available
+# interface for tests that require an interface.
+tests = { intf_type: 'ethernet', agent: agent, testheader: testheader }
+def find_ospf_interface(tests)
+  if tests[:ethernet]
+    intf = tests[:ethernet]
+  else
+    intf = find_interface(tests)
+    # cache for later tests
+    tests[:ethernet] = intf
+  end
+  intf
+end
+int = find_ospf_interface(tests)
+
 # @test_name [TestCase] Executes nondefaults testcase for ACCESSVLAN Resource.
 test_name "TestCase :: #{testheader}" do
   resource_absent_cleanup(agent, 'cisco_vlan', 'VLAN CLEAN :: ')
@@ -71,7 +86,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_absent)
+    on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
@@ -79,21 +94,13 @@ test_name "TestCase :: #{testheader}" do
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [%r{interface Ethernet1/4}],
-                               false, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource nondefaults manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_nondefaults)
+    on(master, AccessVlanLib.create_accessvlan_manifest_nondefaults(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -108,14 +115,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface 'ethernet1/4'", options)
+      "resource cisco_interface '#{int}'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
                                  'access_vlan'                  => '128',
                                  'ipv4_proxy_arp'               => 'false',
                                  'ipv4_redirects'               => 'true',
-                                 'negotiate_auto'               => 'true',
+                                 # 'negotiate_auto'               => 'true', # TBD: Needs plat awareness
                                  'shutdown'                     => 'true',
                                  'switchport_autostate_exclude' => 'false',
                                  'switchport_mode'              => 'access',
@@ -126,24 +133,10 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_interface resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks interface instance on agent using switch show cli cmds.
-  step 'TestStep :: Check interface instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/switchport access vlan 128/],
-                               false, self, logger)
-    end
-
-    logger.info("Check interface instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, AccessVlanLib.create_accessvlan_manifest_absent)
+    on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
@@ -159,14 +152,14 @@ test_name "TestCase :: #{testheader}" do
     # Presence of AccessVLAN 1 implies absence of AccessVLAN 128.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface 'ethernet1/4'", options)
+      "resource cisco_interface '#{int}'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
                                  'access_vlan'                  => '1',
                                  'ipv4_proxy_arp'               => 'false',
                                  'ipv4_redirects'               => 'true',
-                                 'negotiate_auto'               => 'true',
+                                 # 'negotiate_auto'               => 'true', # TBD: Needs plat awareness
                                  'shutdown'                     => 'false',
                                  'switchport_autostate_exclude' => 'false',
                                  'switchport_mode'              => 'access',
@@ -175,20 +168,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_interface resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks interface instance on agent using switch show cli cmds.
-  step 'TestStep :: Check interface instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config interface eth1/4')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/switchport access vlan 128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check interface instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/accessvlanlib.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlanlib.rb
@@ -48,7 +48,7 @@ module AccessVlanLib
   # 'ensure' is set to present.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_present
+  def self.create_accessvlan_manifest_present(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
@@ -56,13 +56,13 @@ node default {
       shutdown                     => 'default',
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       description                  => 'default',
       ipv4_proxy_arp               => 'default',
       ipv4_redirects               => 'default',
-      negotiate_auto               => 'default',
+      #negotiate_auto               => 'default', # TBD: Needs plat awareness
       shutdown                     => 'default',
       switchport_autostate_exclude => 'default',
       switchport_mode              => 'access',
@@ -77,19 +77,19 @@ EOF"
   # 'ensure' is set to absent.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_absent
+  def self.create_accessvlan_manifest_absent(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => absent,
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '1',
       description                  => 'default',
       ipv4_proxy_arp               => 'default',
       ipv4_redirects               => 'default',
-      negotiate_auto               => 'default',
+      #negotiate_auto               => 'default', # TBD: Needs plat awareness
       shutdown                     => 'default',
       switchport_autostate_exclude => 'default',
       switchport_mode              => 'access',
@@ -106,7 +106,7 @@ EOF"
   # and switchport_vtp.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_nondefaults
+  def self.create_accessvlan_manifest_nondefaults(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
@@ -114,13 +114,13 @@ node default {
       shutdown                     => 'default',
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       description                  => 'Configured with puppet',
       ipv4_proxy_arp               => 'default',
       ipv4_redirects               => 'default',
-      negotiate_auto               => 'default',
+      #negotiate_auto               => 'default', # TBD: Needs plat awareness
       shutdown                     => 'true',
       switchport_autostate_exclude => 'default',
       switchport_mode              => 'access',
@@ -134,14 +134,14 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'ipv4_proxy_arp'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_ipv4proxyarp_negative
+  def self.create_accessvlan_manifest_ipv4proxyarp_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       ipv4_proxy_arp               => #{AccessVlanLib::IPV4PROXYARP_NEGATIVE},
@@ -154,14 +154,14 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'ipv4_redirects'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_ipv4redir_negative
+  def self.create_accessvlan_manifest_ipv4redir_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       ipv4_redirects               => #{AccessVlanLib::IPV4REDIRECTS_NEGATIVE},
@@ -174,17 +174,17 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'negotiate_auto'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_negoauto_negative
+  def self.create_accessvlan_manifest_negoauto_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
-      negotiate_auto               => #{AccessVlanLib::NEGOTIATEAUTO_NEGATIVE},
+      #negotiate_auto               => #{AccessVlanLib::NEGOTIATEAUTO_NEGATIVE}, # TBD: Needs plat awareness
     }
 }
 EOF"
@@ -194,14 +194,14 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'shutdown'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_shutdown_negative
+  def self.create_accessvlan_manifest_shutdown_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       shutdown                     => #{AccessVlanLib::SHUTDOWN_NEGATIVE},
@@ -214,14 +214,14 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'autostate'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_autostate_negative
+  def self.create_accessvlan_manifest_autostate_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       switchport_autostate_exclude => #{AccessVlanLib::AUTOSTATE_NEGATIVE},
@@ -234,14 +234,14 @@ EOF"
   # Method to create a manifest for AccessVLAN resource attribute 'switchport_vtp'.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_accessvlan_manifest_vtp_negative
+  def self.create_accessvlan_manifest_vtp_negative(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     cisco_vlan { '128':
       ensure                       => present,
       state                        => 'default',
     }
-    cisco_interface { 'ethernet1/4':
+    cisco_interface { '#{intf}':
       ensure                       => present,
       access_vlan                  => '128',
       switchport_vtp               => #{AccessVlanLib::SWITCHPORTVTP_NEGATIVE},

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
@@ -109,19 +109,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)2400/],
-                               false, self, logger)
-    end
-
-    logger.info("Check vlan instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -151,19 +138,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)2400/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_negatives.rb
@@ -104,19 +104,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)2400/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -145,19 +132,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)2400/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -184,19 +158,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)2400/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
@@ -110,20 +110,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/vlan 2400/, /name DESCR-VLAN2400/],
-                               false, self, logger)
-    end
-
-    logger.info("Check vlan instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -153,20 +139,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/vlan 2400/, /name DESCR-VLAN2400/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
@@ -109,19 +109,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)128/],
-                               false, self, logger)
-    end
-
-    logger.info("Check vlan instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -151,19 +138,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_negatives.rb
@@ -104,19 +104,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -145,19 +132,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -184,19 +158,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan 1,(.*)128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
@@ -110,20 +110,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_vlan resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/vlan 128/, /name DESCR-VLAN0128/],
-                               false, self, logger)
-    end
-
-    logger.info("Check vlan instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -153,20 +139,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_vlan resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check vlan instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/vlan 128/, /name DESCR-VLAN0128/],
-                               true, self, logger)
-    end
-
-    logger.info("Check vlan instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.


### PR DESCRIPTION
Beaker fixes for vlan beaker tests to run on all Nexus platforms.

- Adds dynamic interface lookup rather then using hard coded int names.
- Removes vsh command calls.

**Tests pass on n(5|7|9)k**
- There is one failure but it's a bug on the n5/6k.