### PR TITLE
Extend cisco_interface to include 'fabric_forwarding_anycast_gateway' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `cisco_interface_portchannel` type and provider
 - `cisco_interface_service_vni` type and provider
 - `cisco_overlay_global` type and provider.
+- `cisco_pim` type and provider
+- `cisco_pim_rp_address` type and provider
+- `cisco_pim_grouplist` type and provider
 - `cisco_portchannel_global` type and provider
 - `cisco_vdc` type and provider.
 - `cisco_vni` type and provider.
@@ -48,6 +51,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `table_map`, `table_map_filter`
   - `suppress_inactive`
 - Extended `cisco_interface` with the following attributes:
+  - `fabric_forwarding_anycast_gateway` 
   - `ipv4_address_secondary`, `ipv4_netmask_length_secondary`
   - `ipv4_arp_timeout`
   - `ipv4_pim_sparse_mode`

--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,10 @@ VRF member of the interface.  Valid values are a string or the keyword 'default'
 
 ##### SVI interface config attributes
 
+###### `fabric_forwarding_anycast_gateway`
+Associate SVI with anycast gateway under VLAN configuration mode. The `cisco_overlay_global` `anycast_gateway_mac` must be set before setting this property.
+Valid values are 'true', 'false', and 'default'.
+
 ###### `svi_autostate`
 Enable/Disable autostate on the SVI interface. Valid values are 'true',
 'false', and 'default'.

--- a/examples/cisco/demo_vxlan.pp
+++ b/examples/cisco/demo_vxlan.pp
@@ -49,4 +49,10 @@ class ciscopuppet::cisco::demo_vxlan {
     multicast_group     => '224.1.1.1',
     suppress_arp        => 'default',
   }
+
+  cisco_interface { 'vlan97':
+    ensure => present,
+    fabric_forwarding_anycast_gateway => 'true',
+    require                           => Cisco_overlay_global['default'],
+  }
 }

--- a/examples/demo_all_cisco.pp
+++ b/examples/demo_all_cisco.pp
@@ -44,7 +44,7 @@ class ciscopuppet::demo_all_cisco {
   include ciscopuppet::cisco::demo_vrf
   include ciscopuppet::cisco::demo_vtp
   # Conditionally include ciscopuppet::demo_vxlan 
-  if platform_get() =~ /n(3|9)k/ { 
+  if platform_get() =~ /n9k/ { 
     include ciscopuppet::cisco::demo_vxlan 
   }
 }

--- a/lib/puppet/provider/cisco_interface/nxapi.rb
+++ b/lib/puppet/provider/cisco_interface/nxapi.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:cisco_interface).provide(:nxapi) do
     :ipv6_acl_out,
   ]
   INTF_BOOL_PROPS = [
+    :fabric_forwarding_anycast_gateway,
     :ipv4_pim_sparse_mode,
     :ipv4_proxy_arp,
     :ipv4_redirects,

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -413,6 +413,13 @@ Puppet::Type.newtype(:cisco_interface) do
   # Begin SVI interface config attributes #
   #########################################
 
+  newproperty(:fabric_forwarding_anycast_gateway) do
+    desc 'Associate SVI with anycast gateway under VLAN configuration mode. '\
+         "Valid values are 'true','false' and 'default'."
+
+    newvalues(:true, :false, :default)
+  end # property fabric_forwarding_anycast_gateway
+
   newproperty(:svi_autostate) do
     desc 'Enable/Disable autostate on the SVI interface.'
 

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -354,7 +354,7 @@ tests['speed_dup_mtu'] = {
   },
 }
 
-resource = {
+resource_cisco_overlay_global = {
   name:     'cisco_overlay_global',
   title:    'default',
   property: 'anycast_gateway_mac',
@@ -495,7 +495,7 @@ test_name "TestCase :: #{testheader}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 4. (SVI) Property Testing")
-  resource_set(agent, resource, 'Overlay Global mac setup')
+  resource_set(agent, resource_cisco_overlay_global, 'Overlay Global mac setup')
   interface_cleanup(agent, tests[:svi_name])
   test_harness_interface(tests, 'SVI_default')
   test_harness_interface(tests, 'SVI')

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -276,7 +276,8 @@ tests['SVI_default'] = {
   desc:           '4.1 (SVI) Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_management: 'default'
+    fabric_forwarding_anycast_gateway: 'default',
+    svi_management:                    'default',
   },
   resource:       {
     'svi_management' => 'false'
@@ -287,10 +288,12 @@ tests['SVI'] = {
   desc:           '4.2 (SVI) Non Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    svi_management: 'true'
+    fabric_forwarding_anycast_gateway: 'true',
+    svi_management:                    'true',
   },
   resource:       {
-    'svi_management' => 'true'
+    'fabric_forwarding_anycast_gateway' => 'true',
+    'svi_management'                    => 'true',
   },
 }
 
@@ -349,6 +352,13 @@ tests['speed_dup_mtu'] = {
     # 'speed'  => '100',
     'duplex' => 'full',
   },
+}
+
+resource = {
+  name:     'cisco_overlay_global',
+  title:    'default',
+  property: 'anycast_gateway_mac',
+  value:    '1.1.1',
 }
 
 # cisco_interface uses the interface name as the title.
@@ -485,6 +495,7 @@ test_name "TestCase :: #{testheader}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 4. (SVI) Property Testing")
+  resource_set(agent, resource, 'Overlay Global mac setup')
   interface_cleanup(agent, tests[:svi_name])
   test_harness_interface(tests, 'SVI_default')
   test_harness_interface(tests, 'SVI')

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -276,8 +276,7 @@ tests['SVI_default'] = {
   desc:           '4.1 (SVI) Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    fabric_forwarding_anycast_gateway: 'default',
-    svi_management:                    'default',
+    svi_management: 'default'
   },
   resource:       {
     'svi_management' => 'false'
@@ -288,14 +287,19 @@ tests['SVI'] = {
   desc:           '4.2 (SVI) Non Default Properties',
   intf_type:      'vlan',
   manifest_props: {
-    fabric_forwarding_anycast_gateway: 'true',
-    svi_management:                    'true',
+    svi_management: 'true'
   },
   resource:       {
-    'fabric_forwarding_anycast_gateway' => 'true',
-    'svi_management'                    => 'true',
+    'svi_management' => 'true'
   },
 }
+
+# Fabric Forwarding Anycast Gateway
+if platform[/n9k/]
+  tests['SVI_default'][:manifest_props][:fabric_forwarding_anycast_gateway] = 'default'
+  tests['SVI'][:manifest_props][:fabric_forwarding_anycast_gateway] = 'true'
+  tests['SVI'][:resource][:fabric_forwarding_anycast_gateway] = 'true'
+end
 
 tests['SVI_autostate_default'] = {
   desc:           '4.3 (SVI) Default SVI Autostate Property',

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -679,6 +679,15 @@ def command_config(agent, cmd, msg='')
   on(agent, cmd, acceptable_exit_codes: [0, 2])
 end
 
+# Helper to set properties using the puppet resource command.
+def resource_set(agent, resource, msg='')
+  logger.info("\n#{msg}")
+  cmd = "resource #{resource[:name]} '#{resource[:title]}' " \
+                  "#{resource[:property]}='#{resource[:value]}'"
+  cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+  on(agent, cmd, acceptable_exit_codes: [0, 2])
+end
+
 # Helper to raise skip when prereqs are not met
 def prereq_skip(testheader, testcase, message)
   testheader = '' if testheader.nil?


### PR DESCRIPTION
This is basically https://github.com/cisco/cisco-network-puppet-module/pull/188, authored by @smigopal with a few minor updates.

**TESTS**
- Tests run on both `I2` and `I3` versions
- Tests run with the following `feature fabric forwarding`(`I2` only) and (`nv overlay evpn`) enabled and disabled manually prior to starting the test.
```
Beaker::Hypervisor, found some none boxes to create
No tests to run for suite 'pre_suite'
Begin ./cisco_interface/./test_interface.rb

TestCase :: Resource cisco_interface

------------------------------------------------------------
Section 1. (L3) Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
1.1 (L3) Default Properties [ensure => present]

  * TestStep :: 1.1 (L3) Default Properties [ensure => present] :: MANIFEST    
1.1 (L3) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: RESOURCE    
1.1 (L3) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: IDEMPOTENCE 
1.1 (L3) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1.1

--------
1.2 (L3) Sub-interface [ensure => present]

  * TestStep :: 1.2 (L3) Sub-interface [ensure => present] :: MANIFEST    
1.2 (L3) Sub-interface [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: RESOURCE    
1.2 (L3) Sub-interface :: RESOURCE     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: IDEMPOTENCE 
1.2 (L3) Sub-interface :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
1.3 (L3) Misc Properties [ensure => present]

  * TestStep :: 1.3 (L3) Misc Properties [ensure => present] :: MANIFEST    
1.3 (L3) Misc Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: RESOURCE    
1.3 (L3) Misc Properties :: RESOURCE     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: IDEMPOTENCE 
1.3 (L3) Misc Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_out' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_out' ensure=present

--------
1.4 (L3) ACL Properties [ensure => present]

  * TestStep :: 1.4 (L3) ACL Properties [ensure => present] :: MANIFEST    
1.4 (L3) ACL Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: RESOURCE    
1.4 (L3) ACL Properties :: RESOURCE     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: IDEMPOTENCE 
1.4 (L3) ACL Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. (L2) Access Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

 system default switchport

  * TestStep :: system default switchport shutdown

 system default switchport shutdown

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
2.1 (L2) Access Default [ensure => present]

  * TestStep :: 2.1 (L2) Access Default [ensure => present] :: MANIFEST    
2.1 (L2) Access Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: RESOURCE    
2.1 (L2) Access Default :: RESOURCE     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: IDEMPOTENCE 
2.1 (L2) Access Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
2.2 (L2) Access Properties [ensure => present]

  * TestStep :: 2.2 (L2) Access Properties [ensure => present] :: MANIFEST    
2.2 (L2) Access Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: RESOURCE    
2.2 (L2) Access Properties :: RESOURCE     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: IDEMPOTENCE 
2.2 (L2) Access Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. (L2) Trunk Property Testing

Using interface: ethernet1/1

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
3.1 (L2) Trunk Default [ensure => present]

  * TestStep :: 3.1 (L2) Trunk Default [ensure => present] :: MANIFEST    
3.1 (L2) Trunk Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: RESOURCE    
3.1 (L2) Trunk Default :: RESOURCE     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: IDEMPOTENCE 
3.1 (L2) Trunk Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
3.2 (L2) Trunk [ensure => present]

  * TestStep :: 3.2 (L2) Trunk [ensure => present] :: MANIFEST    
3.2 (L2) Trunk [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: RESOURCE    
3.2 (L2) Trunk :: RESOURCE     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: IDEMPOTENCE 
3.2 (L2) Trunk :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 4. (SVI) Property Testing

Overlay Global mac setup

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'vlan13' to default state

Using interface: vlan13

--------
4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST    
4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE    
4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE 
4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST    
4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE    
4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE 
4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS

Found Platform string: 'NX-OSv Chassis', Alias to: 'n9k'

Using interface: vlan13

--------
4.3 (SVI) Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: RESOURCE    
4.3 (SVI) Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE 
4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.4 (SVI) Non Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE    
4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE 
4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 5. MISC Property Testing

5.1 negotiate-auto :: negotiate :: SKIP
Platform type does not match testcase platform regexp: /n(5|6|7)k/

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

------------------------------------------------------------
  SKIPPED TESTS SUMMARY
------------------------------------------------------------
5.1 negotiate-auto                       :: SKIP


TestCase ::  :: SKIP
Begin ./cisco_interface/./test_vlan_mapping.rb

TestCase :: Resource cisco_interface: vlan_mapping properties

------------------------------------------------------------
Section 0. Testbed Initialization

  * Check for Compatible Line Module
** PLATFORM PREREQUISITE NOT MET: MT-full tests require f3 or compatible line module


TestCase :: cisco_interface :: SKIP
      Test Suite: tests @ 2016-02-11 06:07:17 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 300.33 seconds
      Average Test Time: 150.17 seconds
              Attempted: 2
                 Passed: 0
                 Failed: 0
                Errored: 0
                Skipped: 2
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case ./cisco_interface/./test_interface.rb skip
  Test Case ./cisco_interface/./test_vlan_mapping.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to agent-lab10-nx has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.



Beaker::Hypervisor, found some none boxes to create
No tests to run for suite 'pre_suite'
Begin ./cisco_interface/./test_interface.rb

TestCase :: Resource cisco_interface

------------------------------------------------------------
Section 1. (L3) Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

no system default switchport

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
1.1 (L3) Default Properties [ensure => present]

  * TestStep :: 1.1 (L3) Default Properties [ensure => present] :: MANIFEST    
1.1 (L3) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: RESOURCE    
1.1 (L3) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 1.1 (L3) Default Properties :: IDEMPOTENCE 
1.1 (L3) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1.1

--------
1.2 (L3) Sub-interface [ensure => present]

  * TestStep :: 1.2 (L3) Sub-interface [ensure => present] :: MANIFEST    
1.2 (L3) Sub-interface [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: RESOURCE    
1.2 (L3) Sub-interface :: RESOURCE     :: PASS

  * TestStep :: 1.2 (L3) Sub-interface :: IDEMPOTENCE 
1.2 (L3) Sub-interface :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
1.3 (L3) Misc Properties [ensure => present]

  * TestStep :: 1.3 (L3) Misc Properties [ensure => present] :: MANIFEST    
1.3 (L3) Misc Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: RESOURCE    
1.3 (L3) Misc Properties :: RESOURCE     :: PASS

  * TestStep :: 1.3 (L3) Misc Properties :: IDEMPOTENCE 
1.3 (L3) Misc Properties :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv4 v4_out' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_in' ensure=present

  * TestStep :: ACL:
Setup: puppet resource cisco_acl 'ipv6 v6_out' ensure=present

--------
1.4 (L3) ACL Properties [ensure => present]

  * TestStep :: 1.4 (L3) ACL Properties [ensure => present] :: MANIFEST    
1.4 (L3) ACL Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: RESOURCE    
1.4 (L3) ACL Properties :: RESOURCE     :: PASS

  * TestStep :: 1.4 (L3) ACL Properties :: IDEMPOTENCE 
1.4 (L3) ACL Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 2. (L2) Access Property Testing

Using interface: ethernet1/1

  * TestStep :: system default switchport

 system default switchport

  * TestStep :: system default switchport shutdown

 system default switchport shutdown

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
2.1 (L2) Access Default [ensure => present]

  * TestStep :: 2.1 (L2) Access Default [ensure => present] :: MANIFEST    
2.1 (L2) Access Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: RESOURCE    
2.1 (L2) Access Default :: RESOURCE     :: PASS

  * TestStep :: 2.1 (L2) Access Default :: IDEMPOTENCE 
2.1 (L2) Access Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
2.2 (L2) Access Properties [ensure => present]

  * TestStep :: 2.2 (L2) Access Properties [ensure => present] :: MANIFEST    
2.2 (L2) Access Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: RESOURCE    
2.2 (L2) Access Properties :: RESOURCE     :: PASS

  * TestStep :: 2.2 (L2) Access Properties :: IDEMPOTENCE 
2.2 (L2) Access Properties :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 3. (L2) Trunk Property Testing

Using interface: ethernet1/1

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

--------
3.1 (L2) Trunk Default [ensure => present]

  * TestStep :: 3.1 (L2) Trunk Default [ensure => present] :: MANIFEST    
3.1 (L2) Trunk Default [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: RESOURCE    
3.1 (L2) Trunk Default :: RESOURCE     :: PASS

  * TestStep :: 3.1 (L2) Trunk Default :: IDEMPOTENCE 
3.1 (L2) Trunk Default :: IDEMPOTENCE  :: PASS

Using interface: ethernet1/1

--------
3.2 (L2) Trunk [ensure => present]

  * TestStep :: 3.2 (L2) Trunk [ensure => present] :: MANIFEST    
3.2 (L2) Trunk [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: RESOURCE    
3.2 (L2) Trunk :: RESOURCE     :: PASS

  * TestStep :: 3.2 (L2) Trunk :: IDEMPOTENCE 
3.2 (L2) Trunk :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 4. (SVI) Property Testing

Overlay Global mac setup

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'vlan13' to default state

Using interface: vlan13

--------
4.1 (SVI) Default Properties [ensure => present]

  * TestStep :: 4.1 (SVI) Default Properties [ensure => present] :: MANIFEST    
4.1 (SVI) Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: RESOURCE    
4.1 (SVI) Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.1 (SVI) Default Properties :: IDEMPOTENCE 
4.1 (SVI) Default Properties :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.2 (SVI) Non Default Properties [ensure => present]

  * TestStep :: 4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST    
4.2 (SVI) Non Default Properties [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: RESOURCE    
4.2 (SVI) Non Default Properties :: RESOURCE     :: PASS

  * TestStep :: 4.2 (SVI) Non Default Properties :: IDEMPOTENCE 
4.2 (SVI) Non Default Properties :: IDEMPOTENCE  :: PASS

Found Platform string: 'Nexus9000 C9396PX Chassis', Alias to: 'n9k'

Using interface: vlan13

--------
4.3 (SVI) Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.3 (SVI) Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: RESOURCE    
4.3 (SVI) Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE 
4.3 (SVI) Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

Using interface: vlan13

--------
4.4 (SVI) Non Default SVI Autostate Property [ensure => present]

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST    
4.4 (SVI) Non Default SVI Autostate Property [ensure => present] :: MANIFEST     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE    
4.4 (SVI) Non Default SVI Autostate Property :: RESOURCE     :: PASS

  * TestStep :: 4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE 
4.4 (SVI) Non Default SVI Autostate Property :: IDEMPOTENCE  :: PASS

------------------------------------------------------------
Section 5. MISC Property Testing

5.1 negotiate-auto :: negotiate :: SKIP
Platform type does not match testcase platform regexp: /n(5|6|7)k/

  * TestStep :: Pre Clean:
  * Pre Clean: Set 'ethernet1/1' to default state

------------------------------------------------------------
  SKIPPED TESTS SUMMARY
------------------------------------------------------------
5.1 negotiate-auto                       :: SKIP


TestCase ::  :: SKIP
Begin ./cisco_interface/./test_vlan_mapping.rb

TestCase :: Resource cisco_interface: vlan_mapping properties

------------------------------------------------------------
Section 0. Testbed Initialization

  * Check for Compatible Line Module
** PLATFORM PREREQUISITE NOT MET: MT-full tests require f3 or compatible line module


TestCase :: cisco_interface :: SKIP
      Test Suite: tests @ 2016-02-11 06:30:04 -0500

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 391.94 seconds
      Average Test Time: 195.97 seconds
              Attempted: 2
                 Passed: 0
                 Failed: 0
                Errored: 0
                Skipped: 2
                Pending: 0
                  Total: 2

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case ./cisco_interface/./test_interface.rb skip
  Test Case ./cisco_interface/./test_vlan_mapping.rb skip
Pending Tests Cases:


No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
Warning: ssh connection to dt-n9k5-1.cisco.com has been terminated
Warning: ssh connection to rtp-puppetmaster2.cisco.com has been terminated
Beaker completed successfully, thanks.

```