### PR TITLE
modify switchport_trunk_allowed_vlan to use range_summarize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `ipv4_forwarding`, `switchport_mode fabricpath`
   - `stp_bpdufilter`, `stp_bpduguard`, `stp_cost`, `stp_guard`, `stp_link_type`, `stp_mst_cost`
   - `stp_mst_port_priority`, `stp_port_priority`, `stp_port_type`, `stp_vlan_cost`, `stp_vlan_port_priority`
+  - `modify switchport_trunk_allowed_vlan to use range_summarize() which takes care of idempotency issues with vlan ranges`
 - Extended `cisco_vlan` with the following attributes:
   - `mode`
 - Extended `cisco_vpc_domain` with the following attributes:

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -37,24 +37,24 @@ class ciscopuppet::cisco::demo_interface {
     }
 
     cisco_interface { 'Ethernet1/1' :
-      shutdown                       => true,
-      switchport_mode                => disabled,
-      description                    => 'managed by puppet',
-      ipv4_address                   => '192.168.55.5',
-      ipv4_netmask_length            => 24,
-      ipv4_address_secondary         => '192.168.88.1',
-      ipv4_netmask_length_secondary  => 24,
-      ipv4_forwarding                => true,
-      ipv4_pim_sparse_mode           => false,
-      mtu                            => 1600,
+      shutdown                      => true,
+      switchport_mode               => disabled,
+      description                   => 'managed by puppet',
+      ipv4_address                  => '192.168.55.5',
+      ipv4_netmask_length           => 24,
+      ipv4_address_secondary        => '192.168.88.1',
+      ipv4_netmask_length_secondary => 24,
+      ipv4_forwarding               => true,
+      ipv4_pim_sparse_mode          => false,
+      mtu                           => 1600,
       # Removed because of too many differences between platforms and linecards
       # speed                          => 100,
       # duplex                         => 'full',
-      vrf                            => 'test',
-      ipv4_acl_in                    => 'v4acl1',
-      ipv4_acl_out                   => 'v4acl2',
-      ipv6_acl_in                    => 'v6acl1',
-      ipv6_acl_out                   => 'v6acl2',
+      vrf                           => 'test',
+      ipv4_acl_in                   => 'v4acl1',
+      ipv4_acl_out                  => 'v4acl2',
+      ipv6_acl_in                   => 'v6acl1',
+      ipv6_acl_out                  => 'v6acl2',
     }
 
     cisco_interface { 'Ethernet1/1.1':
@@ -74,7 +74,7 @@ class ciscopuppet::cisco::demo_interface {
 
     cisco_interface { 'Ethernet1/5':
       switchport_mode               => trunk,
-      switchport_trunk_allowed_vlan => '20, 30',
+      switchport_trunk_allowed_vlan => '30, 29, 31-33, 100',
       switchport_trunk_native_vlan  => 40,
     }
 
@@ -107,8 +107,8 @@ class ciscopuppet::cisco::demo_interface {
     }
 
     cisco_interface { 'GigabitEthernet0/0/0/2':
-      description     => 'default',
-      shutdown        => 'default',
+      description => 'default',
+      shutdown    => 'default',
     }
   }
 }

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -211,8 +211,15 @@ Puppet::Type.newtype(:cisco_interface) do
     desc "The allowed VLANs for the specified Ethernet interface. Valid values
           are string, keyword 'default'."
 
-    # Strip whitespace if manifest specified as '20, 30' vs '20,30'
-    munge { |value| value == 'default' ? :default : value.sub(/\s/, '') }
+    # Use the range summarize utility to normalize the vlan ranges
+    munge do |value|
+      if value == 'default'
+        value = :default
+      else
+        value = PuppetX::Cisco::Utils.range_summarize(value)
+      end
+      value
+    end
   end # property switchport_trunk_allowed_vlan
 
   newproperty(:switchport_trunk_native_vlan) do

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -133,21 +133,11 @@ tests['L3_default_nexus'] = {
     duplex:                        'default',
     ipv4_forwarding:               'default',
     ipv4_pim_sparse_mode:          'default',
-    switchport_autostate_exclude:  'default',
-    switchport_mode:               'default',
-    switchport_trunk_allowed_vlan: 'default',
-    switchport_trunk_native_vlan:  'default',
-    switchport_vtp:                'default',
   },
   resource:           {
     'duplex'                        => 'auto',
     'ipv4_forwarding'               => 'false',
     'ipv4_pim_sparse_mode'          => 'false',
-    'switchport_autostate_exclude'  => 'false',
-    'switchport_mode'               => 'disabled',
-    'switchport_trunk_allowed_vlan' => '1-4094',
-    'switchport_trunk_native_vlan'  => '1',
-    'switchport_vtp'                => 'false',
   },
 }
 
@@ -196,6 +186,7 @@ tests['L3_misc_nexus'] = {
   desc:               '1.5 (L3) Misc Properties - Nexus specific',
   operating_system:   'nexus',
   intf_type:          'ethernet',
+  preclean:           true,
   sys_def_switchport: false,
   manifest_props:     {
     switchport_mode:      'disabled',
@@ -302,7 +293,7 @@ tests['L2_trunk'] = {
   manifest_props:     {
     shutdown:                      'false',
     switchport_mode:               'trunk',
-    switchport_trunk_allowed_vlan: '30,40',
+    switchport_trunk_allowed_vlan: '30, 40, 31-33, 100',
     switchport_trunk_native_vlan:  '20',
     switchport_vtp:                'false',
 
@@ -310,7 +301,7 @@ tests['L2_trunk'] = {
   resource:           {
     'shutdown'                      => 'false',
     'switchport_mode'               => 'trunk',
-    'switchport_trunk_allowed_vlan' => '30,40',
+    'switchport_trunk_allowed_vlan' => '30-33,40,100',
     'switchport_trunk_native_vlan'  => '20',
   },
 }

--- a/tests/beaker_tests/cisco_interface/test_interface.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface.rb
@@ -130,14 +130,14 @@ tests['L3_default_nexus'] = {
   preclean:           true,
   sys_def_switchport: false,
   manifest_props:     {
-    duplex:                        'default',
-    ipv4_forwarding:               'default',
-    ipv4_pim_sparse_mode:          'default',
+    duplex:               'default',
+    ipv4_forwarding:      'default',
+    ipv4_pim_sparse_mode: 'default',
   },
   resource:           {
-    'duplex'                        => 'auto',
-    'ipv4_forwarding'               => 'false',
-    'ipv4_pim_sparse_mode'          => 'false',
+    'duplex'               => 'auto',
+    'ipv4_forwarding'      => 'false',
+    'ipv4_pim_sparse_mode' => 'false',
   },
 }
 


### PR DESCRIPTION
This change modifies the type file of cisco_interface for the the property switchport_trunk_allowed_vlan to accept an arbitary range strings with the use of range_summarize(). The utility method range_summarize() massages the input resource string to a form that is compatible with the range summarization that is done by NxOS CLI on VLAN ranges. This takes care of idempotency issues.