### PR TITLE
vdc and vxlan fixes

### DIFF
--- a/lib/puppet/provider/cisco_vxlan_vtep_vni/nxapi.rb
+++ b/lib/puppet/provider/cisco_vxlan_vtep_vni/nxapi.rb
@@ -108,7 +108,7 @@ Puppet::Type.type(:cisco_vxlan_vtep_vni).provide(:nxapi) do
     resources.keys.each do |id|
       provider = vnis.find do |vni|
         vni.interface.to_s == resources[id][:interface].to_s &&
-        vni.vni == resources[id][:vni] &&
+        vni.vni.to_s == resources[id][:vni].to_s &&
         vni.assoc_vrf.to_s == resources[id][:assoc_vrf].to_s
       end
       resources[id].provider = provider unless provider.nil?

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -131,6 +131,7 @@ end
 #################################################################
 test_name "TestCase :: #{testheader}" do
   # Pre-test Cleanup
+  raise_skip_exception('ONLY SUPPORTED ON N7K', self) unless platform == 'n7k'
   limit_resource_module_type_set(default_vdc_name, nil, true)
 
   # -------------------------------------------------------------------

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -70,8 +70,9 @@ testheader = 'Resource cisco_vxlan_vtep'
 # tests[:agent] - the agent object
 #
 tests = {
-  master: master,
-  agent:  agent,
+  master:   master,
+  agent:    agent,
+  platform: 'n9k',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:
@@ -192,6 +193,8 @@ EOF"
 end
 
 def test_harness_cisco_vxlan_vtep(tests, id)
+  return unless platform_supports_test(tests, id)
+
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
   tests[id][:resource_cmd] = puppet_resource_cmd
   tests[id][:desc] += " [ensure => #{tests[id][:ensure]}]"

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -72,7 +72,7 @@ testheader = 'Resource cisco_vxlan_vtep_vni'
 tests = {
   master:   master,
   agent:    agent,
-  platform: 'n(3|9)k',
+  platform: 'n9k',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:
@@ -270,6 +270,8 @@ EOF"
 end
 
 def test_harness_cisco_vxlan_vtep_vni(tests, id)
+  return unless platform_supports_test(tests, id)
+
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
   tests[id][:resource_cmd] = puppet_resource_cmd
   tests[id][:desc] += " [ensure => #{tests[id][:ensure]}]"


### PR DESCRIPTION
Summary of fixes:

- Fixes issue where `vxlan_vtep_vni` resource created a new resource when the resource was already present on the device.
- Skip vdc beaker tests on unsupported platforms.
- Added `n9k` platform support key to `vxlan_vtep*` beaker tests.

**VXLAN TESTS 9K**
```
Begin ./cisco_vxlan_vtep/./test_vxlan_vtep.rb

TestCase :: Resource cisco_vxlan_vtep

------------------------------------------------------------
Section 1. Default Property Testing

  * 
--------
 * TestStep :: Setup switch for cisco_vxlan_vtep provider test

  * TestStep :: 1.1 Default Properties [ensure => present] :: MANIFEST    
1.1 Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 Default Properties [ensure => present] :: RESOURCE    
1.1 Default Properties [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 1.1 Default Properties [ensure => present] :: IDEMPOTENCE 
1.1 Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 1.2 Default Properties [ensure => absent] :: MANIFEST    
1.2 Default Properties [ensure => absent] :: MANIFEST     :: PASS

  * TestStep :: 1.2 Default Properties [ensure => absent] :: RESOURCE    
1.2 Default Properties [ensure => absent] :: RESOURCE     :: PASS

  * TestStep :: 1.2 Default Properties [ensure => absent] :: IDEMPOTENCE 
1.2 Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. Non Default Property Testing

  * TestStep :: 2.1 Non-Default Properties [ensure => present] :: MANIFEST    
2.1 Non-Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 Non-Default Properties [ensure => present] :: RESOURCE    
2.1 Non-Default Properties [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.1 Non-Default Properties [ensure => present] :: IDEMPOTENCE 
2.1 Non-Default Properties [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.2 Non-Default Properties [ensure => absent] :: MANIFEST    
2.2 Non-Default Properties [ensure => absent] :: MANIFEST     :: PASS

  * TestStep :: 2.2 Non-Default Properties [ensure => absent] :: RESOURCE    
2.2 Non-Default Properties [ensure => absent] :: RESOURCE     :: PASS

  * TestStep :: 2.2 Non-Default Properties [ensure => absent] :: IDEMPOTENCE 
2.2 Non-Default Properties [ensure => absent] :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. Property Changes

  * TestStep :: 3.1 Setup [ensure => present] :: MANIFEST    
3.1 Setup [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 Setup [ensure => present] :: RESOURCE    
3.1 Setup [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 3.1 Setup [ensure => present] :: IDEMPOTENCE 
3.1 Setup [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 3.1 Change host_reach, shutdown state, source int [ensure => present] :: MANIFEST    
3.1 Change host_reach, shutdown state, source int [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 Change host_reach, shutdown state, source int [ensure => present] :: RESOURCE    
3.1 Change host_reach, shutdown state, source int [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 3.1 Change host_reach, shutdown state, source int [ensure => present] :: IDEMPOTENCE 
3.1 Change host_reach, shutdown state, source int [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 3.1 Change source_interface, shutdown state: true [ensure => present] :: MANIFEST    
3.1 Change source_interface, shutdown state: true [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 Change source_interface, shutdown state: true [ensure => present] :: RESOURCE    
3.1 Change source_interface, shutdown state: true [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 3.1 Change source_interface, shutdown state: true [ensure => present] :: IDEMPOTENCE 
3.1 Change source_interface, shutdown state: true [ensure => present] :: IDEMPOTENCE  :: PASS

  * 
--------
 * TestStep :: Setup switch for cisco_vxlan_vtep provider test
  * Setup switch for cisco_vxlan_vtep provider test Removing cisco_vxlan_vtep 'nve1'
TestCase :: # {testheader} :: End
./cisco_vxlan_vtep/./test_vxlan_vtep.rb passed in 156.62 seconds
      Test Suite: tests @ 2016-02-10 01:23:46 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 156.61 seconds
      Average Test Time: 156.61 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to dt-n9k5-1.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.


Begin ./cisco_vxlan_vtep_vni/./test_vxlan_vtep_vni.rb

TestCase :: Resource cisco_vxlan_vtep_vni

  * 
--------
 * TestStep :: Setup switch for cisco_vxlan_vtep_vni provider test

------------------------------------------------------------
Section 1. Default Property Testing

  * TestStep :: 1.1 Default Properties Ingress Replication [ensure => present] :: MANIFEST    
1.1 Default Properties Ingress Replication [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 Default Properties Ingress Replication [ensure => present] :: RESOURCE    
1.1 Default Properties Ingress Replication [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 1.1 Default Properties Ingress Replication [ensure => present] :: IDEMPOTENCE 
1.1 Default Properties Ingress Replication [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 1.2 Default Properties Ingress Replication [ensure => absent] :: MANIFEST    
1.2 Default Properties Ingress Replication [ensure => absent] :: MANIFEST     :: PASS

  * TestStep :: 1.2 Default Properties Ingress Replication [ensure => absent] :: RESOURCE    
1.2 Default Properties Ingress Replication [ensure => absent] :: RESOURCE     :: PASS

  * TestStep :: 1.2 Default Properties Ingress Replication [ensure => absent] :: IDEMPOTENCE 
1.2 Default Properties Ingress Replication [ensure => absent] :: IDEMPOTENCE  :: PASS

  * TestStep :: 1.3 Default Properties Multicast Group [ensure => present] :: MANIFEST    
1.3 Default Properties Multicast Group [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 Default Properties Multicast Group [ensure => present] :: RESOURCE    
1.3 Default Properties Multicast Group [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 1.3 Default Properties Multicast Group [ensure => present] :: IDEMPOTENCE 
1.3 Default Properties Multicast Group [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 1.4 Default Properties Multicast Group [ensure => absent] :: MANIFEST    
1.4 Default Properties Multicast Group [ensure => absent] :: MANIFEST     :: PASS

  * TestStep :: 1.4 Default Properties Multicast Group [ensure => absent] :: RESOURCE    
1.4 Default Properties Multicast Group [ensure => absent] :: RESOURCE     :: PASS

  * TestStep :: 1.4 Default Properties Multicast Group [ensure => absent] :: IDEMPOTENCE 
1.4 Default Properties Multicast Group [ensure => absent] :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. Non Default Property Testing

  * TestStep :: 2.1 Ingress Replication Static [ensure => present] :: MANIFEST    
2.1 Ingress Replication Static [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 Ingress Replication Static [ensure => present] :: RESOURCE    
2.1 Ingress Replication Static [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.1 Ingress Replication Static [ensure => present] :: IDEMPOTENCE 
2.1 Ingress Replication Static [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.2 Peer List [ensure => present] :: MANIFEST    
2.2 Peer List [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 Peer List [ensure => present] :: RESOURCE    
2.2 Peer List [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.2 Peer List [ensure => present] :: IDEMPOTENCE 
2.2 Peer List [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.3 Peer List Change Add [ensure => present] :: MANIFEST    
2.3 Peer List Change Add [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.3 Peer List Change Add [ensure => present] :: RESOURCE    
2.3 Peer List Change Add [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.3 Peer List Change Add [ensure => present] :: IDEMPOTENCE 
2.3 Peer List Change Add [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.4 Peer List Default [ensure => present] :: MANIFEST    
2.4 Peer List Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.4 Peer List Default [ensure => present] :: RESOURCE    
2.4 Peer List Default [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.4 Peer List Default [ensure => present] :: IDEMPOTENCE 
2.4 Peer List Default [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.5 Ingress Replication BGP [ensure => present] :: MANIFEST    
2.5 Ingress Replication BGP [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.5 Ingress Replication BGP [ensure => present] :: RESOURCE    
2.5 Ingress Replication BGP [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.5 Ingress Replication BGP [ensure => present] :: IDEMPOTENCE 
2.5 Ingress Replication BGP [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.6 Multicast Group [ensure => present] :: MANIFEST    
2.6 Multicast Group [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.6 Multicast Group [ensure => present] :: RESOURCE    
2.6 Multicast Group [ensure => present] :: RESOURCE     :: PASS

  * TestStep :: 2.6 Multicast Group [ensure => present] :: IDEMPOTENCE 
2.6 Multicast Group [ensure => present] :: IDEMPOTENCE  :: PASS

  * TestStep :: 2.7 Suppress ARP [ensure => present] :: MANIFEST    
#<Beaker::Host::CommandFailure: Host 'dt-n9k5-1' exited with 6 running:
 sudo ip netns exec management /opt/puppetlabs/bin/puppet agent -t
Last 10 lines of output were:
        Info: Using configured environment 'production'
        Info: Retrieving pluginfacts
        Info: Retrieving plugin
        Info: Loading facts
        Info: Caching catalog for dt-n9k5-1.cisco.com
        Info: Applying configuration version '1455117812'
        Notice: /Stage[main]/Main/Node[default]/Cisco_vxlan_vtep_vni[nve1 10000]/suppress_arp: suppress_arp changed 'false' to 'true'
        Error: /Stage[main]/Main/Node[default]/Cisco_vxlan_vtep_vni[nve1 10000]: Could not evaluate: CliError: ' suppress-arp' rejected with message:
        'ERROR: Please configure TCAM region for Ingress ARP-Ether ACL before configuring ARP supression.'
        Notice: Applied catalog in 1.35 seconds>
/nobackup/mwiebe/REPOS_PUPPET/release120/cisco-network-puppet-module/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb:281
/nobackup/mwiebe/REPOS_PUPPET/release120/cisco-network-puppet-module/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb:343
/nobackup/mwiebe/REPOS_PUPPET/release120/cisco-network-puppet-module/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb:291
/var/lib/gems/1.9.1/gems/beaker-2.14.1/bin/beaker:6
Warning: ./cisco_vxlan_vtep_vni/./test_vxlan_vtep_vni.rb errored in 229.75 seconds
      Test Suite: tests @ 2016-02-10 01:26:54 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 229.75 seconds
      Average Test Time: 229.75 seconds
              Attempted: 1
                 Passed: 0
                 Failed: 0
                Errored: 1
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
  Test Case ./cisco_vxlan_vtep_vni/./test_vxlan_vtep_vni.rb reported: #<Beaker::Host::CommandFailure: Host 'dt-n9k5-1' exited with 6 running:
 sudo ip netns exec management /opt/puppetlabs/bin/puppet agent -t
Last 10 lines of output were:
        Info: Using configured environment 'production'
        Info: Retrieving pluginfacts
        Info: Retrieving plugin
        Info: Loading facts
        Info: Caching catalog for dt-n9k5-1.cisco.com
        Info: Applying configuration version '1455117812'
        Notice: /Stage[main]/Main/Node[default]/Cisco_vxlan_vtep_vni[nve1 10000]/suppress_arp: suppress_arp changed 'false' to 'true'
        Error: /Stage[main]/Main/Node[default]/Cisco_vxlan_vtep_vni[nve1 10000]: Could not evaluate: CliError: ' suppress-arp' rejected with message:
        'ERROR: Please configure TCAM region for Ingress ARP-Ether ACL before configuring ARP supression.'
        Notice: Applied catalog in 1.35 seconds>
Skipped Tests Cases:
Pending Tests Cases:


Failed: errored in TestSuite: report_and_raise_on_failure
#<RuntimeError: Failed while running the tests suite>
No tests to run for suite 'post_suite'
Cleanup: cleaning up after failed run
Warning: ssh connection to dt-n9k5-1.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated

You can reproduce this run with:
/usr/local/bin/beaker --host /home/mwiebe/beaker_host_files/host.cfg --tests ./cisco_vxlan_vtep_vni/. --no-validate --no-config --no-color

Important ENV variables that may have affected your run:
    PATH                /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
    home                /home/mwiebe
Failed running the test suite.
```

**NOTE:** Failure above is a valid failure.  A switch reload is required to configure the TCAM region.

**VXLAN TESTS 3K**
```
Begin ./cisco_vxlan_vtep/./test_vxlan_vtep.rb

TestCase :: Resource cisco_vxlan_vtep

------------------------------------------------------------
Section 1. Default Property Testing

  * 
--------
 * TestStep :: Setup switch for cisco_vxlan_vtep provider test

1.1 Default Properties :: default_properties :: SKIP
Platform type does not match testcase platform regexp: /n9k/

1.2 Default Properties :: default_properties :: SKIP
Platform type does not match testcase platform regexp: /n9k/

------------------------------------------------------------
Section 2. Non Default Property Testing

2.1 Non-Default Properties :: non_default_properties :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.2 Non-Default Properties :: non_default_properties :: SKIP
Platform type does not match testcase platform regexp: /n9k/

------------------------------------------------------------
Section 3. Property Changes

3.1 Setup :: non_default_properties :: SKIP
Platform type does not match testcase platform regexp: /n9k/

3.1 Change host_reach, shutdown state, source int :: change_parameters :: SKIP
Platform type does not match testcase platform regexp: /n9k/

3.1 Change source_interface, shutdown state: true :: change_source_int_when_shutdown :: SKIP
Platform type does not match testcase platform regexp: /n9k/


Begin ./cisco_vxlan_vtep_vni/./test_vxlan_vtep_vni.rb

TestCase :: Resource cisco_vxlan_vtep_vni

  * 
--------
 * TestStep :: Setup switch for cisco_vxlan_vtep_vni provider test

------------------------------------------------------------
Section 1. Default Property Testing

1.1 Default Properties Ingress Replication :: default_properties_ingress_replication :: SKIP
Platform type does not match testcase platform regexp: /n9k/

1.2 Default Properties Ingress Replication :: default_properties_ingress_replication :: SKIP
Platform type does not match testcase platform regexp: /n9k/

1.3 Default Properties Multicast Group :: default_properties_multicast_group :: SKIP
Platform type does not match testcase platform regexp: /n9k/

1.4 Default Properties Multicast Group :: default_properties_multicast_group :: SKIP
Platform type does not match testcase platform regexp: /n9k/

------------------------------------------------------------
Section 2. Non Default Property Testing

2.1 Ingress Replication Static :: ingress_replication_static_peer_list_empty :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.2 Peer List :: peer_list :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.3 Peer List Change Add :: peer_list_change_add :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.4 Peer List Default :: peer_list_default :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.5 Ingress Replication BGP :: ingress_replication_bgp :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.6 Multicast Group :: multicast_group :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.7 Suppress ARP :: suppress_arp_true :: SKIP
Platform type does not match testcase platform regexp: /n9k/

2.8 Suppress ARP :: suppress_arp_false :: SKIP
Platform type does not match testcase platform regexp: /n9k/

  * 
--------
```

**N3K VDC TEST**
```
Begin ./cisco_vdc/./test_vdc.rb

TestCase :: Resource cisco_vdc properties


TestCase :: ONLY SUPPORTED ON N7K :: SKIP
      Test Suite: tests @ 2016-02-10 01:36:02 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 7.84 seconds
      Average Test Time: 7.84 seconds
              Attempted: 1
                 Passed: 0
                 Failed: 0
                Errored: 0
                Skipped: 1
                Pending: 0
                  Total: 1

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case ./cisco_vdc/./test_vdc.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to n3k-105.cisco.com has been terminated
Beaker completed successfully, thanks.

```
