### PR TITLE
Updated test and README to support network_dns on ios_xr

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The following table indicates which providers are supported on each platform. As
 |:---|:---:|:-----:|:-----:|:-----:|:---:|:---:|:---:|
 | [domain_name](#type-domain_name) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [name_server](#type-name_server) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| [network_dns](#type-network_dns) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| [network_dns](#type-network_dns) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | [network_interface](#type-network_interface) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [network_snmp](#type-network_snmp) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | [network_trunk](#type-network_trunk) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -3092,7 +3092,7 @@ Hostname or address of the DNS server.  Valid value is a string.
 | N56xx    | unsupported        | unsupported            |
 | N6k      | unsupported        | unsupported            |
 | N7k      | unsupported        | unsupported            |
-| IOS XR   | unsupported        | unsupported            |
+| IOS XR   | TODO               | TODO                   |
 
 #### Parameters
 


### PR DESCRIPTION
```
tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb passed in 119.37 seconds
      Test Suite: tests @ 2016-03-14 15:43:05 +0000

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 119.37 seconds
      Average Test Time: 119.37 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
Cleanup: cleaning up after successful run
```