### PR TITLE
Doc changes for route-map/route-policy differences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Install a backup path into the forwarding table and provide prefix 'independent 
 Enables the receive capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled.  Valid values are true, false, or 'default'
 
 ##### `additional_paths_selection`
-Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the route-map.
+Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the [route-map](#cisco-ios-differences).
 
 ##### `additional_paths_send`
 Enables the send capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled. Valid values are true, false, or 'default'
@@ -632,7 +632,7 @@ Specify max suppress time for route-flap dampening stable route. Valid values ar
 Specify route reuse time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_routemap`
-Specify route-map for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Specify [route-map](#cisco-ios-differences) for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_suppress_time`
 Specify route suppress time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
@@ -675,7 +675,7 @@ Configures the maximum number of equal-cost paths for load sharing. Valid value 
 Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
 ##### `networks`
-Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional route-map.
+Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional [route-map](#cisco-ios-differences).
 
 Example: IPv4 Networks Array
 
@@ -699,10 +699,10 @@ Example: IPv6 Networks Array
 ```
 
 ##### `next_hop_route_map`
-Configure a route map for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Configure a [route-map](#cisco-ios-differences) for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `redistribute`
-A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a route-map/route-policy name. A route-map/route-policy is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
+A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a [route-map](#cisco-ios-differences) name. A route-map is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
 
 Example: Platform requiring route-maps
 
@@ -734,7 +734,7 @@ Advertises only active routes to peersy. Valid values are true, false, or 'defau
 Apply table-map to filter routes downloaded into URIB. Valid values are a string.
 
 ##### `table_map_filter`
-Filters routes rejected by the route map and does not download them to the RIB. Valid values are true, false, or 'default'. This property is not supported on IOS XR.
+Filters routes rejected by the route-map and does not download them to the RIB. Valid values are true, false, or 'default'. This property is not supported on IOS XR.
 
 --
 ### Type: cisco_bgp_neighbor
@@ -867,7 +867,7 @@ Optional max-occurrences value for `allowas_in`. Valid values are an integer val
 `default-originate`. Valid values are True, False, or 'default'. Related: `default_originate_route_map`.
 
 ##### `default_originate_route_map`
-Optional route-map for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
+Optional [route-map](#cisco-ios-differences) for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
 
 ##### `filter_list_in`
 Valid values are a string defining a filter-list name, or 'default'. This property is not supported on IOS XR.
@@ -900,10 +900,10 @@ Valid values are a string defining a prefix-list name, or 'default'. This proper
 Valid values are a string defining a prefix-list name, or 'default'. This property is not supported on IOS XR.
 
 ##### `route_map_in`
-Valid values are a string defining a route-map name, or 'default'.
+Valid values are a string defining a [route-map](#cisco-ios-differences) name, or 'default'.
 
 ##### `route_map_out`
-Valid values are a string defining a route-map name, or 'default'.
+Valid values are a string defining a [route-map](#cisco-ios-differences) name, or 'default'.
 
 ##### `route_reflector_client`
 `route-reflector-client`. Valid values are True, False, or 'default'.
@@ -2062,6 +2062,14 @@ Minimum Requirements:
   * Cisco Nexus 93xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
   * Cisco Nexus 31xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
   * Cisco Nexus 30xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
+
+## Cisco IOS Differences
+
+There are some differences between NX-OS and IOS-XR as described below:
+
+* Route-Map vs Route-Policy
+  * Nexus uses route-maps in some commands, this is a string reference to a route-map defined elsewhere in the configuration.
+  * XR uses route-policies instead.  Similar to Nexus, this is a string reference to a route-policy defined elsewhere.  Under XR, a policy must be defined before it is referenced.
 
 ## Learning Resources
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Please see [Learning Resources](#learning-resources) for additional references.
    * [Resource Type Catalog (by Technology)](#resource-by-tech)
    * [Resource Type Catalog (by Name)](#resource-by-name)
 6. [Limitations - OS compatibility, etc.](#limitations)
-7. [Learning Resources](#learning-resources)
+7. [Cisco OS Differences](#cisco-os-differences)
+8. [Learning Resources](#learning-resources)
 
 
 
@@ -605,7 +606,7 @@ Install a backup path into the forwarding table and provide prefix 'independent 
 Enables the receive capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled.  Valid values are true, false, or 'default'
 
 ##### `additional_paths_selection`
-Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the [route-map](#cisco-ios-differences).
+Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the [route-map](# cisco-os-differences).
 
 ##### `additional_paths_send`
 Enables the send capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled. Valid values are true, false, or 'default'
@@ -632,7 +633,7 @@ Specify max suppress time for route-flap dampening stable route. Valid values ar
 Specify route reuse time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_routemap`
-Specify [route-map](#cisco-ios-differences) for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Specify [route-map](# cisco-os-differences) for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_suppress_time`
 Specify route suppress time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
@@ -675,7 +676,7 @@ Configures the maximum number of equal-cost paths for load sharing. Valid value 
 Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
 ##### `networks`
-Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional [route-map](#cisco-ios-differences).
+Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional [route-map](# cisco-os-differences).
 
 Example: IPv4 Networks Array
 
@@ -699,10 +700,10 @@ Example: IPv6 Networks Array
 ```
 
 ##### `next_hop_route_map`
-Configure a [route-map](#cisco-ios-differences) for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Configure a [route-map](# cisco-os-differences) for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `redistribute`
-A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a [route-map](#cisco-ios-differences) name. A route-map is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
+A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a [route-map](# cisco-os-differences) name. A route-map is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
 
 Example: Platform requiring route-maps
 
@@ -867,7 +868,7 @@ Optional max-occurrences value for `allowas_in`. Valid values are an integer val
 `default-originate`. Valid values are True, False, or 'default'. Related: `default_originate_route_map`.
 
 ##### `default_originate_route_map`
-Optional [route-map](#cisco-ios-differences) for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
+Optional [route-map](# cisco-os-differences) for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
 
 ##### `filter_list_in`
 Valid values are a string defining a filter-list name, or 'default'. This property is not supported on IOS XR.
@@ -900,10 +901,10 @@ Valid values are a string defining a prefix-list name, or 'default'. This proper
 Valid values are a string defining a prefix-list name, or 'default'. This property is not supported on IOS XR.
 
 ##### `route_map_in`
-Valid values are a string defining a [route-map](#cisco-ios-differences) name, or 'default'.
+Valid values are a string defining a [route-map](# cisco-os-differences) name, or 'default'.
 
 ##### `route_map_out`
-Valid values are a string defining a [route-map](#cisco-ios-differences) name, or 'default'.
+Valid values are a string defining a [route-map](# cisco-os-differences) name, or 'default'.
 
 ##### `route_reflector_client`
 `route-reflector-client`. Valid values are True, False, or 'default'.
@@ -2063,7 +2064,7 @@ Minimum Requirements:
   * Cisco Nexus 31xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
   * Cisco Nexus 30xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
 
-## Cisco IOS Differences
+## Cisco OS Differences
 
 There are some differences between NX-OS and IOS-XR as described below:
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Install a backup path into the forwarding table and provide prefix 'independent 
 Enables the receive capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled.  Valid values are true, false, or 'default'
 
 ##### `additional_paths_selection`
-Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the [route-map](# cisco-os-differences).
+Configures the capability of selecting additional paths for a prefix. Valid values are a string defining the name of the [route-map](#cisco-os-differences).
 
 ##### `additional_paths_send`
 Enables the send capability of additional paths for all of the neighbors under this address family for which the capability has not been disabled. Valid values are true, false, or 'default'
@@ -633,7 +633,7 @@ Specify max suppress time for route-flap dampening stable route. Valid values ar
 Specify route reuse time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_routemap`
-Specify [route-map](# cisco-os-differences) for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Specify [route-map](#cisco-os-differences) for route-flap dampening. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `dampening_suppress_time`
 Specify route suppress time for route-flap dampening. Valid values are Integer, keyword 'default'. On IOS XR, this property is only supported in the global BGP context.
@@ -676,7 +676,7 @@ Configures the maximum number of equal-cost paths for load sharing. Valid value 
 Configures the maximum number of ibgp equal-cost paths for load sharing. Valid value is an integer in the range 1-64. Default value is 1.
 
 ##### `networks`
-Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional [route-map](# cisco-os-differences).
+Networks to configure. Valid value is a list of network prefixes to advertise.  The list must be in the form of an array.  Each entry in the array must include a prefix address and an optional [route-map](#cisco-os-differences).
 
 Example: IPv4 Networks Array
 
@@ -700,10 +700,10 @@ Example: IPv6 Networks Array
 ```
 
 ##### `next_hop_route_map`
-Configure a [route-map](# cisco-os-differences) for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
+Configure a [route-map](#cisco-os-differences) for valid nexthops. Valid values are a string defining the name of the route-map. On IOS XR, this property is only supported in the global BGP context.
 
 ##### `redistribute`
-A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a [route-map](# cisco-os-differences) name. A route-map is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
+A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a [route-map](#cisco-os-differences) name. A route-map is highly advised but may be optional on some platforms, in which case it may be omitted from the array list.
 
 Example: Platform requiring route-maps
 
@@ -868,7 +868,7 @@ Optional max-occurrences value for `allowas_in`. Valid values are an integer val
 `default-originate`. Valid values are True, False, or 'default'. Related: `default_originate_route_map`.
 
 ##### `default_originate_route_map`
-Optional [route-map](# cisco-os-differences) for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
+Optional [route-map](#cisco-os-differences) for the `default_originate` property. Can be used independently or in conjunction with `default_originate`. Valid values are a string defining a route-map name, or 'default'.
 
 ##### `filter_list_in`
 Valid values are a string defining a filter-list name, or 'default'. This property is not supported on IOS XR.
@@ -901,10 +901,10 @@ Valid values are a string defining a prefix-list name, or 'default'. This proper
 Valid values are a string defining a prefix-list name, or 'default'. This property is not supported on IOS XR.
 
 ##### `route_map_in`
-Valid values are a string defining a [route-map](# cisco-os-differences) name, or 'default'.
+Valid values are a string defining a [route-map](#cisco-os-differences) name, or 'default'.
 
 ##### `route_map_out`
-Valid values are a string defining a [route-map](# cisco-os-differences) name, or 'default'.
+Valid values are a string defining a [route-map](#cisco-os-differences) name, or 'default'.
 
 ##### `route_reflector_client`
 `route-reflector-client`. Valid values are True, False, or 'default'.


### PR DESCRIPTION
My suggested doc changes.  Instead of polluting all the places where route-map is mentioned, I've moved the route-map/route-policy distinction to an OS-differences section, and linked the first use of "route-map" in each other section to this new section.
