### PR TITLE
Bump metadata for 1.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.2.1] - 2016-02-13
+## [1.2.2] - 2016-02-14
 
 ### Fixed
-- Fixed Cisco NetDev port_channel provider to use the correct cisco_node_utils object.
+- Fixed Cisco NetDev port\_channel provider to use the correct cisco\_node\_utils object.
 - Fixed beaker test setup and cleanup issues.
 - Fixed incomplete documentation references for the open agent container (OAC)
- 
+
+## 1.2.1
+This version was never released.
+
 ## [1.2.0] - 2016-02-12
 
 ### New feature support
@@ -156,7 +159,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial release of puppetlabs-ciscopuppet module, supporting Cisco NX-OS software release 7.0(3)I2(1) on Cisco Nexus switch platforms: N95xx, N93xx, N30xx and N31xx.
 - Please note: 0.9.0 is an EFT pre-release for a limited audience with access to NX-OS 7.0(3)I2(1). Additional code changes may occur in 0.9.x prior to the final 1.0.0 release.
 
-[1.2.1]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.0...v1.2.1
+[1.2.2]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.0...v1.2.2
 [1.2.0]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.0.1...v1.0.2

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ciscopuppet",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "author": "cisco",
   "summary": "Cisco Puppet providers and types for NX-OS devices",
   "license": "Apache-2.0",


### PR DESCRIPTION
The metadata was never updated for 1.2.1 but a tag was already made, so this PR bumps the metadata to 1.2.2 so that the package will build cleanly with the correct version.