### PR TITLE
Update to require Beaker 2.38.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ log/
 pkg/
 Gemfile.lock
 *~
+*.swp
 hosts.cfg

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,11 @@ end
 beaker_version = ENV['BEAKER_VERSION']
 beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
 group :system_tests do
-  gem 'beaker', *location_for(beaker_version) if beaker_version
+  if beaker_version
+    gem 'beaker', *location_for(beaker_version)
+  else
+    gem 'beaker', '~> 2.38', '>= 2.38.1', require: false
+  end
   if beaker_rspec_version
     gem 'beaker-rspec', *location_for(beaker_rspec_version)
   else

--- a/docs/README-beaker-agent-install.md
+++ b/docs/README-beaker-agent-install.md
@@ -15,9 +15,7 @@ This document describes automated Puppet agent installation and setup on Cisco N
 
 ## <a name="pre-install">Pre-Install Tasks</a>
 
-### Platform and Software Support
-
-Beaker Release 2.14.1 and later.
+Refer to [README-beaker-prerequisites](RADME-beaker-prerequisites.md) for required setup steps for Beaker and the target agent node.
 
 ### Disk space
 
@@ -25,6 +23,7 @@ Beaker Release 2.14.1 and later.
 puppet agent software on the target agent node.
 
 ### Environment
+
 NX-OS supports two possible environments for running 3rd party software:
 `bash-shell` and `guestshell`. Choose one environment for running the
 puppet agent software. You may run puppet from either environment but not both
@@ -36,24 +35,6 @@ at the same time.
   * This is a secure linux container environment running CentOS. It is enabled by default.
 
 Access the following [link](README-agent-install.md) for more information on enabling these environments.
-
-### Install Beaker
-
-[Install Beaker](https://github.com/puppetlabs/beaker/wiki/Beaker-Installation) on your designated server.
-
-### Configure NX-OS
-
-You must enable the ssh feature and give sudo access to the 'devops' user for the Beaker workstation to access and install the Puppet agent software into the `bash-shell` or `guestshell` environment.
-
-**Example:**
-
-~~~bash
-configure terminal
-  feature ssh
-  username devops password devopspassword role network-admin
-  username devops shelltype bash
-end
-~~~
 
 ## <a name="beaker-install-config">Beaker Installer Configuration</a>
 

--- a/docs/README-beaker-prerequisites.md
+++ b/docs/README-beaker-prerequisites.md
@@ -4,7 +4,7 @@ This document describes prerequisite setup to be done before running [Beaker](ht
 
 ## Platform and Software Support
 
-Beaker Release 2.37.0 and later
+Beaker Release 2.38.1 and later
 
 ## Install Beaker
 

--- a/docs/README-beaker-prerequisites.md
+++ b/docs/README-beaker-prerequisites.md
@@ -1,0 +1,66 @@
+# Prerequisites for running Beaker
+
+This document describes prerequisite setup to be done before running [Beaker](https://github.com/puppetlabs/beaker/blob/master/README.md) against a NX-OS or IOS XR agent node, whether as an [installer](README-beaker-agent-install.md) or as a [test runner](README-develop-beaker-scripts.md)
+
+## Platform and Software Support
+
+Beaker Release 2.37.0 and later
+
+## Install Beaker
+
+[Install Beaker](https://github.com/puppetlabs/beaker/wiki/Beaker-Installation) on your designated beaker server.
+
+## Configure NX-OS
+
+You must enable the ssh feature and give sudo access to the 'devops' user for the Beaker workstation to access the Puppet agent during testing.
+
+**Example:**
+
+~~~bash
+configure terminal
+  feature ssh
+  username devops password devopspassword role network-admin
+  username devops shelltype bash
+end
+~~~
+
+*Note: To enable sshd inside the `open agent container (OAC)` reference `OAC` documentation.*
+
+### Configure IOS XR
+
+#### Start SSHd for TPNNS
+
+IOS XR provides an SSH server daemon that runs within the [third-party network namespace (TPNNS)](http://www.cisco.com/c/en/us/td/docs/iosxr/AppHosting/AH_Config_Guide/AH_User_Guide_chapter_00.html#concept_B8195E8C04EF4900BF51B2F3832F52AE), which is where Beaker needs to run the Puppet agent. Start this daemon from the IOS XR bash shell:
+
+~~~bash
+run bash
+service sshd_tpnns start
+chkconfig --add sshd_tpnns
+~~~
+
+Note that this daemon listens on port 57722 rather than the SSH default port of 22. You will configure `hosts.cfg` to specify this port for Beaker's use, but if you want to manually SSH to the node, you will need to specify the port number as well:
+
+~~~bash
+ssh devops@192.168.122.222 -p 57722
+~~~
+
+#### Configure a user for passwordless sudo
+
+`sshd_tpnns` doesn't allow login as root, but the Puppet agent needs to run with root permissions. Beaker needs to be able to log in as a user that can transparently invoke `sudo` without a password prompt. There are several ways you can edit the `/etc/sudoers` file (using `visudo` from the Bash prompt) to permit this:
+
+Enable passwordless sudo for all users in group `sudo` (which includes all configured IOS XR users in IOS XR group `root-lr`, including the root-system user created at boot time):
+
+~~~diff
+ #includedir /etc/sudoers.d
+-%sudo ALL=(ALL) ALL
++%sudo ALL=(ALL) NOPASSWD: ALL
+~~~
+
+Or, enable passwordless sudo only for a specific user, such as 'devops':
+
+~~~diff
+ #includedir /etc/sudoers.d
+ %sudo ALL=(ALL) ALL
++devops ALL=(ALL) NOPASSWD: ALL
+~~~
+

--- a/docs/README-develop-beaker-scripts.md
+++ b/docs/README-develop-beaker-scripts.md
@@ -20,71 +20,11 @@
 
 This document describes the process for writing and executing [Beaker](https://github.com/puppetlabs/beaker/blob/master/README.md) Test Cases for cisco puppet providers.
 
-### Platform and Software Support
-
-Beaker Release 2.37.0 and later.
-
 ## <a name="pre-install">Pre-Install Tasks</a>
 
+Refer to [README-beaker-prerequisites](README-beaker-prerequisites.md) for required setup steps for Beaker and the node(s) to be tested.
+
 Install and set up the Puppet agent and `cisco_node_utils` gem as described in [README-agent-install.md](README-agent-install.md).
-
-### Install Beaker
-
-[Install Beaker](https://github.com/puppetlabs/beaker/wiki/Beaker-Installation) on your designated beaker server.
-
-### Configure NX-OS
-
-You must enable the ssh feature and give sudo access to the 'devops' user for the Beaker workstation to access the Puppet agent during testing.
-
-**Example:**
-
-~~~bash
-configure terminal
-  feature ssh
-  username devops password devopspassword role network-admin
-  username devops shelltype bash
-end
-~~~
-
-*Note: To enable sshd inside the `open agent container (OAC)` reference `OAC` documentation.*
-
-### Configure IOS XR
-
-#### Start SSHd for TPNNS
-
-IOS XR provides an SSH server daemon that runs within the [third-party network namespace (TPNNS)](http://www.cisco.com/c/en/us/td/docs/iosxr/AppHosting/AH_Config_Guide/AH_User_Guide_chapter_00.html#concept_B8195E8C04EF4900BF51B2F3832F52AE), which is where Beaker needs to run the Puppet agent. Start this daemon from the IOS XR bash shell:
-
-~~~bash
-run bash
-service sshd_tpnns start
-chkconfig --add sshd_tpnns
-~~~
-
-Note that this daemon listens on port 57722 rather than the SSH default port of 22. You will configure `hosts.cfg` to specify this port for Beaker's use [below](#beaker-config), but if you want to manually SSH to the node, you will need to specify the port number as well:
-
-~~~bash
-ssh devops@192.168.122.222 -p 57722
-~~~
-
-#### Configure a user for passwordless sudo
-
-`sshd_tpnns` doesn't allow login as root, but the Puppet agent needs to run with root permissions. Beaker needs to be able to log in as a user that can transparently invoke `sudo` without a password prompt. There are several ways you can edit the `/etc/sudoers` file (using `visudo` from the Bash prompt) to permit this:
-
-Enable passwordless sudo for all users in group `sudo` (which includes all configured IOS XR users in IOS XR group `root-lr`, including the root-system user created at boot time):
-
-~~~diff
- #includedir /etc/sudoers.d
--%sudo ALL=(ALL) ALL
-+%sudo ALL=(ALL) NOPASSWD: ALL
-~~~
-
-Or, enable passwordless sudo only for a specific user, such as 'devops':
-
-~~~diff
- #includedir /etc/sudoers.d
- %sudo ALL=(ALL) ALL
-+devops ALL=(ALL) NOPASSWD: ALL
-~~~
 
 ## <a name="beaker-config">Beaker Server Configuration</a>
 

--- a/docs/README-develop-beaker-scripts.md
+++ b/docs/README-develop-beaker-scripts.md
@@ -22,7 +22,7 @@ This document describes the process for writing and executing [Beaker](https://g
 
 ### Platform and Software Support
 
-Beaker Release 2.14.1 and later.
+Beaker Release 2.37.0 and later.
 
 ## <a name="pre-install">Pre-Install Tasks</a>
 
@@ -108,9 +108,8 @@ HOSTS:
     <IOS XR agent>:
         roles:
             - agent
-        platform: cisco-7-x86_64
+        platform: cisco_ios_xr-6-x86_64
         ip: <fully qualified domain name>
-        grpc_port: <grpc port number, such as 57777 or 57799
         ssh:
           auth_methods: ["password"]
           # SSHd for third-party network namespace (TPNNS) uses port 57722
@@ -121,7 +120,7 @@ HOSTS:
     <Nexus agent>:
         roles:
             - agent
-        platform: cisco-5-x86_64
+        platform: cisco_nexus-7-x86_64
         ip: <fully qualified domain name>
         vrf: <vrf used for beaker workstation and puppet master ip reachability>
         ssh:
@@ -170,9 +169,8 @@ HOSTS:
     xr-agent:
         roles:
             - agent
-        platform: cisco-7-x86_64
+        platform: cisco_ios_xr-6-x86_64
         ip: xr-agent.domain.com
-        grpc_port: 57777
         ssh:
           auth_methods: ["password"]
           port: 57722

--- a/docs/README-develop-beaker-scripts.md
+++ b/docs/README-develop-beaker-scripts.md
@@ -367,8 +367,7 @@ tests['non_default_properties'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = UtilityLib::PUPPET_BINPATH + 'resource cisco_tunnel'
-  UtilityLib.get_namespace_cmd(agent, cmd, options)
+  UtilityLib::PUPPET_BINPATH + 'resource cisco_tunnel'
 end
 
 def build_manifest_tunnel(tests, id)
@@ -705,8 +704,7 @@ tests['non_default_properties_S'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = UtilityLib::PUPPET_BINPATH + 'resource cisco_router_eigrp'
-  UtilityLib.get_namespace_cmd(agent, cmd, options)
+  UtilityLib::PUPPET_BINPATH + 'resource cisco_router_eigrp'
 end
 
 def build_manifest_eigrp(tests, id)

--- a/docs/template-__PROVIDER__-ensurabilitytest.rb
+++ b/docs/template-__PROVIDER__-ensurabilitytest.rb
@@ -94,8 +94,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, __PROVIDERLIB__.create_<PROVIDER>_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = UtilityLib::PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -104,8 +103,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check <CISCO_PROVIDER> resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      'resource <CISCO_PROVIDER> test', options)
+    cmd_str = UtilityLib::PUPPET_BINPATH + 'resource <CISCO_PROVIDER> test'
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                           false, self, logger)
@@ -131,8 +129,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, __PROVIDERLIB__.create_<PROVIDER>_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = UtilityLib::PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -141,8 +138,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check <CISCO_PROVIDER> resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = UtilityLib.get_namespace_cmd(agent, UtilityLib::PUPPET_BINPATH +
-      'resource <CISCO_PROVIDER> test', options)
+    cmd_str = UtilityLib::PUPPET_BINPATH 'resource <CISCO_PROVIDER> test'
     on(agent, cmd_str) do
       UtilityLib.search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                           true, self, logger)

--- a/docs/template-beaker-feature.rb
+++ b/docs/template-beaker-feature.rb
@@ -140,8 +140,7 @@ end
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = UtilityLib::PUPPET_BINPATH + 'resource cisco_X__RESOURCE_NAME__X'
-  UtilityLib.get_namespace_cmd(agent, cmd, options)
+  UtilityLib::PUPPET_BINPATH + 'resource cisco_X__RESOURCE_NAME__X'
 end
 
 def build_default_values(testcase)

--- a/docs/template-beaker-router.rb
+++ b/docs/template-beaker-router.rb
@@ -148,8 +148,7 @@ end
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = UtilityLib::PUPPET_BINPATH + 'resource cisco_router_X__RESOURCE_NAME__X'
-  UtilityLib.get_namespace_cmd(agent, cmd, options)
+  UtilityLib::PUPPET_BINPATH + 'resource cisco_router_X__RESOURCE_NAME__X'
 end
 
 def build_default_values(testcase)

--- a/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_defaults.rb
@@ -87,8 +87,7 @@ def create_aaaauthelogin_defaults(tests, id, string=false)
   resource_cmd_str =
     PUPPET_BINPATH +
     "resource cisco_aaa_authentication_login '#{title}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, resource_cmd_str, options)
+  tests[id][:resource_cmd] = resource_cmd_str
 end
 
 test_name "TestCase :: #{testheader}" do

--- a/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
@@ -92,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     resource_cmd_str =
       PUPPET_BINPATH +
       "resource cisco_aaa_authentication_login 'default'"
-    tests[id][:resource_cmd] =
-      get_namespace_cmd(agent, resource_cmd_str, options)
+    tests[id][:resource_cmd] = resource_cmd_str
 
     tests[id][:code] = [0, 2]
     tests[id][:desc] =

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -78,8 +78,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -100,8 +99,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -111,8 +109,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',
@@ -144,8 +141,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -155,8 +151,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -76,8 +76,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -106,8 +104,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_deadtime_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -117,8 +114,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,
@@ -151,8 +147,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_vrf_name_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -162,8 +157,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,
@@ -197,8 +191,7 @@ test_name "TestCase :: #{testheader}" do
        AaaGroupLib.create_aaagroup_manifest_source_interface_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -208,8 +201,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,
@@ -243,8 +235,7 @@ test_name "TestCase :: #{testheader}" do
        AaaGroupLib.create_aaagroup_manifest_server_hosts_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -254,8 +245,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -78,8 +78,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -100,8 +99,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -111,8 +109,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,
@@ -147,8 +144,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AaaGroupLib.create_aaagroup_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -158,8 +154,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_aaa_group resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_aaa_group_tacacs 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_aaa_group_tacacs 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(
         stdout,

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
@@ -81,8 +81,7 @@ def create_aaalogincfgsvc_defaults(tests, id, title, string=false)
   resource_cmd_str =
     PUPPET_BINPATH +
     "resource cisco_aaa_authorization_login_cfg_svc '#{title}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, resource_cmd_str, options)
+  tests[id][:resource_cmd] = resource_cmd_str
 end
 
 test_name "TestCase :: #{testheader}" do

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
@@ -89,8 +89,7 @@ test_name "TestCase :: #{testheader}" do
     resource_cmd_str =
       PUPPET_BINPATH +
       "resource cisco_aaa_authorization_login_cfg_svc '#{title}'"
-    tests[id][:resource_cmd] =
-      get_namespace_cmd(agent, resource_cmd_str, options)
+    tests[id][:resource_cmd] = resource_cmd_str
 
     tests[id][:desc] =
       '1.1 Apply manifest with non-default attributes, and test'

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
@@ -81,8 +81,7 @@ def create_aaaloginexecsvc_defaults(tests, id, title, string=false)
   resource_cmd_str =
     PUPPET_BINPATH +
     "resource cisco_aaa_authorization_login_exec_svc '#{title}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, resource_cmd_str, options)
+  tests[id][:resource_cmd] = resource_cmd_str
 end
 
 test_name "TestCase :: #{testheader}" do

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
@@ -89,8 +89,7 @@ test_name "TestCase :: #{testheader}" do
     resource_cmd_str =
       PUPPET_BINPATH +
       "resource cisco_aaa_authorization_login_exec_svc '#{title}'"
-    tests[id][:resource_cmd] =
-      get_namespace_cmd(agent, resource_cmd_str, options)
+    tests[id][:resource_cmd] = resource_cmd_str
 
     tests[id][:desc] =
       '1.1 Apply manifest with non-default attributes, and test'

--- a/tests/beaker_tests/cisco_command_config/test_command_config.rb
+++ b/tests/beaker_tests/cisco_command_config/test_command_config.rb
@@ -226,8 +226,7 @@ tests['configure_loopback_interface'] = {
 # Full command string for puppet resource command used to verify
 # the configuration applied by the cisco_command_config resource.
 def puppet_resource_cmd(tests, id)
-  cmd = PUPPET_BINPATH + "resource #{tests[id][:puppet_resource]}"
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + "resource #{tests[id][:puppet_resource]}"
 end
 
 def build_manifest_cisco_command_config(tests, id)

--- a/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
+++ b/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
@@ -146,8 +146,7 @@ tests['non_default_properties'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_evpn_vni'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_evpn_vni'
 end
 
 def build_manifest_evpn_vni(tests, id)

--- a/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
+++ b/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
@@ -206,8 +206,7 @@ tests['non_default_properties_exclusive'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_fabricpath_global'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_fabricpath_global'
 end
 
 def build_manifest_fabricpath_global(tests, id)

--- a/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
+++ b/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
@@ -120,8 +120,7 @@ tests['non_default_properties'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_fabricpath_topology'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_fabricpath_topology'
 end
 
 def build_manifest_fabricpath_topology(tests, id)

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -464,7 +464,7 @@ def build_manifest_interface(tests, id)
 
   cmd = PUPPET_BINPATH +
         "resource cisco_interface '#{tests[id][:title_pattern]}'"
-  tests[id][:resource_cmd] = get_namespace_cmd(agent, cmd, options)
+  tests[id][:resource_cmd] = cmd
 end
 
 # Helper for 'system default switchport'

--- a/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
+++ b/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
@@ -144,8 +144,7 @@ def build_manifest_vlan_mapping(tests, id)
   }\n      }\nEOF"
 
   cmd = PUPPET_BINPATH + "resource cisco_interface '#{intf}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, cmd, options)
+  tests[id][:resource_cmd] = cmd
 end
 
 def test_harness_vlan_mapping(tests, id)

--- a/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
+++ b/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
@@ -142,7 +142,7 @@ def build_manifest_interface_channel_group(tests, id)
 
   cmd = PUPPET_BINPATH +
         "resource cisco_interface_channel_group '#{tests[id][:title_pattern]}'"
-  tests[id][:resource_cmd] = get_namespace_cmd(agent, cmd, options)
+  tests[id][:resource_cmd] = cmd
 end
 
 # Wrapper for interface_channel_group specific settings prior to calling the

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_defaults.rb
@@ -97,8 +97,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_present(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -107,8 +106,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Test idempotence by running the same manifest
   step 'TestStep :: Test idempotence by running the same manifest' do
     # Expected exit_code is 0 since there should not be any changes this time
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0])
 
     logger.info("Test idempotence by running the same manifest :: #{result}")
@@ -118,8 +116,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',
@@ -141,8 +138,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_absent(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -152,8 +148,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_negatives.rb
@@ -95,8 +95,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_cost_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -106,8 +105,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'cost' => OspfIntfLib::COST_NEGATIVE },
@@ -120,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test' ensure=absent"
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -133,8 +130,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_hellointerval_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -144,8 +140,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'hello_interval' => OspfIntfLib::HELLOINTERVAL_NEGATIVE },
@@ -158,8 +153,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test' ensure=absent"
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -171,8 +165,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_deadinterval_negative(interface))
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -182,8 +175,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'dead_interval' => OspfIntfLib::DEADINTERVAL_NEGATIVE },
@@ -196,8 +188,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test' ensure=absent"
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")
@@ -209,8 +200,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_passiveintf_negative(interface))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -220,8 +210,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'passive_interface' => OspfIntfLib::PASSIVEINTF_NEGATIVE },
@@ -234,8 +223,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Checks ospfintf instance on agent using switch show cli cmds.
   step 'TestStep :: Check ospfintf instance absence on agent' do
     # Cleanup partially configured resource.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test' ensure=absent"
     on(agent, cmd_str)
 
     logger.info("Check ospfintf instance absence on agent :: #{result}")

--- a/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/ospfintf_provider_nondefaults.rb
@@ -97,8 +97,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_nondefaults(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -108,8 +107,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',
@@ -131,8 +129,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfIntfLib.create_ospfintf_manifest_absent(interface))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -142,8 +139,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_intf_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                => 'present',
@@ -165,12 +161,10 @@ test_name "TestCase :: #{testheader}" do
     area2 = '0.0.0.6'
     on(master, OspfIntfLib.create_ospfintf_area_manifest(area1, interface))
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
     # check for successfull configured area
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',
@@ -180,12 +174,10 @@ test_name "TestCase :: #{testheader}" do
     # update area to area2
     on(master, OspfIntfLib.create_ospfintf_area_manifest(area2, interface))
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
     # check for successfull configured area
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',
@@ -193,8 +185,7 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
     end
     # cleanup
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface_ospf '#{interface} test' ensure=absent", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface_ospf '#{interface} test' ensure=absent"
     on(agent, cmd_str)
 
     logger.info("Check ospfintf area change on agent :: #{result}")

--- a/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
+++ b/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
@@ -223,9 +223,7 @@ tests['non_default_properties_eth'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH +
-        'resource cisco_interface_portchannel port-channel100'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_interface_portchannel port-channel100'
 end
 
 def build_manifest_interface_portchannel(tests, id)

--- a/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
+++ b/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
@@ -141,8 +141,7 @@ def build_manifest_interface_service_vni(tests, id)
     }\n  }\nEOF"
 
   cmd = PUPPET_BINPATH + "resource cisco_interface_service_vni '#{intf} #{sid}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, cmd, options)
+  tests[id][:resource_cmd] = cmd
 end
 
 def test_harness_interface_service_vni(tests, id)

--- a/tests/beaker_tests/cisco_ospf/ospf_provider_ensurability.rb
+++ b/tests/beaker_tests/cisco_ospf/ospf_provider_ensurability.rb
@@ -76,8 +76,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfLib.create_ospf_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -87,8 +86,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_ospf green', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_ospf green'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -103,8 +101,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfLib.create_ospf_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -114,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_ospf green', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_ospf green'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/cisco_ospf/ospf_provider_negative.rb
+++ b/tests/beaker_tests/cisco_ospf/ospf_provider_negative.rb
@@ -74,8 +74,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfLib.create_ospf_manifest_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -85,8 +84,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_ospf green', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_ospf green'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => OspfLib::ENSURE_NEGATIVE }, true, self, logger)

--- a/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_defaults.rb
@@ -79,8 +79,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -90,8 +89,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test default'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test default'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -109,8 +107,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -135,8 +132,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -146,8 +142,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test default'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test default'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -165,8 +160,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',

--- a/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_negatives.rb
@@ -82,8 +82,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_autocost_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'auto_cost' => OspfVrfLib::AUTOCOST_NEGATIVE },
@@ -110,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_defaultmetric_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -121,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'default_metric' => OspfVrfLib::DEFAULTMETRIC_NEGATIVE },
@@ -138,8 +134,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_lsahold_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -149,8 +144,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_lsa_hold' => OspfVrfLib::LSAHOLD_NEGATIVE },
@@ -166,8 +160,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_lsamax_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -177,8 +170,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_lsa_max' => OspfVrfLib::LSAMAX_NEGATIVE },
@@ -194,8 +186,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_lsastart_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -205,8 +196,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_lsa_start' => OspfVrfLib::LSASTART_NEGATIVE },
@@ -222,8 +212,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_spfhold_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -233,8 +222,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_spf_hold' => OspfVrfLib::SPFHOLD_NEGATIVE },
@@ -250,8 +238,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_spfmax_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -261,8 +248,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_spf_max' => OspfVrfLib::SPFMAX_NEGATIVE },
@@ -278,8 +264,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_spfstart_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failures.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -289,8 +274,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timer_throttle_spf_start' => OspfVrfLib::SPFSTART_NEGATIVE },

--- a/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_ospf_vrf/ospfvrf_provider_nondefaults.rb
@@ -79,8 +79,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -90,8 +89,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test default'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test default'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -109,8 +107,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -135,8 +132,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, OspfVrfLib.create_ospfvrf_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -146,8 +142,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_ospf_vrf resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test default'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test default'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',
@@ -165,8 +160,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_ospf_vrf 'test green'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_ospf_vrf 'test green'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                   => 'present',

--- a/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
+++ b/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
@@ -150,8 +150,7 @@ tests['non_default_properties'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_overlay_global'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_overlay_global'
 end
 
 def build_manifest_overlay_global(tests, id)

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -219,9 +219,7 @@ tests['non_default_properties_sym'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH +
-        'resource cisco_portchannel_global'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_portchannel_global'
 end
 
 def build_manifest_portchannel_global(tests, id)

--- a/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_defaults.rb
@@ -77,8 +77,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -88,8 +87,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',
@@ -106,8 +104,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -117,8 +114,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',

--- a/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_negatives.rb
@@ -75,8 +75,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_group_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -86,8 +85,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'group' => SnmpCommLib::GROUP_NEGATIVE },
@@ -103,8 +101,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_acl_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -114,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'acl' => SnmpCommLib::ACL_NEGATIVE },

--- a/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_snmp_community/snmpcomm_provider_nondefaults.rb
@@ -77,8 +77,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -88,8 +87,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',
@@ -107,8 +105,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommLib.create_snmpcommunity_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -118,8 +115,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_comm resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_community 'test'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_community 'test'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',

--- a/tests/beaker_tests/cisco_snmp_group/snmpgroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_snmp_group/snmpgroup_provider_defaults.rb
@@ -91,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpGroupLib.create_snmpgroup_manifest_defaults)
 
     # Expected exit_code is 0 since this is a puppet agent cmd without change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str)
 
     logger.info("Get default manifest from master :: #{result}")
@@ -102,8 +101,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_group resource state on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_group 'network-admin'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_group 'network-admin'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present' },
@@ -112,8 +110,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_group 'foobar'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_group 'foobar'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'absent' },

--- a/tests/beaker_tests/cisco_snmp_group/snmpgroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_snmp_group/snmpgroup_provider_negatives.rb
@@ -90,8 +90,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpGroupLib.create_snmpgroup_manifest_negative_1)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test manifest #1 from master :: #{result}")
@@ -102,8 +101,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpGroupLib.create_snmpgroup_manifest_negative_2)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test manifest #2 from master :: #{result}")
@@ -113,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_group resource state on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_group 'network-operator'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_group 'network-operator'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present' },
@@ -123,8 +120,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_group 'go-jackets'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_group 'go-jackets'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'absent' },

--- a/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_defaults.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -89,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_defaults)
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str)
 
     logger.info("Get resource defaults manifest from master :: #{result}")
@@ -100,8 +98,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'aaa_user_cache_timeout' => '3600',

--- a/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_negatives.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -89,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_packetsize_negative)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -100,8 +98,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'packet_size' => SnmpServerLib::PACKETSIZE_NEGATIVE },
@@ -131,8 +128,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_aaatimeout_negative)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -142,8 +138,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'aaa_user_cache_timeout' => SnmpServerLib::AAATIMEOUT_NEGATIVE },
@@ -173,8 +168,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_tcpauth_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -184,8 +178,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'tcp_session_auth' => SnmpServerLib::TCPAUTH_NEGATIVE },
@@ -215,8 +208,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_protocol_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -226,8 +218,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'protocol' => SnmpServerLib::PROTOCOL_NEGATIVE },
@@ -257,8 +248,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_globalpriv_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -268,8 +258,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'global_enforce_priv' => SnmpServerLib::GLOBALPRIV_NEGATIVE },

--- a/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_snmp_server/snmpserver_provider_nondefaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -91,8 +90,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -102,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'aaa_user_cache_timeout' => '1000',
@@ -142,8 +139,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpServerLib.create_snmpserver_manifest_defaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource defaults manifest from master :: #{result}")
@@ -153,8 +149,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_snmp_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_snmp_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'aaa_user_cache_timeout' => '3600',

--- a/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_defaults.rb
@@ -78,8 +78,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -89,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'        => 'present',
@@ -110,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -121,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'        => 'present',

--- a/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_negatives.rb
@@ -76,8 +76,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_authprotocol_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -87,8 +86,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'auth_protocol' => 'unknown',
@@ -105,8 +103,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_privprotocol_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -116,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'priv_protocol' => 'unknown',

--- a/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_snmp_user/snmpuser_provider_nondefaults.rb
@@ -78,8 +78,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -89,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'        => 'present',
@@ -110,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmpuser_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -121,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_snmp_user resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_snmp_user 'snmpuser1'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_snmp_user 'snmpuser1'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'        => 'present',

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'           => 'present',
@@ -140,8 +137,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -151,8 +147,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'           => 'present',

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -91,8 +90,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_timeout_negative)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -102,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timeout' => TacacsServerLib::TIMEOUT_NEGATIVE },
@@ -133,8 +130,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_deadtime_negative)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -144,8 +140,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'deadtime' => TacacsServerLib::DEADTIME_NEGATIVE },
@@ -175,8 +170,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_type_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -186,8 +180,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'encryption_type' => TacacsServerLib::ENCRYPTYPE_NEGATIVE },
@@ -217,8 +210,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_passwd_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -228,8 +220,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'encryption_password' => TacacsServerLib::ENCRYPPASSWD_NEGATIVE },
@@ -259,8 +250,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_sourceintf_negative)
 
     # Expected exit_code is 4 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [4])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -270,8 +260,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'source_interface' => TacacsServerLib::SOURCEINTF_NEGATIVE },

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'              => 'present',
@@ -143,8 +140,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacsserver_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -154,8 +150,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'              => 'present',

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'present',
@@ -137,8 +134,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -148,8 +144,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'present',

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_negatives.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -91,8 +90,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_timeout_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -102,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'timeout' => TacacsServerHostLib::TIMEOUT_NEGATIVE },
@@ -133,8 +130,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_port_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -144,8 +140,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'port' => TacacsServerHostLib::PORT_NEGATIVE },
@@ -175,8 +170,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_type_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -186,8 +180,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'encryption_type' => TacacsServerHostLib::ENCRYPTYPE_NEGATIVE },
@@ -217,8 +210,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_passwd_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -228,8 +220,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'encryption_password' => TacacsServerHostLib::ENCRYPPASSWD_NEGATIVE },

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
@@ -93,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'              => 'present',
@@ -138,8 +135,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerHostLib.create_tacacsserverhost_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -149,8 +145,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_tacacs_server_host absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_tacacs_server_host', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'              => 'present',

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -110,7 +110,7 @@ def build_manifest_vdc(tests, id)
   }\n      }\nEOF"
 
   cmd = PUPPET_BINPATH + "resource cisco_vdc '#{default_vdc_name}'"
-  tests[id][:resource_cmd] = get_namespace_cmd(agent, cmd, options)
+  tests[id][:resource_cmd] = cmd
 end
 
 def test_harness_vdc(tests, id)

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_defaults.rb
@@ -94,8 +94,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Ensure that 'system default switchport [default]' is set property before
@@ -112,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_present(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -123,8 +121,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
@@ -148,8 +145,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -160,8 +156,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Presence of AccessVLAN 1 implies absence of AccessVLAN 128.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_negatives.rb
@@ -88,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -101,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_ipv4proxyarp_negative(int))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -112,8 +110,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ipv4_proxy_arp' => AccessVlanLib::IPV4PROXYARP_NEGATIVE },
@@ -129,8 +126,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_ipv4redir_negative(int))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -140,8 +136,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ipv4_redirects' => AccessVlanLib::IPV4REDIRECTS_NEGATIVE },
@@ -158,8 +153,7 @@ test_name "TestCase :: #{testheader}" do
   #  on(master, AccessVlanLib.create_accessvlan_manifest_negoauto_negative(int))
   #
   #  # Expected exit_code is 1 since this is a puppet agent cmd with error.
-  #  cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-  #    'agent -t', options)
+  #  cmd_str = PUPPET_BINPATH + 'agent -t'
   #  on(agent, cmd_str, acceptable_exit_codes: [1])
   #
   #  logger.info("Get negative test resource manifest from master :: #{result}")
@@ -170,8 +164,7 @@ test_name "TestCase :: #{testheader}" do
   # step 'TestStep :: Check cisco_interface resource absence on agent' do
   #  # Expected exit_code is 0 since this is a puppet resource cmd.
   #  # Flag is set to true to check for absence of RegExp pattern in stdout.
-  #  cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-  #    "resource cisco_interface '#{int}'", options)
+  #  cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
   #  on(agent, cmd_str) do
   #    search_pattern_in_output(stdout,
   #                             { 'negotiate_auto' => AccessVlanLib::NEGOTIATEAUTO_NEGATIVE },
@@ -188,8 +181,7 @@ test_name "TestCase :: #{testheader}" do
   #  on(master, AccessVlanLib.create_accessvlan_manifest_shutdown_negative(int))
   #
   #  # Expected exit_code is 1 since this is a puppet agent cmd with error.
-  #  cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-  #    'agent -t', options)
+  #  cmd_str = PUPPET_BINPATH + 'agent -t'
   #  on(agent, cmd_str, acceptable_exit_codes: [1])
   #
   #  logger.info("Get negative test resource manifest from master :: #{result}")
@@ -199,8 +191,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'shutdown' => AccessVlanLib::SHUTDOWN_NEGATIVE },
@@ -216,8 +207,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_autostate_negative(int))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -227,8 +217,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'switchport_autostate_exclude' => AccessVlanLib::AUTOSTATE_NEGATIVE },
@@ -244,8 +233,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_vtp_negative(int))
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -255,8 +243,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'switchport_vtp' => AccessVlanLib::SWITCHPORTVTP_NEGATIVE },

--- a/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/accessvlan_provider_nondefaults.rb
@@ -94,8 +94,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Ensure that 'system default switchport' [default] is set property before
@@ -112,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_nondefaults(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -123,8 +121,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_interface resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',
@@ -148,8 +145,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, AccessVlanLib.create_accessvlan_manifest_absent(int))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -160,8 +156,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Presence of AccessVLAN 1 implies absence of AccessVLAN 128.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_interface '#{int}'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_interface '#{int}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'                       => 'present',

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -84,8 +83,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_present(platform.match('n9k')))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -95,8 +93,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -126,8 +122,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_negatives.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -82,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_vlanname_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -93,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'vlan_name' => VlanLib::VLANNAME_NEGATIVE },
@@ -110,8 +107,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_state_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -121,8 +117,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'state' => VlanLib::STATE_NEGATIVE },
@@ -138,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_shutdown_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -149,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'shutdown' => VlanLib::SHUTDOWN_NEGATIVE },

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -84,8 +83,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_nondefaults(platform.match('n9k')))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -95,8 +93,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'     => 'present',
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_extvlan_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -126,8 +122,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '2400'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '2400'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -84,8 +83,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_present(platform.match('n9k')))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -95,8 +93,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -126,8 +122,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_negatives.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -82,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_vlanname_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -93,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'vlan_name' => VlanLib::VLANNAME_NEGATIVE },
@@ -110,8 +107,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_state_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -121,8 +117,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'state' => VlanLib::STATE_NEGATIVE },
@@ -138,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_shutdown_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -149,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'shutdown' => VlanLib::SHUTDOWN_NEGATIVE },

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -84,8 +83,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_nondefaults(platform.match('n9k')))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -95,8 +93,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'     => 'present',
@@ -116,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VlanLib.create_stdvlan_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -127,8 +123,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vlan resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource cisco_vlan '128'", options)
+    cmd_str = PUPPET_BINPATH + "resource cisco_vlan '128'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
@@ -87,8 +87,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -98,8 +97,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',
@@ -133,8 +131,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -144,8 +141,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
@@ -85,8 +85,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_domain_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -96,8 +95,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'domain' => VtpLib::DOMAIN_NEGATIVE },
@@ -127,8 +125,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_filename_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -138,8 +135,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'filename' => VtpLib::FILENAME_NEGATIVE },
@@ -169,8 +165,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_password_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [1])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -180,8 +175,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'password' => VtpLib::PASSWORD_NEGATIVE },
@@ -211,8 +205,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_version_negative)
 
     # Expected exit_code is 6 since this is a puppet agent cmd with failure.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [6])
 
     logger.info("Get negative test resource manifest from master :: #{result}")
@@ -222,8 +215,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'version' => VtpLib::VERSION_NEGATIVE },

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
@@ -87,8 +87,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -98,8 +97,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',
@@ -135,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, VtpLib.create_vtp_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -146,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check cisco_vtp resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource cisco_vtp', options)
+    cmd_str = PUPPET_BINPATH + 'resource cisco_vtp'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'   => 'present',

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -170,8 +170,7 @@ tests['change_source_int_when_shutdown'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_vxlan_vtep'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_vxlan_vtep'
 end
 
 def build_manifest_cisco_vxlan_vtep(tests, id)

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -235,8 +235,7 @@ tests['suppress_arp_false'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH + 'resource cisco_vxlan_vtep_vni'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource cisco_vxlan_vtep_vni'
 end
 
 def build_manifest_cisco_vxlan_vtep_vni(tests, id)

--- a/tests/beaker_tests/file_service_package/file_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/file_provider_nondefaults.rb
@@ -70,8 +70,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     # Or expected exit_code is 0 since this is a puppet agent cmd with no change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -83,8 +82,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, FileSvcPkgLib.create_file_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -94,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check file resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource file '/tmp/testfile.txt'", options)
+    cmd_str = PUPPET_BINPATH + "resource file '/tmp/testfile.txt'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'file',
@@ -116,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, FileSvcPkgLib.create_file_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -127,8 +123,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check file resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource file '/tmp/testfile.txt'", options)
+    cmd_str = PUPPET_BINPATH + "resource file '/tmp/testfile.txt'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'file',

--- a/tests/beaker_tests/file_service_package/package_provider_nondefaults_1.rb
+++ b/tests/beaker_tests/file_service_package/package_provider_nondefaults_1.rb
@@ -68,8 +68,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # No change would imply that curl package is installed prior to test.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -81,8 +80,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, FileSvcPkgLib.create_package_curl_manifest_installed)
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0])
 
     logger.info("Get resource installed manifest from master :: #{result}")
@@ -93,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     # The Curl package state should not be purged.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource package 'curl'", options)
+    cmd_str = PUPPET_BINPATH + "resource package 'curl'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'purged' },

--- a/tests/beaker_tests/file_service_package/package_provider_nondefaults_2.rb
+++ b/tests/beaker_tests/file_service_package/package_provider_nondefaults_2.rb
@@ -81,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
     # No change would imply that Sample package is uninstalled prior to test.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
     # Change would imply that Sample package is installed prior to test.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -96,8 +95,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     # Change would imply that Sample package is uninstalled prior to test and
     # installed after test.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -108,8 +106,7 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     # Sample package state should not be purged.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource package 'n9000_sample'", options)
+    cmd_str = PUPPET_BINPATH + "resource package 'n9000_sample'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'purged' },

--- a/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
@@ -70,8 +70,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     # Or expected exit_code is 0 since this is a puppet agent cmd with no change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -83,8 +82,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, FileSvcPkgLib.create_service_manifest_nondefaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource nondefaults manifest from master :: #{result}")
@@ -94,8 +92,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check service resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource service '#{FileSvcPkgLib::TEST_SERVICE}'", options)
+    cmd_str = PUPPET_BINPATH + "resource service '#{FileSvcPkgLib::TEST_SERVICE}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'running' },
@@ -111,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, FileSvcPkgLib.create_service_manifest_stopped)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
     logger.info('Pause 5 seconds to allow state transition')
     sleep 5
@@ -124,8 +120,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check service resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource service '#{FileSvcPkgLib::TEST_SERVICE}'", options)
+    cmd_str = PUPPET_BINPATH + "resource service '#{FileSvcPkgLib::TEST_SERVICE}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'running' },

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -49,32 +49,10 @@ IGNORE_VALUE = :ignore_value
 # These methods are defined outside of a module so that
 # they can access the Beaker DSL API's.
 
-# Method to return the VRF namespace specific command string from basic
-# command string. VRF is declared in hosts.cfg.
-# @param host [String] Host on which to act upon.
-# @param cmdstr [String] The command string to execute on host.
-# @param options [Hash] Options hash literal to get configured VRF.
-# @result namespacestr [String] Returns 'sudo ip netns exec vrf <cmd>'
-# command string for 'cisco' platform.
-def get_namespace_cmd(host, cmdstr, options)
-  case host['platform']
-  when /cisco/
-    agentvrf = options[:HOSTS][host.to_s.to_sym][:vrf]
-    grpc_port = options[:HOSTS][host.to_s.to_sym][:grpc_port]
-    if grpc_port.nil?
-      # Nexus
-      return "sudo ip netns exec #{agentvrf} " + cmdstr
-    else
-      # IOS XR
-      # TODO: remove this workaround when we have grpc UDS support
-      user = options[:HOSTS][host.to_s.to_sym][:ssh][:user]
-      pass = options[:HOSTS][host.to_s.to_sym][:ssh][:password]
-      node_var = "NODE=\"127.0.0.1:#{grpc_port} #{user} #{pass}\""
-      return "sudo #{node_var} " + cmdstr
-    end
-  else
-    return cmdstr
-  end
+# Method rendered obsolete by Beaker enhancements (BKR-703).
+# TODO: remove me.
+def get_namespace_cmd(_, cmdstr, _)
+  cmdstr
 end
 
 # Method to return the Vegas shell command string for a NXOS CLI command.

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -49,12 +49,6 @@ IGNORE_VALUE = :ignore_value
 # These methods are defined outside of a module so that
 # they can access the Beaker DSL API's.
 
-# Method rendered obsolete by Beaker enhancements (BKR-703).
-# TODO: remove me.
-def get_namespace_cmd(_, cmdstr, _)
-  cmdstr
-end
-
 # Method to return the Vegas shell command string for a NXOS CLI command.
 # @param nxosclistr [String] The NXOS CLI command string to execute on host.
 # @result vshellcmd [String] Returns 'vsh -c <cmd>' command string.
@@ -138,8 +132,7 @@ end
 
 # Full command string for puppet agent
 def puppet_agent_cmd
-  cmd = PUPPET_BINPATH + 'agent -t'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'agent -t'
 end
 
 # Auto generation of properties for manifests
@@ -276,8 +269,7 @@ end
 # @param res_name [String] the resource to retrieve instances of
 # @return [Array] an array of string names of instances
 def get_current_resource_instances(agent, res_name)
-  cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource #{res_name}", options)
+  cmd_str = PUPPET_BINPATH + "resource #{res_name}"
   on(agent, cmd_str, acceptable_exit_codes: [0])
   names = stdout.scan(/#{res_name} { '(.+)':/).flatten
   names
@@ -304,8 +296,7 @@ def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
       when /cisco_vrf/
         next if title[/management/]
       end
-      cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-        "resource #{res_name} '#{title}' ensure=absent", options)
+      cmd_str = PUPPET_BINPATH + "resource #{res_name} '#{title}' ensure=absent"
       logger.info("  * #{stepinfo} Removing #{res_name} '#{title}'")
       on(agent, cmd_str, acceptable_exit_codes: [0])
     end
@@ -314,8 +305,7 @@ end
 
 # Helper to clean a specific resource by title name
 def resource_absent_by_title(agent, res_name, title)
-  res_cmd =
-    get_namespace_cmd(agent, PUPPET_BINPATH + "resource #{res_name}", options)
+  res_cmd = PUPPET_BINPATH + "resource #{res_name}"
   on(agent, "#{res_cmd} '#{title}' ensure=absent")
 end
 
@@ -323,8 +313,7 @@ end
 # Optionally remove all titles found.
 # Returns an array of titles.
 def resource_titles(agent, res_name, action=:find)
-  res_cmd =
-    get_namespace_cmd(agent, PUPPET_BINPATH + "resource #{res_name}", options)
+  res_cmd = PUPPET_BINPATH + "resource #{res_name}"
   on(agent, res_cmd)
 
   titles = []
@@ -369,7 +358,7 @@ def config_acl(agent, afi, acl, state, stepinfo='ACL:')
     state = state ? 'present' : 'absent'
     cmd = "resource cisco_acl '#{afi} #{acl}' ensure=#{state}"
     logger.info("Setup: puppet #{cmd}")
-    cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+    cmd = PUPPET_BINPATH + cmd
     on(agent, cmd, acceptable_exit_codes: [0, 2])
   end
 end
@@ -399,7 +388,7 @@ def config_bridge_domain(agent, test_bd, stepinfo='bridge-domain config:')
 
     # Remove vlan
     cmd = "resource cisco_vlan '#{test_bd}' ensure=absent"
-    cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+    cmd = PUPPET_BINPATH + cmd
     on(agent, cmd, acceptable_exit_codes: [0, 2])
 
     # Configure bridge-domain
@@ -422,7 +411,7 @@ def interface_cleanup(agent, intf, stepinfo='Pre Clean:')
   step "TestStep :: #{stepinfo}" do
     cmd = "resource cisco_command_config 'interface_cleanup' "\
           "command='default interface #{intf}'"
-    cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+    cmd = PUPPET_BINPATH + cmd
     logger.info("  * #{stepinfo} Set '#{intf}' to default state")
     on(agent, cmd, acceptable_exit_codes: [0, 2])
   end
@@ -537,7 +526,7 @@ def puppet_resource_cmd_from_params(tests, id)
     cmd = PUPPET_BINPATH + "resource #{tests[:resource_name]} '#{title_string}'"
 
     logger.info("\ntitle_string: '#{title_string}'")
-    tests[id][:resource_cmd] = get_namespace_cmd(agent, cmd, options)
+    tests[id][:resource_cmd] = cmd
   end
 end
 
@@ -790,7 +779,7 @@ end
 def command_config(agent, cmd, msg='')
   logger.info("\n#{msg}")
   cmd = "resource cisco_command_config 'cc' command='#{cmd}'"
-  cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+  cmd = PUPPET_BINPATH + cmd
   on(agent, cmd, acceptable_exit_codes: [0, 2])
 end
 
@@ -799,7 +788,7 @@ def resource_set(agent, resource, msg='')
   logger.info("\n#{msg}")
   cmd = "resource #{resource[:name]} '#{resource[:title]}' " \
                   "#{resource[:property]}='#{resource[:value]}'"
-  cmd = get_namespace_cmd(agent, PUPPET_BINPATH + cmd, options)
+  cmd = PUPPET_BINPATH + cmd
   on(agent, cmd, acceptable_exit_codes: [0, 2])
 end
 
@@ -890,7 +879,7 @@ end
 
 # Facter command builder helper method
 def facter_cmd(cmd)
-  get_namespace_cmd(agent, FACTER_BINPATH + cmd, options)
+  FACTER_BINPATH + cmd
 end
 
 # Used to cache the operation system information

--- a/tests/beaker_tests/netdev_stdlib/domain_name_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/domain_name_provider_defaults.rb
@@ -88,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, DomainNameLib.create_domain_name_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -99,8 +98,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check domain_name resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource domain_name test.xyz', options)
+    cmd_str = PUPPET_BINPATH + 'resource domain_name test.xyz'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -115,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, DomainNameLib.create_domain_name_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -126,8 +123,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check domain_name resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource domain_name test.xyz', options)
+    cmd_str = PUPPET_BINPATH + 'resource domain_name test.xyz'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/netdev_stdlib/name_server_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/name_server_provider_defaults.rb
@@ -66,8 +66,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NameServerLib.create_name_server_manifest_absent)
 
     # Expected exit_code is 0,2 since server may or may not be configured.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info("Setup switch for provider test :: #{result}")
@@ -79,8 +78,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NameServerLib.create_name_server_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -90,8 +88,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check name_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource name_server 7.7.7.7', options)
+    cmd_str = PUPPET_BINPATH + 'resource name_server 7.7.7.7'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -106,8 +103,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NameServerLib.create_name_server_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -117,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check name_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource name_server 7.7.7.7', options)
+    cmd_str = PUPPET_BINPATH + 'resource name_server 7.7.7.7'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_dns_provider_nondefaults.rb
@@ -125,8 +125,7 @@ test_name "TestCase :: #{testheader}" do
                                                         ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Set the domain property in a manifest from master :: #{result}")
@@ -136,8 +135,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_dns resource on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_dns 'settings'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_dns 'settings'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'present',
@@ -159,8 +157,7 @@ test_name "TestCase :: #{testheader}" do
                                                         ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Set the domain property in a manifest from master :: #{result}")
@@ -170,8 +167,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_dns resource on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_dns 'settings'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_dns 'settings'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'  => 'present',
@@ -193,8 +189,7 @@ test_name "TestCase :: #{testheader}" do
                                                         ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Set the domain property in a manifest from master :: #{result}")
@@ -204,8 +199,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_dns resource on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_dns 'settings'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_dns 'settings'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'present',

--- a/tests/beaker_tests/netdev_stdlib/network_interface_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_interface_provider_defaults.rb
@@ -70,8 +70,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -96,8 +95,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NetworkInterfaceLib.create_non_defaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -107,8 +105,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_interface resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_interface 'ethernet1/4'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_interface 'ethernet1/4'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'mtu'         => '1500',

--- a/tests/beaker_tests/netdev_stdlib/network_trunk_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_trunk_provider_defaults.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NetworkTrunkLib.create_absent)
 
     # Expected exit_code is 0,2 since server may or may not be configured.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
@@ -80,8 +79,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -105,8 +103,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NetworkTrunkLib.create_non_defaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -116,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_trunk resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_trunk 'ethernet1/4'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_trunk 'ethernet1/4'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'untagged_vlan' => '1',

--- a/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
@@ -86,8 +86,7 @@ test_name "TestCase :: #{testheader}" do
                                                           ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Set the domain property in a manifest from master :: #{result}")
@@ -97,8 +96,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_vlan resource on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_vlan '666'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_vlan '666'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',
@@ -138,8 +136,7 @@ test_name "TestCase :: #{testheader}" do
                                                           ))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Set the domain property in a manifest from master :: #{result}")
@@ -149,8 +146,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_vlan resource on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource network_vlan '666'", options)
+    cmd_str = PUPPET_BINPATH + "resource network_vlan '666'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure'    => 'present',

--- a/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
@@ -137,9 +137,7 @@ tests['non_default_properties'] = {
 
 # Full command string for puppet resource command
 def puppet_resource_cmd
-  cmd = PUPPET_BINPATH +
-        'resource port_channel port-channel100'
-  get_namespace_cmd(agent, cmd, options)
+  PUPPET_BINPATH + 'resource port_channel port-channel100'
 end
 
 def build_manifest_portchannel(tests, id)

--- a/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationLib.create_absent)
 
     # Expected exit_code is 0,2 since server may or may not be configured.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
@@ -80,8 +79,7 @@ test_name "TestCase :: #{testheader}" do
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     # Expected exit_code is 0 since this is a vegas shell cmd.
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationLib.create_non_defaults)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      "resource snmp_notification 'aaa server-state-change'", options)
+    cmd_str = PUPPET_BINPATH + "resource snmp_notification 'aaa server-state-change'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'enable' => 'true' },

--- a/tests/beaker_tests/network_snmp/network_snmp_provider_defaults.rb
+++ b/tests/beaker_tests/network_snmp/network_snmp_provider_defaults.rb
@@ -65,8 +65,7 @@ test_name "TestCase :: #{testheader}" do
     # Cleanup before starting test.
     on(master, NetworkSnmpLib.create_network_snmp_manifest_unset)
 
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -78,8 +77,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NetworkSnmpLib.create_network_snmp_manifest_set)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource set manifest from master :: #{result}")
@@ -89,8 +87,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_snmp resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource network_snmp default', options)
+    cmd_str = PUPPET_BINPATH + 'resource network_snmp default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'enable' => 'true' },
                                false, self, logger)
@@ -109,8 +106,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NetworkSnmpLib.create_network_snmp_manifest_unset)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource unset manifest from master :: #{result}")
@@ -120,8 +116,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_snmp resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource network_snmp default', options)
+    cmd_str = PUPPET_BINPATH + 'resource network_snmp default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'enable' => 'false' },
                                false, self, logger)

--- a/tests/beaker_tests/ntp_config/ntp_config_provider_defaults.rb
+++ b/tests/beaker_tests/ntp_config/ntp_config_provider_defaults.rb
@@ -74,8 +74,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Setup switch for provider' do
     # Cleanup before starting test.
     on(master, NtpConfigLib.create_ntp_config_manifest_unset)
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -87,8 +86,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpConfigLib.create_ntp_config_manifest_set(intf))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -98,8 +96,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_config resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_config default', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_config default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'source_interface' => intf },
                                false, self, logger)
@@ -114,8 +111,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpConfigLib.create_ntp_config_manifest_unset)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -125,8 +121,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_config resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_config default', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_config default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'source_interface' => 'unset' },
                                false, self, logger)

--- a/tests/beaker_tests/ntp_server/ntp_server_provider_defaults.rb
+++ b/tests/beaker_tests/ntp_server/ntp_server_provider_defaults.rb
@@ -72,8 +72,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpServerLib.create_ntp_server_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -83,8 +82,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_server 5.5.5.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_server 5.5.5.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -101,8 +99,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpServerLib.create_ntp_server_manifest_present_prefer)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present and prefer true manifest from master :: #{result}")
@@ -112,8 +109,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_server resource presence with prefer true on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_server 5.5.5.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_server 5.5.5.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -130,8 +126,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpServerLib.create_ntp_server_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -141,8 +136,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_server 5.5.5.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_server 5.5.5.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)
@@ -157,8 +151,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpServerLib.create_ntp_server_manifest_present_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -168,8 +161,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_server 2002::5', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_server 2002::5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -184,8 +176,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, NtpServerLib.create_ntp_server_manifest_absent_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -195,8 +186,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check ntp_server resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource ntp_server 2002::5', options)
+    cmd_str = PUPPET_BINPATH + 'resource ntp_server 2002::5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/radius/radius_provider_defaults.rb
+++ b/tests/beaker_tests/radius/radius_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusLib.create_radius_manifest_true)
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no changes.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -84,8 +83,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusLib.create_radius_manifest_false)
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no changes.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0])
 
     logger.info("Get resource present manifest from master :: #{result}")

--- a/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
+++ b/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusGlobalLib.create_radius_global_manifest)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -82,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'key' => '44444444' },
                                false, self, logger)
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusGlobalLib.create_radius_global_manifest_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'key' => '44444444' },
                                false, self, logger)
@@ -137,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusGlobalLib.create_radius_global_manifest_change_removed)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -148,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'key' => 'unset' },
                                false, self, logger)

--- a/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
+++ b/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
@@ -72,8 +72,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerLib.create_radius_server_manifest_present(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -83,8 +82,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -115,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerLib.create_radius_server_manifest_present_change(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -126,8 +123,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -158,8 +154,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerLib.create_radius_server_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -169,8 +164,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)
@@ -185,8 +179,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerLib.create_radius_server_manifest_present_ipv6(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -196,8 +189,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server 2003::7', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server 2003::7'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -228,8 +220,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerLib.create_radius_server_manifest_absent_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -239,8 +230,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server 2003::7', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server 2003::7'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/radius_server_group/radius_server_group_provider_defaults.rb
+++ b/tests/beaker_tests/radius_server_group/radius_server_group_provider_defaults.rb
@@ -81,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerGroupLib.create_radius_server_group_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -92,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -110,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerGroupLib.create_radius_server_group_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -121,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -139,8 +135,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerGroupLib.create_radius_server_group_manifest_present_servers_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -150,8 +145,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -168,8 +162,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, RadiusServerGroupLib.create_radius_server_group_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -179,8 +172,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check radius_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource radius_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource radius_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/search_domain/search_domain_provider_defaults.rb
+++ b/tests/beaker_tests/search_domain/search_domain_provider_defaults.rb
@@ -84,8 +84,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SearchDomainLib.create_search_domain_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -95,8 +94,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check search_domain resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource search_domain test.xyz', options)
+    cmd_str = PUPPET_BINPATH + 'resource search_domain test.xyz'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -126,8 +124,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SearchDomainLib.create_search_domain_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-                                           'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource absent manifest from master :: #{result}")
@@ -137,8 +134,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check search_domain resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource search_domain test.xyz', options)
+    cmd_str = PUPPET_BINPATH + 'resource search_domain test.xyz'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/snmp_community/snmp_community_provider_defaults.rb
+++ b/tests/beaker_tests/snmp_community/snmp_community_provider_defaults.rb
@@ -58,8 +58,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider' do
     on(master, SnmpCommunityLib.create_snmp_community_manifest_absent)
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -71,8 +70,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommunityLib.create_snmp_community_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -82,8 +80,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_community resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_community red', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_community red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -102,8 +99,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommunityLib.create_snmp_community_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -113,8 +109,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_community resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_community red', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_community red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -133,8 +128,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpCommunityLib.create_snmp_community_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -144,8 +138,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_community resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_community red', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_community red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/snmp_notification_receiver/snmp_notification_receiver_provider_defaults.rb
+++ b/tests/beaker_tests/snmp_notification_receiver/snmp_notification_receiver_provider_defaults.rb
@@ -76,8 +76,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_v3)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -87,8 +86,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -117,8 +115,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_change_v3)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -128,8 +125,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -158,8 +154,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_change_v3_2)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -169,8 +164,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -199,8 +193,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_change_v3_3)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -210,8 +203,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -240,8 +232,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_v2)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -251,8 +242,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -279,8 +269,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_change_v2)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -290,8 +279,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -318,8 +306,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_present_v1)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -329,8 +316,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver 2.3.4.5', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver 2.3.4.5'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -357,8 +343,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpNotificationReceiverLib.create_snmp_notification_receiver_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -368,8 +353,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification_receiver resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_notification_receiver test_snmp_notification_receiver', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_notification_receiver test_snmp_notification_receiver'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
+++ b/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
@@ -59,8 +59,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Setup switch for provider' do
     # Ensure that resource is removed beforehand
     on(master, SnmpUserLib.create_snmp_user_manifest_absent)
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -72,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmp_user_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -83,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_user resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_user test_snmp_user', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_user test_snmp_user'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -109,8 +106,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmp_user_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -120,8 +116,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_user resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_user test_snmp_user', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_user test_snmp_user'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -146,8 +141,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SnmpUserLib.create_snmp_user_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -157,8 +151,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_user resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource snmp_user test_snmp_user', options)
+    cmd_str = PUPPET_BINPATH + 'resource snmp_user test_snmp_user'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/syslog_server/syslog_server_provider_defaults.rb
+++ b/tests/beaker_tests/syslog_server/syslog_server_provider_defaults.rb
@@ -74,8 +74,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogServerLib.create_syslog_server_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -85,8 +84,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_server 1.2.3.4', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_server 1.2.3.4'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -105,8 +103,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogServerLib.create_syslog_server_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -116,8 +113,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_server 1.2.3.4', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_server 1.2.3.4'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)
@@ -132,8 +128,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogServerLib.create_syslog_server_manifest_present_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -143,8 +138,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_server 2003::3', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_server 2003::3'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -163,8 +157,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogServerLib.create_syslog_server_manifest_absent_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -174,8 +167,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_server 2003::3', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_server 2003::3'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/syslog_settings/syslog_settings_provider_defaults.rb
+++ b/tests/beaker_tests/syslog_settings/syslog_settings_provider_defaults.rb
@@ -67,8 +67,7 @@ test_name "TestCase :: #{testheader}" do
     # For deterministic results, make sure syslog_settings is set to
     # seconds.
     on(master, SyslogSettingLib.create_syslog_settings_manifest_seconds)
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -80,8 +79,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogSettingLib.create_syslog_settings_manifest_milliseconds)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -91,8 +89,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_settings resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_settings default', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_settings default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'time_stamp_units' => 'milliseconds' },
                                false, self, logger)
@@ -107,8 +104,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, SyslogSettingLib.create_syslog_settings_manifest_seconds)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -118,8 +114,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check syslog_settings resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource syslog_settings default', options)
+    cmd_str = PUPPET_BINPATH + 'resource syslog_settings default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'time_stamp_units' => 'seconds' },
                                false, self, logger)

--- a/tests/beaker_tests/tacacs/tacacs_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs/tacacs_provider_defaults.rb
@@ -63,8 +63,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider' do
     on(master, TacacsLib.create_tacacs_manifest_change_disabled)
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -76,8 +75,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsLib.create_tacacs_manifest)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -87,8 +85,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs default', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'enable' => 'true' },
                                false, self, logger)
@@ -103,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsLib.create_tacacs_manifest_change_disabled)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -114,8 +110,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs default', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'enable' => 'false' },
                                false, self, logger)

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
@@ -71,8 +71,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsGlobalLib.create_tacacs_global_manifest)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -82,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'key' => '44444444' },
                                false, self, logger)
@@ -104,8 +102,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsGlobalLib.create_tacacs_global_manifest_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -115,8 +112,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'key' => '44444444' },
                                false, self, logger)
@@ -137,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsGlobalLib.create_tacacs_global_manifest_change_disabled)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -148,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_global resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_global default', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'enable' => 'false' },
                                false, self, logger)

--- a/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
@@ -67,8 +67,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacs_server_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -78,8 +77,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -102,8 +100,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacs_server_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -113,8 +110,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -137,8 +133,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacs_server_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -148,8 +143,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server 8.8.8.8', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server 8.8.8.8'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)
@@ -164,8 +158,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacs_server_manifest_present_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -175,8 +168,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server 2020::20', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server 2020::20'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -199,8 +191,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerLib.create_tacacs_server_manifest_absent_ipv6)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -210,8 +201,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server 2020::20', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server 2020::20'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/tests/beaker_tests/tacacs_server_group/tacacs_server_group_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_server_group/tacacs_server_group_provider_defaults.rb
@@ -69,8 +69,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerGroupLib.create_tacacs_server_setup)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
     logger.info('Setup switch for provider')
@@ -82,8 +81,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerGroupLib.create_tacacs_server_group_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -93,8 +91,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -111,8 +108,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerGroupLib.create_tacacs_server_group_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -122,8 +118,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -140,8 +135,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerGroupLib.create_tacacs_server_group_manifest_present_servers_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -151,8 +145,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
@@ -169,8 +162,7 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsServerGroupLib.create_tacacs_server_group_manifest_absent)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'agent -t', options)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [2])
 
     logger.info("Get resource present manifest from master :: #{result}")
@@ -180,8 +172,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check tacacs_server_group resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
-      'resource tacacs_server_group red', options)
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_server_group red'
     on(agent, cmd_str) do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                true, self, logger)

--- a/utilities/installer/SAMPLE_host.cfg
+++ b/utilities/installer/SAMPLE_host.cfg
@@ -15,11 +15,11 @@
 # Replace the < > with your information
 
 HOSTS:
-    <IOS XR agent>:
+    <IOS XR node fully qualified domain name>:
         roles:
             - agent
         platform: cisco_ios_xr-6-x86_64
-        ip: <fully qualified domain name>
+        ip: <ip address>
         ssh:
           auth_methods: ["password"]
           # SSHd for third-party network namespace (TPNNS) uses port 57722
@@ -27,11 +27,11 @@ HOSTS:
           user: <configured admin username>
           password: <configured admin password>
 
-    <Nexus agent>:
+    <Nexus node fully qualified domain name>:
         roles:
             - agent
         platform: cisco_nexus-7-x86_64
-        ip: <fully qualified domain name>
+        ip: <ip address>
         vrf: <vrf used for beaker workstation and puppet master ip reachability>
         ssh:
           auth_methods: ["password"]
@@ -46,12 +46,12 @@ HOSTS:
     #<agent4>:
     #  <...>
 
-    <master>:
+    <master fully qualified domain name>:
         # Note: Only one master configuration block allowed
         roles:
             - master
         platform: <server os-version-architecture>
-        ip: <fully qualifed domain name>
+        ip: <ip address>
         ssh:
           auth_methods: ["password"]
           user: root
@@ -75,11 +75,11 @@ CONFIG:
 # Example where < > markers replaced with sample data
 #
 #HOSTS:
-#    nx-agent:
+#    nx-agent.domain.com:
 #        roles:
 #            - agent
 #        platform: cisco_nexus-7-x86_64
-#        ip: nx-agent.domain.com
+#        ip: 10.0.0.100
 #        vrf: management
 #        #target: guestshell
 #        ssh:
@@ -87,22 +87,22 @@ CONFIG:
 #          user: devops
 #          password: devopspassword
 #
-#    xr-agent:
+#    xr-agent.domain.com:
 #        roles:
 #            - agent
 #        platform: cisco_ios_xr-6-x86_64
-#        ip: xr-agent.domain.com
+#        ip: 10.0.0.101
 #        ssh:
 #          auth_methods: ["password"]
 #          port: 57722
 #          user: admin
 #          password: adminpassword
 #
-#    puppetmaster1:
+#    puppetmaster1.domain.com:
 #        roles:
 #            - master
 #        platform: ubuntu-1404-x86_64
-#        ip: puppetmaster1.domain.com
+#        ip: 10.0.0.2
 #        ssh:
 #          auth_methods: ["password"]
 #          user: root

--- a/utilities/installer/SAMPLE_host.cfg
+++ b/utilities/installer/SAMPLE_host.cfg
@@ -58,10 +58,12 @@ HOSTS:
           password: <configured root password>
 
 CONFIG:
-  # Puppet Package Information:
-    package_url: <url>
-    package_name: <rpm package name>
-    # rpm_gpg_key: <optional path to rpm gpg key>
+  # cisco_node_utils gem configuration (Optional) (Uncomment if needed)
+    # cisco_node_utils: # if present, install this gem
+    #   gem:  <path to gem file, if absent, install from rubygems.org>
+    #   port: <gRPC server port, defaults to 57400>
+    #   user: <admin username - defaults to host[ssh][user]>
+    #   password: <admin password - defaults to host[ssh][password]>
 
   # Puppet Configuration Template: (Optional) (Uncomment if needed)
     # puppet_config_template: <path to puppet.conf template file on beaker workstation>
@@ -109,12 +111,12 @@ CONFIG:
 #          password: rootpassword
 #
 #CONFIG:
-#  # Puppet Package Information:
-#    package_url: http://yoursever.domain.com/
-#    #package_url: ftp://yourserver.domain.com/
-#    #package_url: /bootflash/
-#    package_name: puppet-agent.rpm
-#    rpm_gpg_key: /path_on_beaker_workstation/RPM-GPG-KEY-puppetlabs
+#  # cisco_node_utils gem configuration:
+#    cisco_node_utils:
+#      gem: /home/user/cisco_node_utils-1.2.0.dev.gem
+#      username: admin
+#      password: admin
+#      port: 57400
 #
 #  # Puppet Configuration Template:
 #    puppet_config_template: /path_on_beaker_workstation/puppet.conf

--- a/utilities/installer/SAMPLE_host.cfg
+++ b/utilities/installer/SAMPLE_host.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2016 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,22 @@
 # Replace the < > with your information
 
 HOSTS:
-    <agent1>:
+    <IOS XR agent>:
         roles:
             - agent
-        platform: cisco-7-x86_64
+        platform: cisco_ios_xr-6-x86_64
+        ip: <fully qualified domain name>
+        ssh:
+          auth_methods: ["password"]
+          # SSHd for third-party network namespace (TPNNS) uses port 57722
+          port: 57722
+          user: <configured admin username>
+          password: <configured admin password>
+
+    <Nexus agent>:
+        roles:
+            - agent
+        platform: cisco_nexus-7-x86_64
         ip: <fully qualified domain name>
         vrf: <vrf used for beaker workstation and puppet master ip reachability>
         ssh:
@@ -28,11 +40,10 @@ HOSTS:
         #Uncomment the following line to install into the guestshell
         #target: guestshell
 
-
-    #<agent2>:
+    #<agent3>:
     #  <...>
 
-    #<agent3>:
+    #<agent4>:
     #  <...>
 
     <master>:
@@ -64,17 +75,28 @@ CONFIG:
 # Example where < > markers replaced with sample data
 #
 #HOSTS:
-#    agent1:
+#    nx-agent:
 #        roles:
 #            - agent
-#        platform: cisco-7-x86_64
-#        ip: agent1.domain.com
+#        platform: cisco_nexus-7-x86_64
+#        ip: nx-agent.domain.com
 #        vrf: management
 #        #target: guestshell
 #        ssh:
 #          auth_methods: ["password"]
 #          user: devops
 #          password: devopspassword
+#
+#    xr-agent:
+#        roles:
+#            - agent
+#        platform: cisco_ios_xr-6-x86_64
+#        ip: xr-agent.domain.com
+#        ssh:
+#          auth_methods: ["password"]
+#          port: 57722
+#          user: admin
+#          password: adminpassword
 #
 #    puppetmaster1:
 #        roles:

--- a/utilities/installer/install_puppet.rb
+++ b/utilities/installer/install_puppet.rb
@@ -444,11 +444,11 @@ agents.each do |agent|
 
     # Clean agent certificats on master and agent
     if options['cert_clean']
-      on master, "#{PUPPET_PATH}/bin/puppet cert clean #{agent['ip']}",
+      on master, "#{PUPPET_PATH}/bin/puppet cert clean #{agent.hostname}",
          accept_all_exit_codes: true, pty: true
       ssl_dir = (on agent, 'puppet agent --configprint ssldir',
                     accept_all_exit_codes: true, pty: true).stdout.chomp
-      on agent, "find #{ssl_dir} -name #{agent['ip']}.pem -delete",
+      on agent, "find #{ssl_dir} -name #{agent.hostname}.pem -delete",
          accept_all_exit_codes: true, pty: true
     end
 

--- a/utilities/installer/install_puppet.rb
+++ b/utilities/installer/install_puppet.rb
@@ -172,7 +172,7 @@ $env['PATH'] = "$PATH:#{PUPPET_PATH}/bin/:#{PUPPET_PATH}/lib/"
 # @param agent [String]
 # @return [String] Path to puppet.conf file
 def get_puppet_config(agent)
-  cl = "puppet agent --configprint config"
+  cl = 'puppet agent --configprint config'
   (on agent, cl, environment: $env, pty: true).stdout.chomp
 end
 
@@ -230,7 +230,6 @@ def get_agent_config(agent)
   target_guestshell?(agent) ? opts = { pty: true } : opts = {}
   on(agent, "cat #{get_puppet_config(agent)}", opts).stdout
 end
-
 
 # Get default puppet.conf file from puppet.conf file after
 # the agent is installed.
@@ -374,7 +373,7 @@ def setup_env(agent)
   end
   on agent, "ln -sf #{PUPPET_PATH}/bin/puppet /usr/bin/puppet", codes
   # SSH environment directory may not exist by default for XR
-  on agent, "mkdir -p ~/.ssh", codes
+  on agent, 'mkdir -p ~/.ssh', codes
 end
 
 # Install cisco_node_utils gem on target agent
@@ -408,11 +407,12 @@ def install_cisco_gem_on(agent)
   conf_data << "\n  username: #{opts['username']}" if opts['username']
   conf_data << "\n  password: #{opts['password']}" if opts['password']
   conf_data << "\n  port:     #{opts['port']}" if opts['port']
-  on agent, "touch /etc/cisco_node_utils.yaml"
-  on agent, "chmod a+rw /etc/cisco_node_utils.yaml"
-  on agent, "echo \"#{conf_data}\" > /etc/cisco_node_utils.yaml"
-  on agent, "chown root /etc/cisco_node_utils.yaml"
-  on agent, "chmod 0600 /etc/cisco_node_utils.yaml"
+  config_file = '/etc/cisco_node_utils.yaml'
+  on agent, "touch #{config_file}"
+  on agent, "chmod a+rw #{config_file}"
+  on agent, "echo \"#{conf_data}\" > #{config_file}"
+  on agent, "chown root #{config_file}"
+  on agent, "chmod 0600 #{config_file}"
 end
 
 #---------------------------------------------------------------------#
@@ -458,7 +458,7 @@ agents.each do |agent|
     if options['cert_clean']
       on master, "#{PUPPET_PATH}/bin/puppet cert clean #{agent['ip']}",
          accept_all_exit_codes: true, pty: true
-      ssl_dir = (on agent, "puppet agent --configprint ssldir",
+      ssl_dir = (on agent, 'puppet agent --configprint ssldir',
                     accept_all_exit_codes: true, pty: true, environment: $env).stdout.chomp
       on agent, "find #{ssl_dir} -name #{agent['ip']}.pem -delete",
          accept_all_exit_codes: true, pty: true, environment: $env
@@ -466,7 +466,7 @@ agents.each do |agent|
 
     # Start puppet agent
     logger.notify "Kick start puppet on agent: #{agent}"
-    result = on agent, "puppet agent -t",
+    result = on agent, 'puppet agent -t',
                 accept_all_exit_codes: true, pty: true, environment: $env
     if result.exit_code != 0 && result.exit_code != 2
       logger.warn "AGENT: #{agent} did not start properly. Check logs for details"


### PR DESCRIPTION
This PR moves to support (and require, as PuppetLabs has made backward-incompatible changes) Beaker 2.37 and specifically the changes made in puppetlabs/beaker#1066. In making these changes, I identified some issues with this code and have opened a PR (puppetlabs/beaker#1081) to address those - this PR should not be merged until that one has been addressed and a new version of Beaker (presumably 2.38) has been released.

This PR builds upon and replaces #204.

Key changes to our beaker tests:
- Host platform strings now must be `cisco_nexus-7-x86_64` and `cisco_ios_xr-6-x86_64` (the old strings of `cisco-7-x86_64` are now rejected by Beaker as invalid).
- Our beaker utility_lib's `get_namespace_cmd` is no longer needed as the relevant functionality is now provided by Beaker itself (this was the basis of #204, but I've taken one step further by removing the method altogether instead of just making it do nothing)
  - Note - now that we don't need get_namespace_cmd, the test code can probably be improved a few steps further by using Beaker DSL constructs like `puppet()` in place of the generic `on()`, but that's beyond the scope of the PR.

Beaker example run (XR):
```
TestCase :: cisco_bgp
  
  ------------------------------------------------------------
  Section 1. Default Property Testing
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '1 default'
    
    title_string: '1 default'
  
  Found Platform string: 'Cisco XRv9K Virtual Router', Alias to: 'xrv9k'
  
  * 
  --------
   * TestStep :: absent clean
      * absent clean Removing cisco_bgp '11.4 default'
  
  --------
  1.1 Default Properties [ensure => present]
  
  * TestStep :: 1.1 Default Properties [ensure => present] :: MANIFEST    
  1.1 Default Properties [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 1.1 Default Properties :: RESOURCE    
    1.1 Default Properties :: RESOURCE     :: PASS
  
  * TestStep :: 1.1 Default Properties :: IDEMPOTENCE 
    1.1 Default Properties :: IDEMPOTENCE  :: PASS
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '1 default'
    
    title_string: '1 default'
  
  --------
  1.1 Default Properties [ensure => absent]
  
  * TestStep :: 1.1 Default Properties [ensure => absent] :: MANIFEST    
  1.1 Default Properties [ensure => absent] :: MANIFEST     :: PASS
  
  * TestStep :: 1.1 Default Properties :: RESOURCE    
    1.1 Default Properties :: RESOURCE     :: PASS
  
  * TestStep :: 1.1 Default Properties :: IDEMPOTENCE 
    1.1 Default Properties :: IDEMPOTENCE  :: PASS
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '1 blue'
    
    title_string: '1 blue'
  
  * 
  --------
   * TestStep :: absent clean
  
  --------
  1.1 Default Properties (vrf blue) [ensure => present]
  
  * TestStep :: 1.1 Default Properties (vrf blue) [ensure => present] :: MANIFEST    
  1.1 Default Properties (vrf blue) [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 1.1 Default Properties (vrf blue) :: RESOURCE    
    1.1 Default Properties (vrf blue) :: RESOURCE     :: PASS
  
  * TestStep :: 1.1 Default Properties (vrf blue) :: IDEMPOTENCE 
    1.1 Default Properties (vrf blue) :: IDEMPOTENCE  :: PASS
  
  ------------------------------------------------------------
  Section 2. Non Default Property Testing
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '1 default'
    
    title_string: '1 default'
  
  --------
  2.1 Non Defaults [ensure => present]
  
  * TestStep :: 2.1 Non Defaults [ensure => present] :: MANIFEST    
  2.1 Non Defaults [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 2.1 Non Defaults :: RESOURCE    
    2.1 Non Defaults :: RESOURCE     :: PASS
  
  * TestStep :: 2.1 Non Defaults :: IDEMPOTENCE 
    2.1 Non Defaults :: IDEMPOTENCE  :: PASS
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '1 blue'
    
    title_string: '1 blue'
  
  --------
  2.1 Non Defaults (vrf blue) [ensure => present]
  
  * TestStep :: 2.1 Non Defaults (vrf blue) [ensure => present] :: MANIFEST    
  2.1 Non Defaults (vrf blue) [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: 2.1 Non Defaults (vrf blue) :: RESOURCE    
    2.1 Non Defaults (vrf blue) :: RESOURCE     :: PASS
  
  * TestStep :: 2.1 Non Defaults (vrf blue) :: IDEMPOTENCE 
    2.1 Non Defaults (vrf blue) :: IDEMPOTENCE  :: PASS
  
  ------------------------------------------------------------
  Section 3. Title Pattern Testing
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] 'new_york'
    [:title_params]  {:asn=>"11.4", :vrf=>"red"}
    
    title_string: '11.4 red'
  
  * 
  --------
   * TestStep :: absent clean
      * absent clean Removing cisco_bgp '1 default'
  
  --------
  T.1 Title Pattern [ensure => present]
  
  * TestStep :: T.1 Title Pattern [ensure => present] :: MANIFEST    
  T.1 Title Pattern [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: T.1 Title Pattern :: RESOURCE    
    T.1 Title Pattern :: RESOURCE     :: PASS
  
  * TestStep :: T.1 Title Pattern :: IDEMPOTENCE 
    T.1 Title Pattern :: IDEMPOTENCE  :: PASS
  
  * 
  --------
  Create resource command title string:
    [:resource_name] 'cisco_bgp'
    [:title_pattern] '11.4'
    [:title_params]  {:vrf=>"blue"}
    
    title_string: '11.4 blue'
  
  --------
  T.2 Title Pattern [ensure => present]
  
  * TestStep :: T.2 Title Pattern [ensure => present] :: MANIFEST    
  T.2 Title Pattern [ensure => present] :: MANIFEST     :: PASS
  
  * TestStep :: T.2 Title Pattern :: RESOURCE    
    T.2 Title Pattern :: RESOURCE     :: PASS
  
  * TestStep :: T.2 Title Pattern :: IDEMPOTENCE 
    T.2 Title Pattern :: IDEMPOTENCE  :: PASS
  
  * 
  --------
   * TestStep :: absent clean
      * absent clean Removing cisco_bgp '11.4 default'
TestCase :: cisco_bgp :: End
Begin teardown
End teardown
tests/beaker_tests/cisco_bgp/test_bgp.rb passed in 198.82 seconds
```

Key changes to the beaker installer script:
- Host platform strings now must be `cisco_nexus-7-x86_64` and `cisco_ios_xr-6-x86_64` (the old strings of `cisco-7-x86_64` are now rejected by Beaker as invalid).
- removed `package_url` and `package_name` config options (always use yum.puppetlabs.com)
- corrected `tmp_location` value for XR
- Set environment variables as parameter to cmd instead of `pp` method
- Removed `pp` method, no longer needed
- Use `hostname` instead of `ip` from hosts.cfg to construct puppet.conf
- Use Beaker builtin `install_puppet_agent_on` letting us remove `install_target()`
- Can now install cisco_node_utils (from rubygems.org or from a local gem file) if the `cisco_node_utils:` key is provided in host.cfg
- Can now configure `/etc/cisco_node_utils.yaml` with data provided in host.cfg


Installer (IOS XR):
```
Bootstrap puppet agent sunstone-gfm.cisco.com
Copying /etc/resolv.conf to node
localhost $ scp resolv.conf sunstone-gfm.cisco.com:/disk0:/tmp_puppet/resolve.conf {:ignore => }
Set up environment on agent: sunstone-gfm.cisco.com
Installing puppet on agent: sunstone-gfm.cisco.com
Installing cisco_node_utils gem on agent: sunstone-gfm.cisco.com
localhost $ scp /home/glmatthe/cisco-network-node-utils/cisco_node_utils-1.2.0.gem sunstone-gfm.cisco.com:/disk0:/tmp_puppet/cisco_node_utils-1.2.0.gem {:ignore => }
Configuring cisco_node_utils gem on agent: sunstone-gfm.cisco.com
Configure puppet on agent: sunstone-gfm.cisco.com
Kick start puppet on agent: sunstone-gfm.cisco.com

  PUPPET AGENT BOOTSTRAP RESULTS:
  +---------------------------------------------------------+
    TOTAL NUMBER OF AGENTS PROCESSED : 1
    TOTAL SUCCESSFUL AGENT INSTALLS  : 1
    TOTAL FAILED AGENT INSTALLS      : 0
  +---------------------------------------------------------+
```