### PR TITLE
cisco_vxlan_vtep: added property source-interface hold-down-time

### DIFF
--- a/examples/cisco/demo_vxlan.pp
+++ b/examples/cisco/demo_vxlan.pp
@@ -26,11 +26,12 @@ class ciscopuppet::cisco::demo_vxlan {
   }
 
   cisco_vxlan_vtep { 'nve1':
-    ensure            => present,
-    description       => 'Configured by puppet',
-    host_reachability => 'evpn',
-    shutdown          => 'false',
-    source_interface  => 'loopback55',
+    ensure                          => present,
+    description                     => 'Configured by puppet',
+    host_reachability               => 'evpn',
+    shutdown                        => 'false',
+    source_interface                => 'loopback55',
+    source_interface_hold_down_time => '50',
   }
 
   cisco_vxlan_vtep_vni {'nve1 10000':

--- a/lib/puppet/provider/cisco_vxlan_vtep/nxapi.rb
+++ b/lib/puppet/provider/cisco_vxlan_vtep/nxapi.rb
@@ -38,6 +38,7 @@ Puppet::Type.type(:cisco_vxlan_vtep).provide(:nxapi) do
     :description,
     :host_reachability,
     :source_interface,
+    :source_interface_hold_down_time,
   ]
 
   VXLAN_VTEP_BOOL_PROPS = [

--- a/lib/puppet/type/cisco_vxlan_vtep.rb
+++ b/lib/puppet/type/cisco_vxlan_vtep.rb
@@ -29,11 +29,12 @@ Puppet::Type.newtype(:cisco_vxlan_vtep) do
 
   ~~~puppet
     cisco_vxlan_vtep { 'nve1':
-      ensure             => present,
-      description        => 'nve interface',
-      host_reachability  => 'evpn',
-      shutdown           => false,
-      source_interface   => 'loopback1',
+      ensure                          => present,
+      description                     => 'nve interface',
+      host_reachability               => 'evpn',
+      shutdown                        => false,
+      source_interface                => 'loopback1',
+      source_interface_hold_down_time => '50',
     }
   ~~~
   "
@@ -102,5 +103,27 @@ Puppet::Type.newtype(:cisco_vxlan_vtep) do
     munge do |value|
       value == 'default' ? :default : value.gsub(/\s+/, '').downcase
     end
+  end
+
+  newproperty(:source_interface_hold_down_time) do
+    desc "Suppress advertisement of the NVE loopback address until the overlay
+          has converged. Valid values are Integer, keyword 'default'."
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'source_interface_hold_down_time must be an integer.'
+      end
+      value
+    end
+  end # source_interface_hold_down_time
+
+  validate do
+    # source_interface_hold_down_time can be set only if source_interface is set
+    fail 'source_interface_hold_down_time can be set only if source_interface '\
+         'is set' if self[:source_interface_hold_down_time] &&
+                     !self[:source_interface]
   end
 end

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -103,10 +103,11 @@ tests = {
 tests['default_properties'] = {
   title_pattern:  'nve1',
   manifest_props: "
-    description        => 'default',
-    host_reachability  => 'default',
-    shutdown           => 'default',
-    source_interface   => 'default',
+    description                     => 'default',
+    host_reachability               => 'default',
+    shutdown                        => 'default',
+    source_interface                => 'default',
+    source_interface_hold_down_time => 'default',
   ",
   resource_props: {
     'host_reachability' => 'flood',
@@ -117,31 +118,35 @@ tests['default_properties'] = {
 tests['non_default_properties'] = {
   title_pattern:  'nve1',
   manifest_props: "
-    description        => 'Configured by Puppet',
-    host_reachability  => 'evpn',
-    shutdown           => 'false',
-    source_interface   => 'loopback55',
+    description                     => 'Configured by Puppet',
+    host_reachability               => 'evpn',
+    shutdown                        => 'false',
+    source_interface                => 'loopback55',
+    source_interface_hold_down_time => '50',
   ",
   resource_props: {
-    'description'       => 'Configured by Puppet',
-    'host_reachability' => 'evpn',
-    'shutdown'          => 'false',
-    'source_interface'  => 'loopback55',
+    'description'                     => 'Configured by Puppet',
+    'host_reachability'               => 'evpn',
+    'shutdown'                        => 'false',
+    'source_interface'                => 'loopback55',
+    'source_interface_hold_down_time' => '50',
   },
 }
 
 tests['change_parameters'] = {
   title_pattern:  'nve1',
   manifest_props: "
-    host_reachability  => 'flood',
-    shutdown           => 'true',
-    source_interface   => 'loopback1',
+    host_reachability               => 'flood',
+    shutdown                        => 'true',
+    source_interface                => 'loopback1',
+    source_interface_hold_down_time => '100',
   ",
   resource_props: {
-    'description'       => 'Configured by Puppet',
-    'host_reachability' => 'flood',
-    'shutdown'          => 'true',
-    'source_interface'  => 'loopback1',
+    'description'                     => 'Configured by Puppet',
+    'host_reachability'               => 'flood',
+    'shutdown'                        => 'true',
+    'source_interface'                => 'loopback1',
+    'source_interface_hold_down_time' => '100',
   },
 }
 


### PR DESCRIPTION
Rubocop passes.

Beaker tests pass. 

* TestStep :: Setup switch for cisco_vxlan_vtep provider test
      * Setup switch for cisco_vxlan_vtep provider test Removing cisco_vxlan_vtep 'nve1'
TestCase :: # {testheader} :: End
cisco_vxlan_vtep/test_vxlan_vtep.rb passed in 128.92 seconds
      Test Suite: tests @ 2016-02-09 17:28:30 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 128.92 seconds
      Average Test Time: 128.92 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:
