### PR TITLE
Use correct provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,7 @@ class ciscopuppet::install (String $repo = 'https://rubygems.org', String $proxy
 
   package { 'cisco_node_utils' :
     ensure          => present,
-    provider        => 'gem',
+    provider        => 'puppet_gem',
     source          => $repo,
     install_options => $opts,
   }


### PR DESCRIPTION
The install manifest is working with Puppet 4 only (type system usage).
Puppet 4 AIO packages (like the one which will be installed on Cisco
devices) must use the 'puppet_gem' provider instead of the system 'gem'
provider.