### PR TITLE
TA88175: cisco_vrf_af:pt:Add new puppet type for cisco_vrf_af for Nexus and XR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `ipv4_forwarding`, `switchport_mode fabricpath`
 - Extended `cisco_vlan` with the following attributes:
   - `mode`
+- Extended `cisco_vrf_af` with the following attributes:
+  - `route_policy_export`
+  - `route_policy_import`
+  - `route_target_export_stitching`
+  - `route_target_import_stitching`
 - Extended `cisco_vxlan_vtep` with the following attributes:
   - `source_interface_hold_down_time`
 - Extended `cisco_bgp` with the following attributes:

--- a/README.md
+++ b/README.md
@@ -2658,14 +2658,18 @@ Manages Cisco Virtual Routing and Forwarding (VRF) Address-Family configuration.
 
 #### <a name="cisco_vrf_af-caveats">Caveats</a>
 
-| Property                    | Caveat Description                   |
-|-----------------------------|--------------------------------------|
-| route_target_both_auto      | Only supported on N3k and N9k        |
-| route_target_both_auto_evpn | Only supported on N3k and N9k        |
-| route_target_export         | Only supported on N3k, N9k, and XR   |
-| route_target_export_evpn    | Only supported on N3k and N9k        |
-| route_target_import         | Only supported on N3k, N9k, and XR   |
-| route_target_import_evpn    | Only supported on N3k and N9k        |
+| Property                      | Caveat Description                   |
+|-------------------------------|--------------------------------------|
+| route_policy_export           | Only supported on N9kv and XR        |
+| route_policy_import           | Only supported on N9kv and XR        |
+| route_target_both_auto        | Only supported on N3k and N9k        |
+| route_target_both_auto_evpn   | Only supported on N3k and N9k        |
+| route_target_export           | Only supported on N3k, N9k, and XR   |
+| route_target_export_evpn      | Only supported on N3k and N9k        |
+| route_target_export_stitching | Only supported on XR                 |
+| route_target_import           | Only supported on N3k, N9k, and XR   |
+| route_target_import_evpn      | Only supported on N3k and N9k        |
+| route_target_import_stitching | Only supported on XR                 |
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -2660,16 +2660,12 @@ Manages Cisco Virtual Routing and Forwarding (VRF) Address-Family configuration.
 
 | Property                      | Caveat Description                   |
 |-------------------------------|--------------------------------------|
-| route_policy_export           | Only supported on N9kv and XR        |
-| route_policy_import           | Only supported on N9kv and XR        |
-| route_target_both_auto        | Only supported on N3k and N9k        |
-| route_target_both_auto_evpn   | Only supported on N3k and N9k        |
-| route_target_export           | Only supported on N3k, N9k, and XR   |
-| route_target_export_evpn      | Only supported on N3k and N9k        |
-| route_target_export_stitching | Only supported on XR                 |
-| route_target_import           | Only supported on N3k, N9k, and XR   |
-| route_target_import_evpn      | Only supported on N3k and N9k        |
-| route_target_import_stitching | Only supported on XR                 |
+| route_target_both_auto        | Only supported on nexus              |
+| route_target_both_auto_evpn   | Only supported on nexus              |
+| route_target_export_evpn      | Only supported on nexus              |
+| route_target_export_stitching | Only supported on IOS XR             |
+| route_target_import_evpn      | Only supported on nexus              |
+| route_target_import_stitching | Only supported on IOS XR             |
 
 #### Parameters
 
@@ -2687,6 +2683,12 @@ Address-Family Identifier (AFI). Required. Valid values are 'ipv4' or 'ipv6'.
 ##### `safi`
 Sub Address-Family Identifier (SAFI). Required. Valid values are `unicast` or `multicast`.
 *`multicast` is not supported on some platforms.*
+
+##### `route policy export`
+Set route-policy(IOS XR) or map(nexus) export name. Valid value is string or keyword 'default'.
+
+##### `route policy import`
+Set route-policy(IOS XR) or map(nexus) import name. Valid value is string or keyword 'default'.
 
 ##### `route target both auto`
 Enable/Disable the route-target 'auto' setting for both import and export target communities. Valid values are true, false, or 'default'.
@@ -2708,11 +2710,17 @@ route_target_export_evpn => '5:5'
 ##### `route_target_import_evpn`
 (EVPN only) Sets the route-target import extended communities for EVPN. Valid values are an Array or space-separated String of extended communities, or the keyword 'default'.
 
+##### `route_target_import_stitching`
+(Stitching only) Sets the route-target import extended communities for stitching. Valid values are an Array or space-separated String of extended communities, or the keyword 'default'.
+
 ##### `route_target_export`
 Sets the route-target export extended communities. Valid values are an Array or space-separated String of extended communities, or the keyword 'default'.
 
 ##### `route_target_export_evpn`
 (EVPN only) Sets the route-target export extended communities for EVPN. Valid values are an Array or space-separated String of extended communities, or the keyword 'default'.
+
+##### `route_target_export_stitching`
+(Stitching only) Sets the route-target export extended communities for stitching. Valid values are an Array or space-separated String of extended communities, or the keyword 'default'.
 
 --
 ### Type: cisco_vtp

--- a/examples/cisco/demo_vrf.pp
+++ b/examples/cisco/demo_vrf.pp
@@ -17,12 +17,12 @@
 class ciscopuppet::cisco::demo_vrf {
 
   $rt_export_stitching = $operatingsystem ? {
-    'ios_xr' => ['22:13 stitching', '24:15 stitching'],
+    'ios_xr' => ['22:13', '24:15'],
     default  => undef
   }
 
   $rt_import_stitching = $operatingsystem ? {
-    'ios_xr' => ['26:13 stitching', '28:15 stitching'],
+    'ios_xr' => ['26:13', '28:15'],
     default  => undef
   }
 
@@ -104,7 +104,7 @@ class ciscopuppet::cisco::demo_vrf {
     route_target_import_evpn      => $rt_import_evpn,
     route_target_import_stitching => $rt_import_stitching,
     route_target_export_evpn      => $rt_export_evpn,
-    route_target_export_stitching => $rt_import_stitching,
+    route_target_export_stitching => $rt_export_stitching,
     route_target_both_auto_evpn   => $rt_both_evpn,
   }
 }

--- a/examples/cisco/demo_vrf.pp
+++ b/examples/cisco/demo_vrf.pp
@@ -16,9 +16,19 @@
 
 class ciscopuppet::cisco::demo_vrf {
 
+  $rt_export_stitching = $operatingsystem ? {
+    'ios_xr' => ['22:13 stitching', '24:15 stitching'],
+    default  => undef
+  }
+
+  $rt_import_stitching = $operatingsystem ? {
+    'ios_xr' => ['26:13 stitching', '28:15 stitching'],
+    default  => undef
+  }
+
   $shutdown = $operatingsystem ? {
     'ios_xr' => false,
-    default => undef
+    default  => undef
   }
 
   # Check for platform/linecard support
@@ -86,11 +96,15 @@ class ciscopuppet::cisco::demo_vrf {
 
   cisco_vrf_af { 'red ipv4 unicast':
     ensure                        => present,
+    route_policy_export           => 'abc',
+    route_policy_import           => 'abc',
     route_target_import           => $rt_import,
     route_target_export           => $rt_export,
     route_target_both_auto        => $rt_both,
     route_target_import_evpn      => $rt_import_evpn,
+    route_target_import_stitching => $rt_import_stitching,
     route_target_export_evpn      => $rt_export_evpn,
+    route_target_export_stitching => $rt_import_stitching,
     route_target_both_auto_evpn   => $rt_both_evpn,
   }
 }

--- a/lib/puppet/provider/cisco_vrf_af/cisco.rb
+++ b/lib/puppet/provider/cisco_vrf_af/cisco.rb
@@ -33,17 +33,25 @@ Puppet::Type.type(:cisco_vrf_af).provide(:cisco) do
   VRF_AF_ARRAY_FLAT_PROPS = [
     :route_target_import,
     :route_target_import_evpn,
+    :route_target_import_stitching,
     :route_target_export,
     :route_target_export_evpn,
+    :route_target_export_stitching,
+  ]
+  VRF_AF_NON_BOOL_PROPS = [
+    :route_policy_export,
+    :route_policy_import,
   ]
   VRF_AF_BOOL_PROPS = [
     :route_target_both_auto,
     :route_target_both_auto_evpn,
   ]
   VRF_AF_ALL_PROPS =
-    VRF_AF_ARRAY_FLAT_PROPS + VRF_AF_BOOL_PROPS
+    VRF_AF_ARRAY_FLAT_PROPS + VRF_AF_NON_BOOL_PROPS + VRF_AF_BOOL_PROPS
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_flat, self, '@nu',
                                             VRF_AF_ARRAY_FLAT_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
+                                            VRF_AF_NON_BOOL_PROPS)
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@nu',
                                             VRF_AF_BOOL_PROPS)
 
@@ -65,6 +73,9 @@ Puppet::Type.type(:cisco_vrf_af).provide(:cisco) do
     }
     # Call node_utils getter for every property
     VRF_AF_ARRAY_FLAT_PROPS.each do |prop|
+      current_state[prop] = nu_obj.send(prop)
+    end
+    VRF_AF_NON_BOOL_PROPS.each do |prop|
       current_state[prop] = nu_obj.send(prop)
     end
     VRF_AF_BOOL_PROPS.each do |prop|

--- a/lib/puppet/type/cisco_vrf_af.rb
+++ b/lib/puppet/type/cisco_vrf_af.rb
@@ -41,7 +41,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
       route_target_import_evpn     => ['7:7'],
     }
 
-    (xr)
+    (ios_xr)
     cisco_vrf_af {'red ipv4 unicast':
       ensure                        => present,
       #afi                          => 'ipv4',
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
 
   newproperty(:route_policy_export) do
     desc 'Set route-policy(ios xr) or map(nexus) export name. Valid value '\
-         'is string.'
+         "is string or keyword 'default'."
 
     munge do |val|
       val = :default if val == 'default'
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
 
   newproperty(:route_policy_import) do
     desc 'Set route-policy(ios xr) or map(nexus) import name. Valid value '\
-         'is string.'
+         "is string or keyword 'default'."
 
     munge do |val|
       val = :default if val == 'default'
@@ -234,7 +234,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
     match_error = 'must be specified in AS:nn or IPv4:nn notation'
     validate do |community|
       community.split.each do |value|
-        fail "Confederation peer value '#{value}' #{match_error}" unless
+        fail "Route target stitching peer value '#{value}' #{match_error}" unless
           /^(?:\d+\.\d+\.\d+\.)?\d+:\d+$/.match(value) ||
           value == 'default' || value == :default
       end
@@ -280,7 +280,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
     match_error = 'must be specified in AS:nn or IPv4:nn notation'
     validate do |community|
       community.split.each do |value|
-        fail "Confederation peer value '#{value}' #{match_error}" unless
+        fail "Route target stitching peer value '#{value}' #{match_error}" unless
           /^(?:\d+\.\d+\.\d+\.)?\d+:\d+$/.match(value) ||
           value == 'default' || value == :default
       end

--- a/lib/puppet/type/cisco_vrf_af.rb
+++ b/lib/puppet/type/cisco_vrf_af.rb
@@ -28,6 +28,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
 
   Example:
   ~~~puppet
+    (nexus)
     cisco_vrf_af {'red ipv4 unicast':
       ensure                       => present,
       #afi                         => 'ipv4',
@@ -38,6 +39,19 @@ Puppet::Type.newtype(:cisco_vrf_af) do
       route_target_export_evpn     => ['1:1', '2:2', '3:3'],
       route_target_import          => ['5:6'],
       route_target_import_evpn     => ['7:7'],
+    }
+
+    (xr)
+    cisco_vrf_af {'red ipv4 unicast':
+      ensure                        => present,
+      #afi                          => 'ipv4',
+      #safi                         => 'unicast',
+      route_policy_export           => 'abc',
+      route_policy_import           => 'abc',
+      route_target_export           => ['1.2.3.4:55', '8:9'],
+      route_target_export_stitching => ['1:1', '2:2', '3:3'],
+      route_target_import           => ['5:6'],
+      route_target_import_stitching => ['7:7'],
     }
   ~~~
 
@@ -131,6 +145,26 @@ Puppet::Type.newtype(:cisco_vrf_af) do
 
   ensurable
 
+  newproperty(:route_policy_export) do
+    desc 'Set route-policy(ios xr) or map(nexus) export name. Valid value '\
+         'is string.'
+
+    munge do |val|
+      val = :default if val == 'default'
+      val
+    end
+  end # property route_policy_export
+
+  newproperty(:route_policy_import) do
+    desc 'Set route-policy(ios xr) or map(nexus) import name. Valid value '\
+         'is string.'
+
+    munge do |val|
+      val = :default if val == 'default'
+      val
+    end
+  end # property route_policy_import
+
   newproperty(:route_target_both_auto) do
     desc "Enable/Disable route-target 'auto' for both import and export "\
          "target communities. Valid values are true, false, or 'default'."
@@ -192,6 +226,29 @@ Puppet::Type.newtype(:cisco_vrf_af) do
     end
   end # route_target_import_evpn
 
+  newproperty(:route_target_import_stitching, array_matching: :all) do
+    desc '(stitching only) Set the route-target import stitching communities. '\
+         'Valid values are an Array, a space-separated String of extended '\
+         "communities, or the keyword 'default'."
+
+    match_error = 'must be specified in AS:nn or IPv4:nn notation'
+    validate do |community|
+      community.split.each do |value|
+        fail "Confederation peer value '#{value}' #{match_error}" unless
+          /^(?:\d+\.\d+\.\d+\.)?\d+:\d+$/.match(value) ||
+          value == 'default' || value == :default
+      end
+    end
+
+    munge do |community|
+      community == 'default' ? :default : community.split
+    end
+
+    def insync?(is)
+      (is.size == should.flatten.size && is.sort == should.flatten.sort)
+    end
+  end # route_target_import_stitching
+
   newproperty(:route_target_export, array_matching: :all) do
     desc 'Set the route-target export extended communities. Valid values are '\
          'an Array, a space-separated String of extended communities, or the '\
@@ -237,4 +294,27 @@ Puppet::Type.newtype(:cisco_vrf_af) do
       (is.size == should.flatten.size && is.sort == should.flatten.sort)
     end
   end # route_target_export_evpn
+
+  newproperty(:route_target_export_stitching, array_matching: :all) do
+    desc '(stitching only) Set the route-target export stitching communities. '\
+         'Valid values are an Array, a space-separated String of extended '\
+         "communities, or the keyword 'default'."
+
+    match_error = 'must be specified in AS:nn or IPv4:nn notation'
+    validate do |community|
+      community.split.each do |value|
+        fail "Confederation peer value '#{value}' #{match_error}" unless
+          /^(?:\d+\.\d+\.\d+\.)?\d+:\d+$/.match(value) ||
+          value == 'default' || value == :default
+      end
+    end
+
+    munge do |community|
+      community == 'default' ? :default : community.split
+    end
+
+    def insync?(is)
+      (is.size == should.flatten.size && is.sort == should.flatten.sort)
+    end
+  end # route_target_export_stitching
 end # Puppet::Type.newtype

--- a/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
+++ b/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
@@ -95,17 +95,13 @@ tests[:title_patterns_3] = {
   resource:      { 'ensure' => 'present' },
 }
 
-def unsupported_properties(tests, id)
+def unsupported_properties(_tests, _id)
   unprops = []
   if operating_system == 'nexus'
-    if /n(3|9)k/.match(platform)
-      unprops = [
-        :route_target_export_stitching,
-        :route_target_import_stitching,
-      ]
-    else
-      unprops = tests[id][:manifest_props]
-    end
+    unprops = [
+      :route_target_export_stitching,
+      :route_target_import_stitching,
+    ]
   else
     unprops = [
       :route_target_both_auto,


### PR DESCRIPTION
Adding route_policy_export, route_policy_import, route_target_export_stitching, route_target_import_stitching.
All beaker tests passed on eXR and N9kv.