### PR TITLE
Hotfix v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.1] - 2016-02-13
+
+### Fixed
+- Fixed Cisco NetDev port_channel provider to use the correct cisco_node_utils object.
+- Fixed beaker test setup and cleanup issues.
+- Fixed incomplete documentation references for the open agent container (OAC)
+ 
 ## [1.2.0] - 2016-02-12
 
 ### New feature support
@@ -149,6 +156,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial release of puppetlabs-ciscopuppet module, supporting Cisco NX-OS software release 7.0(3)I2(1) on Cisco Nexus switch platforms: N95xx, N93xx, N30xx and N31xx.
 - Please note: 0.9.0 is an EFT pre-release for a limited audience with access to NX-OS 7.0(3)I2(1). Additional code changes may occur in 0.9.x prior to the final 1.0.0 release.
 
+[1.2.1]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.0.1...v1.0.2

--- a/README.md
+++ b/README.md
@@ -2729,6 +2729,9 @@ Minimum Requirements:
   * Cisco Nexus 93xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
   * Cisco Nexus 31xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
   * Cisco Nexus 30xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
+  * Cisco Nexus 56xx, OS Version 7.3(0)N1(1), Environments: Open Agent Container (OAC)
+  * Cisco Nexus 60xx, OS Version 7.3(0)N1(1), Environments: Open Agent Container (OAC)
+  * Cisco Nexus 7xxx, OS Version 7.3(0)D1(1), Environments: Open Agent Container (OAC)
 
 ## Learning Resources
 

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -3,14 +3,15 @@
 #### Table of Contents
 
 1. [Overview](#overview)
-2. [Pre-Install Tasks](#pre-install)
-3. [Puppet Agent Environment: bash-shell](#env-bs)
-4. [Puppet Agent Environment: guestshell](#env-gs)
-5. [Puppet Agent Installation, Configuration and Usage](#agent-config)
-6. [Optional: Guestshell & High Availability (HA) Platforms](#ha)
-7. [Optional: Puppet Agent Persistence](#persistence)
-8. [Optional: Automated Installation Options](#auto-install)
-9. [References](#references)
+1. [Pre-Install Tasks](#pre-install)
+1. [Puppet Agent Environment: bash-shell](#env-bs)
+1. [Puppet Agent Environment: guestshell](#env-gs)
+1. [Puppet Agent Environment: open agent container (OAC)](#env-oac)
+1. [Puppet Agent Installation, Configuration and Usage](#agent-config)
+1. [Optional: Guestshell & High Availability (HA) Platforms](#ha)
+1. [Optional: Puppet Agent Persistence](#persistence)
+1. [Optional: Automated Installation Options](#auto-install)
+1. [References](#references)
 
 ## <a name="overview">Overview</a>
 
@@ -218,7 +219,7 @@ search mycompany.com
 EOF
 ~~~
 
-## <a name="env-gs">Puppet Agent Environment: open agent container</a>
+## <a name="env-oac">Puppet Agent Environment: open agent container (OAC)</a>
 
 This section is only necessary if Puppet will run from the `open agent container`.
 

--- a/lib/puppet/provider/port_channel/nxapi.rb
+++ b/lib/puppet/provider/port_channel/nxapi.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:port_channel).provide(:nxapi, parent: Puppet::Type.type(:cisc
 
   def self.instances
     interfaces = []
-    Cisco::Interface.interfaces.each do |interface_name, i|
+    Cisco::InterfaceChannelGroup.interfaces.each do |interface_name, i|
       interface = {
         interface:     interface_name,
         channel_group: i.send(:channel_group),
@@ -66,7 +66,7 @@ Puppet::Type.type(:port_channel).provide(:nxapi, parent: Puppet::Type.type(:cisc
       # loop through interfaces
       if @resource[:interfaces]
         @resource[:interfaces].each do |i|
-          bla = Cisco::Interface.interfaces[i]
+          bla = Cisco::InterfaceChannelGroup.interfaces[i]
           bla.channel_group = @resource[:id] if @resource[:id]
         end
       end

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
@@ -79,6 +79,10 @@ def find_ospf_interface(tests)
 end
 int = find_ospf_interface(tests)
 
+# Cleanup commands for 'system default switchport [default]'
+cmd1 = 'no system default switchport'
+cmd2 = cmd1 + ' shutdown'
+
 # @test_name [TestCase] Executes defaults testcase for ACCESSVLAN Resource.
 test_name "TestCase :: #{testheader}" do
   resource_absent_cleanup(agent, 'cisco_vlan', 'VLAN CLEAN :: ')
@@ -93,6 +97,11 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Ensure that 'system default switchport [default]' is set property before
+    # the test starts.
+    command_config(agent, cmd1, cmd1)
+    command_config(agent, cmd2, cmd2)
 
     logger.info("Setup switch for provider test :: #{result}")
   end
@@ -169,6 +178,11 @@ test_name "TestCase :: #{testheader}" do
 
     logger.info("Check cisco_interface resource absence on agent :: #{result}")
   end
+
+  # Ensure that 'system default switchport [default]' is set property before
+  # after the test ends.
+  command_config(agent, cmd1, cmd1)
+  command_config(agent, cmd2, cmd2)
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
@@ -79,6 +79,10 @@ def find_ospf_interface(tests)
 end
 int = find_ospf_interface(tests)
 
+# Cleanup commands for 'system default switchport [default]'
+cmd1 = 'no system default switchport'
+cmd2 = cmd1 + ' shutdown'
+
 # @test_name [TestCase] Executes nondefaults testcase for ACCESSVLAN Resource.
 test_name "TestCase :: #{testheader}" do
   resource_absent_cleanup(agent, 'cisco_vlan', 'VLAN CLEAN :: ')
@@ -93,6 +97,11 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    # Ensure that 'system default switchport' [default] is set property before
+    # the test starts.
+    command_config(agent, cmd1, cmd1)
+    command_config(agent, cmd2, cmd2)
 
     logger.info("Setup switch for provider test :: #{result}")
   end
@@ -169,6 +178,11 @@ test_name "TestCase :: #{testheader}" do
 
     logger.info("Check cisco_interface resource absence on agent :: #{result}")
   end
+
+  # Ensure that 'system default switchport [default]' is set property before
+  # after the test ends.
+  command_config(agent, cmd1, cmd1)
+  command_config(agent, cmd2, cmd2)
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -338,13 +338,18 @@ test_name "TestCase :: #{testheader}" do
   tests[id][:desc] = '2.6 Multicast Group'
   test_harness_cisco_vxlan_vtep_vni(tests, id)
 
-  id = 'suppress_arp_true'
-  tests[id][:desc] = '2.7 Suppress ARP'
-  test_harness_cisco_vxlan_vtep_vni(tests, id)
+  # TBD - The following tests will generate the following error.
+  #  ERROR: Please configure TCAM region... Configuring the TCAM region
+  # requires a switch reboot.  These tests will remain commented out
+  # until we can design a solution.
 
-  id = 'suppress_arp_false'
-  tests[id][:desc] = '2.8 Suppress ARP'
-  test_harness_cisco_vxlan_vtep_vni(tests, id)
+  # id = 'suppress_arp_true'
+  # tests[id][:desc] = '2.7 Suppress ARP'
+  # test_harness_cisco_vxlan_vtep_vni(tests, id)
+
+  # id = 'suppress_arp_false'
+  # tests[id][:desc] = '2.8 Suppress ARP'
+  # test_harness_cisco_vxlan_vtep_vni(tests, id)
 
   resource_absent_cleanup(agent, 'cisco_vxlan_vtep_vni',
                           'Setup switch for cisco_vxlan_vtep_vni provider test')

--- a/tests/beaker_tests/file_service_package/package_provider_nondefaults_2.rb
+++ b/tests/beaker_tests/file_service_package/package_provider_nondefaults_2.rb
@@ -59,6 +59,12 @@ require File.expand_path('../filesvcpkglib.rb', __FILE__)
 result = 'PASS'
 testheader = 'PACKAGE Resource :: All Attributes NonDefaults'
 
+skipmsg = "\n\n*** WARNING ***\nThis test case relies on patches that are " \
+  "built for specific image versions.\nMake sure the patch being tested is " \
+  'compatible with the current image and then comment out this ' \
+  "raise_skip_exception call to run the test.\n*** WARNING ***\n"
+raise_skip_exception(skipmsg, self)
+
 # @test_name [TestCase] Executes nondefaults testcase for PACKAGE Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/netdev_stdlib/domain_name_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/domain_name_provider_defaults.rb
@@ -58,6 +58,10 @@ require File.expand_path('../domain_namelib.rb', __FILE__)
 result = 'PASS'
 testheader = 'DOMAIN_NAME Resource :: All Attributes Defaults'
 
+# Cleanup commands for test setup/cleanup
+clean_commands = ['no ip domain-name test.abc', 'no ip domain-name test.xyz',
+                  'no vrf context test']
+
 # @test_name [TestCase] Executes defaults testcase for NAME_SERVER Resource.
 test_name "TestCase :: #{testheader}" do
   ## @step [Step] Sets up switch for provider test.
@@ -65,20 +69,10 @@ test_name "TestCase :: #{testheader}" do
     # Let's check and make sure that an expected default group/role is present
     # and an unexpected non-default group/role is absent
 
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    cmd_str = get_vshell_cmd('conf t ; ' \
-                                        'no ip domain-name test.abc ;' \
-                                        'no ip domain-name test.xyz ;' \
-                                        'no vrf context test')
-    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
-
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config all')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/domain-name test.abc$/],
-                               true, self, logger)
+    clean_commands.each do |cmd|
+      command_config(agent, cmd, cmd)
     end
+
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -164,6 +158,10 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check domain_name instance absence on agent :: #{result}")
+  end
+
+  clean_commands.each do |cmd|
+    command_config(agent, cmd, cmd)
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.


### PR DESCRIPTION
- Fixed Cisco NetDev port_channel provider to use the correct cisco_node_utils object.
- Fixed beaker test setup and cleanup issues.
- Fixed incomplete documentation references for the open agent container (OAC)