### PR TITLE
Update module version and netdev_stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ciscopuppet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "cisco",
   "summary": "Cisco Puppet providers and types for NX-OS devices",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/cisco/cisco-network-puppet-module",
   "issues_url": "https://github.com/cisco/cisco-network-puppet-module/issues",
   "dependencies": [
-    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.11.0" }
+    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.11.1" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
- Update `cisco-network-puppet-module` version to `1.2.0`
- Update `puppetlabs/netdev_stdlib` version requirement to be `0.11.1`
   - https://forge.puppetlabs.com/puppetlabs/netdev_stdlib

**Build Module**
```
# puppet module build cisco-network-puppet-module
Notice: Building /root/github/release120/cisco-network-puppet-module for release
Module built: /root/github/release120/cisco-network-puppet-module/pkg/puppetlabs-ciscopuppet-1.2.0.tar.gz
# 
```

**Install Module**
```
# puppet module install ./puppetlabs-ciscopuppet-1.2.0.tar.gz
Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/etc/puppetlabs/code/environments/production/modules
└─┬ puppetlabs-ciscopuppet (v1.2.0)
  └── puppetlabs-netdev_stdlib (v0.11.0 -> v0.11.1)
root@rtp-puppetmaster2:~/github/release120/cisco-network-puppet-module/pkg# 
root@rtp-puppetmaster2:~/github/release120/cisco-network-puppet-module/pkg# puppet module list
/etc/puppetlabs/code/environments/production/modules
├── puppetlabs-ciscopuppet (v1.2.0)
└── puppetlabs-netdev_stdlib (v0.11.1)
/etc/puppetlabs/code/modules (no modules installed)
/opt/puppetlabs/puppet/modules (no modules installed)
# 
```