### PR TITLE
remove setup and add test_harness_dependencies

### DIFF
--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -246,24 +246,18 @@ tests[:non_default_bd] = {
   },
 }
 
-# setup_sys_bd_stp
-def setup_sys_bd_stp(platform, test_sys_bd)
-  config_sys_bd(agent, test_sys_bd) if platform == 'n7k'
-end
-
-# Helper for setting system bridge-domain configs
-def config_sys_bd(agent, test_sys_bd, stepinfo='sys-bd config:')
-  step stepinfo do
-    # Configure system bridge-domain
-    if test_sys_bd == :bd_all
-      cmd = 'system bridge-domain all'
-      command_config(agent, cmd, cmd)
-    elsif test_sys_bd == :bd_none
-      cmd = 'system bridge-domain all ; system bridge-domain none'
-      command_config(agent, cmd, cmd)
-    end
+# Overridden to properly handle dependencies for this test file.
+def test_harness_dependencies(_tests, id)
+  return unless platform == 'n7k'
+  if id == :default || id == :non_default
+    cmd = 'system bridge-domain all ; system bridge-domain none'
+    command_config(agent, cmd, cmd)
+  elsif id == :default_bd || id == :non_default_bd
+    cmd = 'system bridge-domain all'
+    command_config(agent, cmd, cmd)
   end
 end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
@@ -273,21 +267,17 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("#### This device is of type: #{device} #####")
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  setup_sys_bd_stp(device, :bd_none)
   test_harness_run(tests, :default)
   test_harness_run(tests, :default_mst)
   test_harness_run(tests, :default_plat_1)
   test_harness_run(tests, :default_plat_2)
-  setup_sys_bd_stp(device, :bd_all)
   test_harness_run(tests, :default_bd)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  setup_sys_bd_stp(device, :bd_none)
   test_harness_run(tests, :non_default)
   test_harness_run(tests, :non_default_plat_1)
   test_harness_run(tests, :non_default_plat_2)
-  setup_sys_bd_stp(device, :bd_all)
   test_harness_run(tests, :non_default_bd)
   skipped_tests_summary(tests)
 end


### PR DESCRIPTION
Chris asked me to remove the setup_sys_bd_stp() method and use the test_harness_dependencies for the beaker tests. This PR is for that.
All the test results were pass as before.