### PR TITLE
Puppet & Beaker Implementation for fabric_forwarding_anycast_gateway property under Cisco_Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `cisco_interface_portchannel` type and provider
 - `cisco_interface_service_vni` type and provider
 - `cisco_overlay_global` type and provider.
+- `cisco_pim` type and provider
+- `cisco_pim_rp_address` type and provider
+- `cisco_pim_grouplist` type and provider
 - `cisco_portchannel_global` type and provider
 - `cisco_vdc` type and provider.
 - `cisco_vni` type and provider.
@@ -48,6 +51,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `table_map`, `table_map_filter`
   - `suppress_inactive`
 - Extended `cisco_interface` with the following attributes:
+  - `fabric_forwarding_anycast_gateway` 
   - `ipv4_address_secondary`, `ipv4_netmask_length_secondary`
   - `ipv4_arp_timeout`
   - `ipv4_pim_sparse_mode`

--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,10 @@ VRF member of the interface.  Valid values are a string or the keyword 'default'
 
 ##### SVI interface config attributes
 
+###### `fabric_forwarding_anycast_gateway`
+Associate SVI with anycast gateway under VLAN configuration mode.
+Valid values are 'true', 'false', and 'default'.
+
 ###### `svi_autostate`
 Enable/Disable autostate on the SVI interface. Valid values are 'true',
 'false', and 'default'.

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -87,6 +87,16 @@ class ciscopuppet::cisco::demo_interface {
     ipv4_arp_timeout => 300,
   }
 
+  cisco_overlay_global { 'default':
+    anycast_gateway_mac                    => '1.1.1',
+  }
+
+  cisco_interface { 'vlan97':
+    ensure => present,
+    fabric_forwarding_anycast_gateway        => 'true',
+    require                                  => Cisco_overlay_global['default'],
+  }
+
   #  Requires F3 or newer linecards
   # cisco_interface { 'Ethernet9/1':
   #   switchport_mode                => trunk,

--- a/lib/puppet/provider/cisco_interface/nxapi.rb
+++ b/lib/puppet/provider/cisco_interface/nxapi.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:cisco_interface).provide(:nxapi) do
     :ipv6_acl_out,
   ]
   INTF_BOOL_PROPS = [
+    :fabric_forwarding_anycast_gateway,
     :ipv4_pim_sparse_mode,
     :ipv4_proxy_arp,
     :ipv4_redirects,

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -413,6 +413,13 @@ Puppet::Type.newtype(:cisco_interface) do
   # Begin SVI interface config attributes #
   #########################################
 
+  newproperty(:fabric_forwarding_anycast_gateway) do
+    desc 'Associate SVI with anycast gateway under VLAN configuration mode. '\
+         "Valid values are 'true','false' and 'default'."
+
+    newvalues(:true, :false, :default)
+  end # property fabric_forwarding_anycast_gateway
+
   newproperty(:svi_autostate) do
     desc 'Enable/Disable autostate on the SVI interface.'
 

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -276,7 +276,8 @@ tests['SVI_default'] = {
   desc:           '4.1 (SVI) Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_management: 'default'
+    svi_management:                    'default',
+    fabric_forwarding_anycast_gateway: 'default',
   },
   resource:       {
     'svi_management' => 'false'
@@ -287,10 +288,12 @@ tests['SVI'] = {
   desc:           '4.2 (SVI) Non Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_management: 'true'
+    svi_management:                    'true',
+    fabric_forwarding_anycast_gateway: 'true',
   },
   resource:       {
-    'svi_management' => 'true'
+    'svi_management'                    => 'true',
+    'fabric_forwarding_anycast_gateway' => 'true',
   },
 }
 
@@ -349,6 +352,13 @@ tests['speed_dup_mtu'] = {
     # 'speed'  => '100',
     'duplex' => 'full',
   },
+}
+
+resource = {
+  name:     'cisco_overlay_global',
+  title:    'default',
+  property: 'anycast_gateway_mac',
+  value:    '1.1.1',
 }
 
 # cisco_interface uses the interface name as the title.
@@ -468,6 +478,7 @@ end
 test_name "TestCase :: #{testheader}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. (L3) Property Testing")
+
   test_harness_interface(tests, 'L3_default')
   test_harness_interface(tests, 'L3_sub_int')
   test_harness_interface(tests, 'L3_misc')
@@ -482,12 +493,13 @@ test_name "TestCase :: #{testheader}" do
   logger.info("\n#{'-' * 60}\nSection 3. (L2) Trunk Property Testing")
   test_harness_interface(tests, 'L2_trunk_default')
   test_harness_interface(tests, 'L2_trunk')
-
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 4. (SVI) Property Testing")
+  resource_set(agent, resource, 'Overlay Global mac setup')
   interface_cleanup(agent, tests[:svi_name])
   test_harness_interface(tests, 'SVI_default')
   test_harness_interface(tests, 'SVI')
+
   test_harness_interface(tests, 'SVI_autostate_default')
   test_harness_interface(tests, 'SVI_autostate')
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -679,6 +679,15 @@ def command_config(agent, cmd, msg='')
   on(agent, cmd, acceptable_exit_codes: [0, 2])
 end
 
+# Helper to set properties using the puppet resource command.
+def resource_set(agent, resource, msg='')
+  logger.info("\n#{msg}")
+  cmd = "resource #{resource[:name]} '#{resource[:title]}' " \
+                  "#{resource[:property]}='#{resource[:value]}'"
+  cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+  on(agent, cmd, acceptable_exit_codes: [0, 2])
+end
+
 # Helper to raise skip when prereqs are not met
 def prereq_skip(testheader, testcase, message)
   testheader = '' if testheader.nil?


### PR DESCRIPTION
# Description:
Puppet & Beaker Implementation for fabric_forwarding_anycast_gateway property under Cisco_Interface

# Rubocop:
-------------
```
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module# rubocop lib/puppet/provider/cisco_interface/nxapi.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module# rubocop lib/puppet/type/cisco_interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module# rubocop tests/beaker_tests/cisco_interface/test_interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module# rubocop tests/beaker_tests/lib/utilitylib.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module#
```
# Beaker Tests:
—————————
```
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module/tests/beaker_tests# /home/rtpfe1/.rvm/gems/ruby-2.2.1/bin/beaker --hosts hosts.cfg --pre-suite presuite/presuite_certcheck.rb --no-validate --no-configure --test cisco_interface/test_interface.rb
<snip>
Begin cisco_interface/test_interface.rb

TestCase :: Resource cisco_interface

  ------------------------------------------------------------
  Section 4. (SVI) Property Testing

  Overlay Global mac setup

  * TestStep :: Pre Clean:
      * Pre Clean: Set 'vlan13' to default state

  Using interface: vlan13

  --------
  4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST
  4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE
    4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE
    4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

  Using interface: vlan13

  --------
  4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST
  4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE
    4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE
    4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS
TestCase :: Resource cisco_interface :: End
cisco_interface/test_interface.rb passed in 47.30 seconds
      Test Suite: tests @ 2016-02-11 06:03:11 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 47.30 seconds
      Average Test Time: 47.30 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to agent1 has been terminated
Warning: ssh connection to puppetmaster1 has been terminated
Beaker completed successfully, thanks.
root@agent-lab11-ws:/home/rtpfe1/smigopal/feb_interface_puppet/cisco-network-puppet-module/tests/beaker_tests#
```