### PR TITLE
Add OAC install documentation

### DIFF
--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -23,8 +23,18 @@ This document describes Puppet agent installation and setup on Cisco Nexus switc
 #### Platform and Software Minimum Requirements
 
 * The Cisco NX-OS Puppet implementation requires open source Puppet version 4.0 or Puppet Enterprise 2015.2
-* Cisco NX-OS release 7.0(3)I2(1)
-* Supported Platforms: Cisco Nexus 95xx, Nexus 93xx, Nexus 30xx, Nexus 31xx
+* The following table lists supported platforms and OS versions.
+
+Platform         | OS    | OS Version           |
+-----------------|-------|----------------------|
+Cisco Nexus 30xx | NX-OS | 7.0(3)I2(1) and later
+Cisco Nexus 31xx | NX-OS | 7.0(3)I2(1) and later
+Cisco Nexus 93xx | NX-OS | 7.0(3)I2(1) and later
+Cisco Nexus 95xx | NX-OS | 7.0(3)I2(1) and later
+Cisco N9kv       | NX-OS | 7.0(3)I2(1) and later
+Cisco Nexus 56xx | NX-OS | 7.3(0)N1(1) and later
+Cisco Nexus 60xx | NX-OS | 7.3(0)N1(1) and later
+Cisco Nexus 7xxx | NX-OS | 7.3(0)D1(1) and later
 
 Please note: A virtual Nexus N9000/N3000 may be helpful for development and testing. Users with a valid [cisco.com](http://cisco.com) user ID can obtain a copy of a virtual Nexus N9000/N3000 by sending their [cisco.com](http://cisco.com) user ID in an email to <get-n9kv@cisco.com>. If you do not have a [cisco.com](http://cisco.com) user ID please register for one at [https://tools.cisco.com/IDREG/guestRegistration](https://tools.cisco.com/IDREG/guestRegistration)
 
@@ -35,15 +45,22 @@ Puppet agent software.
 
 #### Environment
 
-NX-OS supports two possible environments for running third party software:
-`bash-shell` and `guestshell`. Choose one environment for running the
-Puppet agent software. You may run Puppet from either environment but not from both
-at the same time.
+NX-OS supports three possible environments for running third party software:
+`bash-shell`, `guestshell` and the `open agent container (OAC)`.
+
+Environment                  | Supported Platforms                      |
+-----------------------------|------------------------------------------|
+`bash-shell` or `guestshell` | Cisco Nexus 30xx, 31xx, 93xx, 95xx, N9Kv |
+`open agent container`       | Cisco Nexus 56xx, 60xx, 7xxx             |
+
+You may run Puppet from either `bash-shell` or `guestshell` on supported platforms but not from both at the same time.
 
 * `bash-shell`
   * This is the native WRL Linux environment underlying NX-OS. It is disabled by default.
 * `guestshell`
-  * This is a secure Linux container environment running CentOS. It is enabled by default in most platforms.
+  * This is a secure Linux container environment running CentOS. It is enabled by default in most platforms that support it.
+* `open agent container`
+  * This is a 32-bit CentOS based container targeted specifically to allow Puppet Agents on platforms that support it.  The OAC must be downloaded and installed before the Puppet Agent can be installed.
 
 #### Set Up the Network
 
@@ -113,13 +130,6 @@ EOF
 ```
 vsh -c 'copy running-config startup-config'
 ```
-
-Optionally, configure a proxy server:
-
-~~~bash
-export http_proxy=http://proxy.yourdomain.com:<port>
-export https_proxy=https://proxy.yourdomain.com:<port>
-~~~
 
 ## <a name="env-gs">Puppet Agent Environment: guestshell</a>
 
@@ -206,13 +216,176 @@ search mycompany.com
 EOF
 ~~~
 
+## <a name="env-gs">Puppet Agent Environment: open agent container</a>
+
+This section is only necessary if Puppet will run from the `open agent container`.
+
+#### Set Up NX-OS
+
+Download the `OAC` `oac.1.1.0.ova` file.
+
+* For Cisco Nexus 7xxx devices: [Download Link](https://software.cisco.com/download/release.html?i=!y&mdfid=283748960&softwareid=282088129&release=7.3%280%29D1%281%29&os=)
+
+* For Cisco Nexus 56xx and 60xx devices: [Download Link]**TODO**()
+
+Copy the `ova` file to the `bootflash:` device.
+
+~~~
+n7k# dir bootflash: | inc oac.1.0.0.ova
+   45424640    Feb 12 19:37:40 2016  oac.1.0.0.ova
+n7k# 
+~~~
+
+Use the `show virtual-service global` command to display available resources for the `OAC` Virtual Service.
+
+~~~
+n7k# show virtual-service global 
+
+Virtual Service Global State and Virtualization Limits:
+
+Infrastructure version : 1.9
+Total virtual services installed : 0
+Total virtual services activated : 0
+
+Machine types supported   : LXC
+Machine types disabled    : KVM
+
+Maximum VCPUs per virtual service : 1
+
+Resource virtualization limits:
+Name                        Quota    Committed    Available
+-----------------------------------------------------------------------
+system CPU (%)                  6            0            6
+memory (MB)                  2304            0         2304
+bootflash (MB)                600            0          600
+
+n7k# 
+~~~
+
+The recommended minimum values are currently:
+
+~~~bash
+  memory    : 256MB
+  bootflash : 400MB
+~~~
+
+**NOTE:** If insufficent `bootflash:` resources are available, remove unneeded files from `bootflash:` to free up space.
+
+Install the `OAC` Virtual Service using the `virtual-service install name oac package bootflash:oac.ova` command.
+
+~~~
+n7k# virtual-service install name oac package bootflash:oac.1.1.0.ova
+Note: Installing package 'bootflash:/oac.1.1.0.ova' for virtual service 'oac'. Once the install has finished, the VM may be activated. Use 'show virtual-service list' for progress.
+
+n7k# 2016 Feb 12 19:51:14 n7k %$ VDC-1 %$ %VMAN-2-INSTALL_STATE: Successfully installed virtual service 'oac'
+
+n7k# show virtual-service list
+
+Virtual Service List:
+
+Name                    Status             Package Name
+-----------------------------------------------------------------------
+oac                     Installed          oac.1.1.0.ova
+
+n7k# 
+~~~
+
+Configure and activate the OAC Virtual Service.
+
+~~~
+n7k# config t
+Enter configuration commands, one per line.  End with CNTL/Z.
+n7k(config)# virtual-service oac
+n7k(config-virt-serv)# activate
+Note: Activating virtual-service 'oac', this might take a few minutes. Use 'show virtual-service list' for progress.
+n7k(config-virt-serv)# 
+n7k(config-virt-serv)# end
+n7k# 
+n7k# 2016 Feb 12 19:55:06 n7k %$ VDC-1 %$ %VMAN-2-ACTIVATION_STATE: Successfully activated virtual service 'oac'
+
+n7k# show virtual-service list
+
+Virtual Service List:
+
+Name                    Status             Package Name
+-----------------------------------------------------------------------
+oac                     Activated          oac.1.1.0.ova
+
+n7k# 
+~~~
+
+Connect to the `OAC` Virtual Service using the `virtual-service connect name oac console` command.
+
+~~~
+n7k# virtual-service connect name oac console
+Connecting to virtual-service.  Exit using ^c^c^c
+Trying 127.1.1.5...
+Connected to 127.1.1.5.
+Escape character is '^]'.
+
+
+CentOS release 6.7 (Final)
+Kernel 2.6.99.99 on an x86_64
+
+localhost login: root
+Password: 
+You are required to change your password immediately (root enforced)
+Changing password for root.
+(current) UNIX password: 
+New password: 
+Retype new password: 
+[root@localhost ~]# 
+[root@localhost ~]# 
+~~~
+
+The initial `root` password is `oac` but you will be required to change it immediately.
+
+See [References](#references) for more OAC documentation *TODO*.
+
+#### Set Up OAC Network
+
+The `open agent container` is an independent CentOS container that doesn't inherit settings from NX-OS; thus it requires additional network configuration.  This configuration will be applied inside the `OAC` container.
+
+~~~bash
+# Once connected to the OAC console
+
+# If using the management interface, you must enter the management namespace
+sudo su -
+chvrf management
+
+# Set up hostname and DNS configuration
+hostname n7k
+
+echo 'n7k' > /etc/hostname
+
+cat >> /etc/resolv.conf << EOF
+nameserver 10.0.0.202
+domain mycompany.com
+search mycompany.com
+EOF
+~~~
+
 ## <a name="agent-config">Puppet Agent Installation, Configuration, and Usage</a>
 
-This section is common to both `bash-shell` and `guestshell`.
+This section is common to `bash-shell`, `guestshell` and the `open agent container`.
 
 #### Install Puppet Agent
 
-The `bash-shell` and `guestshell` environments use different puppet RPMs.
+If needed, configure a proxy server to gain network access to `yum.puppetlabs.com`:
+
+~~~bash
+export http_proxy=http://proxy.yourdomain.com:<port>
+export https_proxy=https://proxy.yourdomain.com:<port>
+~~~
+
+Import the GPG keys.
+
+~~~
+rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-reductive
+~~~
+
+The `bash-shell`, `guestshell` and `open agent container` environments use different puppet RPMs.
 
 * For `bash-shell` use:
 
@@ -227,6 +400,14 @@ yum install puppet
 yum install http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 yum install puppet
 ~~~
+
+* For `open agent container` use:
+
+~~~bash
+yum install http://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
+yum install puppet
+~~~
+
 
 Update PATH var:
 
@@ -354,7 +535,7 @@ systemctl start my_puppet
 
 ----
 ~~~
-Copyright (c) 2014-2015 Cisco and/or its affiliates.
+Copyright (c) 2014-2016 Cisco and/or its affiliates.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -236,7 +236,6 @@ Copy the `ova` file to the `bootflash:` device.
 ~~~
 n7k# dir bootflash: | inc oac.1.0.0.ova
    45424640    Feb 12 19:37:40 2016  oac.1.0.0.ova
-n7k# 
 ~~~
 
 Use the `show virtual-service global` command to display available resources for the `OAC` Virtual Service.


### PR DESCRIPTION
Adds OAC install documentation.

Few things missing will be added in a subsequent update
- OAC download link for n5/6k.  Kokomo has not been officially released yet.
- OAC documentation (need link)