### PR TITLE
Fix cisco_acl failure due to wrong expectations

### DIFF
--- a/tests/beaker_tests/cisco_acl/test_acl.rb
+++ b/tests/beaker_tests/cisco_acl/test_acl.rb
@@ -109,8 +109,7 @@ tests['default_properties_ipv4'] = {
     fragments                        => 'default',
   ",
   resource_props: {
-    'stats_per_entry' => 'false',
-    'fragments'       => '',
+    'stats_per_entry' => 'false'
   },
 }
 
@@ -121,8 +120,7 @@ tests['default_properties_ipv6'] = {
     fragments                        => 'default',
   ",
   resource_props: {
-    'stats_per_entry' => 'false',
-    'fragments'       => '',
+    'stats_per_entry' => 'false'
   },
 }
 
@@ -160,8 +158,7 @@ tests['title_patterns_afi_only'] = {
     acl_name                         => 'beaker_afi_only',
   ",
   resource_props:        {
-    'stats_per_entry' => 'false',
-    'fragments'       => '',
+    'stats_per_entry' => 'false'
   },
 }
 
@@ -175,8 +172,7 @@ tests['title_patterns_acl_name_only'] = {
     afi                              => 'ipv4',
   ",
   resource_props:        {
-    'stats_per_entry' => 'false',
-    'fragments'       => '',
+    'stats_per_entry' => 'false'
   },
 }
 
@@ -233,6 +229,8 @@ end
 test_name "TestCase :: #{testheader}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+  resource_absent_cleanup(agent, 'cisco_acl',
+                          'Setup switch for cisco_acl provider test')
   # node_feature_cleanup(agent, 'acl')
 
   # -----------------------------------


### PR DESCRIPTION
test_acl was failing because it was expecting `puppet resource cisco_acl` to report `fragments => ''` in the default-value tests, but `fragments` defaults to `nil` and not to `''`.

```
Begin tests/beaker_tests/cisco_acl/test_acl.rb

TestCase :: Resource cisco_acl
  
  ------------------------------------------------------------
  Section 1. Default Property Testing
  
  * 
  --------
   * TestStep :: Setup switch for cisco_acl provider test
      * Setup switch for cisco_acl provider test Removing cisco_acl 'ipv4 beaker_1'
  
  --------
  1.1 Default Properties [ensure => present] [ensure => present]
  
  * TestStep :: 1.1 Default Properties [ensure => present] [ensure => present] :: MANIFEST    
  1.1 Default Properties [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 1.1 Default Properties [ensure => present] :: RESOURCE    
    1.1 Default Properties [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 1.1 Default Properties [ensure => present] :: IDEMPOTENCE 
    1.1 Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  1.2 Default Properties [ensure => absent] [ensure => absent]
  
  * TestStep :: 1.2 Default Properties [ensure => absent] [ensure => absent] :: MANIFEST    
  1.2 Default Properties [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 1.2 Default Properties [ensure => absent] :: RESOURCE    
    1.2 Default Properties [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 1.2 Default Properties [ensure => absent] :: IDEMPOTENCE 
    1.2 Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  --------
  1.3 Default Properties [ensure => present] [ensure => present]
  
  * TestStep :: 1.3 Default Properties [ensure => present] [ensure => present] :: MANIFEST    
  1.3 Default Properties [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 1.3 Default Properties [ensure => present] :: RESOURCE    
    1.3 Default Properties [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 1.3 Default Properties [ensure => present] :: IDEMPOTENCE 
    1.3 Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  1.4 Default Properties [ensure => absent] [ensure => absent]
  
  * TestStep :: 1.4 Default Properties [ensure => absent] [ensure => absent] :: MANIFEST    
  1.4 Default Properties [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 1.4 Default Properties [ensure => absent] :: RESOURCE    
    1.4 Default Properties [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 1.4 Default Properties [ensure => absent] :: IDEMPOTENCE 
    1.4 Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  ------------------------------------------------------------
  Section 2. Non Default Property Testing
  
  --------
  2.1 Non Default Properties [ensure => present] [ensure => present]
  
  * TestStep :: 2.1 Non Default Properties [ensure => present] [ensure => present] :: MANIFEST    
  2.1 Non Default Properties [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 2.1 Non Default Properties [ensure => present] :: RESOURCE    
    2.1 Non Default Properties [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 2.1 Non Default Properties [ensure => present] :: IDEMPOTENCE 
    2.1 Non Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  2.2 Non Default Properties [ensure => absent] [ensure => absent]
  
  * TestStep :: 2.2 Non Default Properties [ensure => absent] [ensure => absent] :: MANIFEST    
  2.2 Non Default Properties [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 2.2 Non Default Properties [ensure => absent] :: RESOURCE    
    2.2 Non Default Properties [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 2.2 Non Default Properties [ensure => absent] :: IDEMPOTENCE 
    2.2 Non Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  --------
  2.3 Non Default Properties [ensure => present] [ensure => present]
  
  * TestStep :: 2.3 Non Default Properties [ensure => present] [ensure => present] :: MANIFEST    
  2.3 Non Default Properties [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 2.3 Non Default Properties [ensure => present] :: RESOURCE    
    2.3 Non Default Properties [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 2.3 Non Default Properties [ensure => present] :: IDEMPOTENCE 
    2.3 Non Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  2.4 Non Default Properties [ensure => absent] [ensure => absent]
  
  * TestStep :: 2.4 Non Default Properties [ensure => absent] [ensure => absent] :: MANIFEST    
  2.4 Non Default Properties [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 2.4 Non Default Properties [ensure => absent] :: RESOURCE    
    2.4 Non Default Properties [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 2.4 Non Default Properties [ensure => absent] :: IDEMPOTENCE 
    2.4 Non Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  --------
  3.1 Title Patterns [ensure => present] [ensure => present]
  
  * TestStep :: 3.1 Title Patterns [ensure => present] [ensure => present] :: MANIFEST    
  3.1 Title Patterns [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 3.1 Title Patterns [ensure => present] :: RESOURCE    
    3.1 Title Patterns [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 3.1 Title Patterns [ensure => present] :: IDEMPOTENCE 
    3.1 Title Patterns [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  3.2 Title Patterns [ensure => absent] [ensure => absent]
  
  * TestStep :: 3.2 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST    
  3.2 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 3.2 Title Patterns [ensure => absent] :: RESOURCE    
    3.2 Title Patterns [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 3.2 Title Patterns [ensure => absent] :: IDEMPOTENCE 
    3.2 Title Patterns [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  --------
  3.3 Title Patterns [ensure => present] [ensure => present]
  
  * TestStep :: 3.3 Title Patterns [ensure => present] [ensure => present] :: MANIFEST    
  3.3 Title Patterns [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 3.3 Title Patterns [ensure => present] :: RESOURCE    
    3.3 Title Patterns [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 3.3 Title Patterns [ensure => present] :: IDEMPOTENCE 
    3.3 Title Patterns [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  3.4 Title Patterns [ensure => absent] [ensure => absent]
  
  * TestStep :: 3.4 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST    
  3.4 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 3.4 Title Patterns [ensure => absent] :: RESOURCE    
    3.4 Title Patterns [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 3.4 Title Patterns [ensure => absent] :: IDEMPOTENCE 
    3.4 Title Patterns [ensure => absent] :: IDEMPOTENCE  :: PASS
  
  --------
  3.5 Title Patterns [ensure => present] [ensure => present]
  
  * TestStep :: 3.5 Title Patterns [ensure => present] [ensure => present] :: MANIFEST    
  3.5 Title Patterns [ensure => present] [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 3.5 Title Patterns [ensure => present] :: RESOURCE    
    3.5 Title Patterns [ensure => present] :: RESOURCE     :: PASS
  
  * TestStep :: 3.5 Title Patterns [ensure => present] :: IDEMPOTENCE 
    3.5 Title Patterns [ensure => present] :: IDEMPOTENCE  :: PASS
  
  --------
  3.6 Title Patterns [ensure => absent] [ensure => absent]
  
  * TestStep :: 3.6 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST    
  3.6 Title Patterns [ensure => absent] [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 3.6 Title Patterns [ensure => absent] :: RESOURCE    
    3.6 Title Patterns [ensure => absent] :: RESOURCE     :: PASS
  
  * TestStep :: 3.6 Title Patterns [ensure => absent] :: IDEMPOTENCE 
    3.6 Title Patterns [ensure => absent] :: IDEMPOTENCE  :: PASS
TestCase :: # {testheader} :: End
tests/beaker_tests/cisco_acl/test_acl.rb passed in 233.92 seconds
      Test Suite: tests @ 2016-02-09 13:16:56 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 233.92 seconds
      Average Test Time: 233.92 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1
```