### PR TITLE
Documentation updates for IOS XR

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ The set of supported network element platforms is continuously expanding. Please
 
 ## Setup
 
-#### Puppet Master
+### Puppet Master
 
-The `ciscopuppet` module is installed on the Puppet Master server. Please see [Puppet Labs: Installing Modules](https://docs.puppetlabs.com/puppet/latest/reference/modules_installing.html) for general information on Puppet module installation.
+The `ciscopuppet` module must be installed on the Puppet Master server. Please see [Puppet Labs: Installing Modules](https://docs.puppetlabs.com/puppet/latest/reference/modules_installing.html) for general information on Puppet module installation.
 
-#### Puppet Agent
-The Puppet Agent requires installation and setup on each device. Agent setup can be performed as a manual process or it may be automated. For more information please see the [README-agent-install.md](docs/README-agent-install.md) document for detailed instructions on agent installation and configuration on Cisco Nexus devices.
+### Puppet Agent
+The Puppet Agent requires installation and setup on each device. Agent setup can be performed as a manual process or it may be automated. For more information please see the [README-agent-install.md](docs/README-agent-install.md) document for detailed instructions on agent installation and configuration on Cisco Nexus  and IOS XR devices.
 
-##### Artifacts
+#### Artifacts
 
 As noted in the agent installation guide, these are the current RPM versions for use with ciscopuppet:
 * NX-OS:
@@ -74,49 +74,9 @@ As noted in the agent installation guide, these are the current RPM versions for
 * IOS XR:
   * Native: Use [http://yum.puppetlabs.com/puppetlabs-release-pc1-cisco-wrlinux-7.noarch.rpm](http://yum.puppetlabs.com/puppetlabs-release-pc1-cisco-wrlinux-7.noarch.rpm)
 
-##### Gems
+### `cisco_node_utils` Ruby gem
 
-The ciscopuppet module has dependencies on the [`cisco_node_utils`](https://rubygems.org/gems/cisco_node_utils) ruby gem. After installing the Puppet Agent software you will then need to install the gem on the agent device.
-
-This gem has various dependencies which differ between IOS XR and Nexus; installing `cisco_node_utils` by itself will automatically install the dependencies that are relevant to the target platform.
-
-Nexus example:
-
-~~~bash
-[root@guestshell]#  /opt/puppetlabs/puppet/bin/gem install cisco_node_utils
-
-[root@guestshell]#  /opt/puppetlabs/puppet/bin/gem list | egrep 'cisco|net_http'
-cisco_node_utils (1.2.0)
-net_http_unix (0.2.1)
-~~~
-
-IOS XR example:
-
-~~~bash
-bash-4.3# /opt/puppetlabs/puppet/bin/gem install cisco_node_utils
-
-bash-4.3# /opt/puppetlabs/puppet/bin/gem list 'cisco|grpc|google'
-cisco_node_utils (1.2.0)
-google-protobuf (3.0.0.alpha.5.0.3 x86_64-linux)
-googleauth (0.5.1)
-grpc (0.13.0 x86_64-linux)
-~~~
-
-*Please note: The `ciscopuppet` module requires a compatible `cisco_node_utils` gem. This is not an issue with release versions; however, when using a pre-release module it may be necessary to manually build a compatible gem. Please see the `cisco_node_utils` developer's guide for more information on building a `cisco_node_utils` gem:  [README-develop-node-utils-APIs.md](https://github.com/cisco/cisco-network-node-utils/blob/develop/docs/README-develop-node-utils-APIs.md#step-5-build-and-install-the-gem)*
-
-##### Gem Persistence (Nexus bash-shell only)
-
-Please note that in the Nexus `bash-shell` environment these gems are currently not persistent across system reload. This persistence issue can be mitigated by simply defining a manifest entry for installing the `cisco_node_utils` gem via the package provider.
-
-Example:
-
-~~~Puppet
-package { 'cisco_node_utils' :
-  provider => 'gem',
-  ensure => present,
-}
-~~~
-*This persistence issue does not affect the `guestshell` or `open agent container (OAC)` environments. Gems are persistent across reload in these environments.*
+This module has dependencies on the [`cisco_node_utils`](https://rubygems.org/gems/cisco_node_utils) ruby gem. After installing the Puppet Agent software you will then need to install (and possibly configure) the gem on the agent device. See [README-gem-install.md](docs/README-gem-install.md) for detailed instructions.
 
 ## Usage
 
@@ -3695,8 +3655,8 @@ Minimum Requirements:
   * Cisco Nexus 7xxx, OS Version 7.3(0)D1(1), Environments: Open Agent Container (OAC)
 * Cisco IOS XR:
   * Open source Puppet version 4.3.2+ or Puppet Enterprise 2015.3.2+
-  * Cisco IOS XRv 9000, OS Version TODO, Environments: TODO
-  * Cisco Network Convergence System (NCS) 55xx, OS Version TODO, Environments: TODO
+  * Cisco IOS XRv 9000, OS Version TODO, Environments: native (Bash-shell)
+  * Cisco Network Convergence System (NCS) 55xx, OS Version TODO, Environments: native (Bash-shell)
 
 ## Cisco OS Differences
 

--- a/docs/README-beaker-agent-install.md
+++ b/docs/README-beaker-agent-install.md
@@ -3,12 +3,11 @@
 #### Table of Contents
 
 1. [Overview](#overview)
-2. [Pre-Install Tasks](#pre-install)
-3. [Beaker Installer Configuration](#beaker-install-config)
-4. [Automated Puppet Agent Install: bash-shell](#install-bs)
-5. [Automated Puppet Agent Install: guestshell](#install-gs)
-6. [Limitations](#limitations)
-7. [License Information](#license-information)
+1. [Pre-Install Tasks](#pre-install)
+1. [Beaker Installer Configuration](#beaker-install-config)
+1. [Automated Puppet Agent Install: bash-shell](#install-bs)
+1. [Automated Puppet Agent Install: guestshell](#install-gs)
+1. [License Information](#license-information)
 
 ## <a name="overview">Overview</a>
 
@@ -139,20 +138,10 @@ beaker --host <path to host.cfg> --pre-suite <path to install_puppet.rb> --no-va
 
 For installs into the `guestshell`, uncomment the `target: guestshell` field in the host.cfg file and run the Beaker tool.
 
-## <a name="limitations">Limitations</a>
-
-Minimum Requirements:
-* Cisco NX-OS Puppet implementation requires open source Puppet version 4.0 or Puppet Enterprise 2015.2
-* Supported Platforms:
- * Cisco Nexus 95xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
- * Cisco Nexus 93xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
- * Cisco Nexus 31xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
- * Cisco Nexus 30xx, OS Version 7.0(3)I2(1), Environments: Bash-shell, Guestshell
-
 ## <a name="license-information">License Information</a>
 
 ~~~
-Copyright (c) 2014-2015 Cisco and/or its affiliates.
+Copyright (c) 2014-2016 Cisco and/or its affiliates.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/README-develop-beaker-scripts.md
+++ b/docs/README-develop-beaker-scripts.md
@@ -1,4 +1,4 @@
-# How To Create Beaker Test Cases
+# How To Create and Run Beaker Test Cases
 
 #### Table of Contents
 
@@ -18,36 +18,15 @@
 
 ## <a name="overview">Overview</a>
 
-This document describes the process for writing [Beaker](https://github.com/puppetlabs/beaker/blob/master/README.md) Test Cases for cisco puppet providers.
-
-## <a name="pre-install">Pre-Install Tasks</a>
+This document describes the process for writing and executing [Beaker](https://github.com/puppetlabs/beaker/blob/master/README.md) Test Cases for cisco puppet providers.
 
 ### Platform and Software Support
 
 Beaker Release 2.14.1 and later.
 
-### Disk space
+## <a name="pre-install">Pre-Install Tasks</a>
 
-400MB of free disk space on bootflash is recommended before installing the
-puppet agent software on the target agent node.
-
-### Environment
-NX-OS supports two possible environments for running 3rd party software:
-`bash-shell` and `guestshell`. Choose one environment for running the
-puppet agent software. You may run puppet from either environment but not both
-at the same time.
-
-* `bash-shell`
-  * This is the native WRL linux environment underlying NX-OS. It is disabled by default.
-* `guestshell`
-  * This is a secure linux container environment running CentOS. It is enabled by default.
-* `open agent container`
-  * This is a 32-bit CentOS-based container created specifically for running Puppet Agent software.
-  * OAC containers are created for specific platforms and must be downloaded from Cisco.
-  * The OAC must be installed before the Puppet Agent can be installed.
-
-
-Access the following [link](README-agent-install.md) for more information on enabling these environments.
+Install and set up the Puppet agent and `cisco_node_utils` gem as described in [README-agent-install.md](README-agent-install.md).
 
 ### Install Beaker
 
@@ -71,20 +50,9 @@ end
 
 ### Configure IOS XR
 
-#### Enable gRPC server
-
-[Enable the gRPC server](http://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/DataModels/b-Datamodels-cg-ncs5500/b-Datamodels-cg-ncs5500_chapter_010.html#concept_700172ED7CF44313B0D7E521B2983F32) and select a port for it to listen on. Example:
-
-~~~
-configure
-grpc port 57777
-commit
-end
-~~~
-
 #### Start SSHd for TPNNS
 
-IOS XR provides an SSH server daemon that runs within the [third-party network namespace (TPNNS)](http://www.cisco.com/c/en/us/td/docs/iosxr/AppHosting/AH_Config_Guide/AH_User_Guide_chapter_00.html#concept_B8195E8C04EF4900BF51B2F3832F52AE), which is where the Puppet agent needs to run. Start this daemon from the IOS XR bash shell:
+IOS XR provides an SSH server daemon that runs within the [third-party network namespace (TPNNS)](http://www.cisco.com/c/en/us/td/docs/iosxr/AppHosting/AH_Config_Guide/AH_User_Guide_chapter_00.html#concept_B8195E8C04EF4900BF51B2F3832F52AE), which is where Beaker needs to run the Puppet agent. Start this daemon from the IOS XR bash shell:
 
 ~~~bash
 run bash

--- a/docs/README-gem-install.md
+++ b/docs/README-gem-install.md
@@ -1,0 +1,79 @@
+# Installing the `cisco_node_utils` gem for Puppet
+
+#### Table of Contents
+
+1. [Overview](#overview)
+1. [Gem Installation](#gem-installation)
+1. [Gem Configuration](#gem-configuration)
+1. [Gem Persistence](#gem-persistence)
+
+## Overview
+
+The ciscopuppet module has dependencies on the [`cisco_node_utils`](https://rubygems.org/gems/cisco_node_utils) ruby gem. After [installing the Puppet Agent software](README-agent-install.md) you will then need to install the gem on the agent device.
+
+## Gem Installation
+
+This gem has various dependencies which differ between IOS XR and Nexus; installing `cisco_node_utils` by itself will automatically install the dependencies that are relevant to the target platform.
+
+Nexus example:
+
+~~~bash
+[root@guestshell]# /opt/puppetlabs/puppet/bin/gem install cisco_node_utils
+...
+[root@guestshell]# /opt/puppetlabs/puppet/bin/gem list | egrep 'cisco|net_http'
+cisco_node_utils (1.2.0)
+net_http_unix (0.2.1)
+~~~
+
+IOS XR example:
+
+~~~bash
+bash-4.3# /opt/puppetlabs/puppet/bin/gem install cisco_node_utils
+...
+bash-4.3# /opt/puppetlabs/puppet/bin/gem list 'cisco|grpc|google'
+cisco_node_utils (1.2.0)
+google-protobuf (3.0.0.alpha.5.0.3 x86_64-linux)
+googleauth (0.5.1)
+grpc (0.13.0 x86_64-linux)
+~~~
+
+*Please note: The `ciscopuppet` module requires a compatible `cisco_node_utils` gem. This is not an issue with release versions; however, when using a pre-release module it may be necessary to manually build a compatible gem. Please see the `cisco_node_utils` developer's guide for more information on building a `cisco_node_utils` gem:  [README-develop-node-utils-APIs.md](https://github.com/cisco/cisco-network-node-utils/blob/develop/docs/README-develop-node-utils-APIs.md#step-5-build-and-install-the-gem)*
+
+## Gem Configuration
+
+*This section currently applies to IOS XR only.*
+
+For IOS XR, in order to use most functionality of `cisco_node_utils`, you will also need to create an appropriate [configuration file](https://github.com/cisco/cisco-network-node-utils#configuration). Since Puppet normally runs as root, we recommend creating the system-wide configuration file and marking it as readable only by root:
+
+~~~bash
+# customize these as appropriate
+export GRPC_PORT=57400
+export IOS_XR_USER='adminusername'
+export IOS_XR_PASS='admin_password!'
+cat >> /etc/cisco_node_utils.yaml << EOF
+default:
+  port: $GRPC_PORT
+  username: "$IOS_XR_USER"
+  password: "$IOS_XR_PASS"
+EOF
+sudo chown root /etc/cisco_node_utils.yaml
+sudo chmod 0600 /etc/cisco_node_utils.yaml
+~~~
+
+## Gem Persistence
+
+*This section currently applies to the NX-OS `bash-shell` environment only.*
+
+Please note that in the Nexus `bash-shell` environment these gems are currently not persistent across system reload. This persistence issue can be mitigated by simply defining a manifest entry for installing the `cisco_node_utils` gem via the package provider.
+
+Example:
+
+~~~Puppet
+package { 'cisco_node_utils' :
+  provider => 'gem',
+  ensure => present,
+}
+~~~
+
+*This persistence issue does not affect the `guestshell` or `open agent container (OAC)` environments. Gems are persistent across reload in these environments.*
+


### PR DESCRIPTION
* Add setup/installation examples for IOS XR
* Move information about installing/configuring cisco_node_utils gem into a new README-gem-install.md document so that this information can be easily referenced from several of the other READMEs without duplication.
* Various other attempts at reducing the duplication of information amongst multiple documents.