### PR TITLE
Add skip_unless_supported() for beaker tests

### DIFF
--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -70,9 +70,10 @@ testheader = 'Resource cisco_vxlan_vtep'
 # tests[:agent] - the agent object
 #
 tests = {
-  master:   master,
-  agent:    agent,
-  platform: 'n9k',
+  master:        master,
+  agent:         agent,
+  platform:      'n(8|9)k',
+  resource_name: 'cisco_vxlan_vtep',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:
@@ -218,6 +219,8 @@ end
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{testheader}" do
+  skip_unless_supported(tests)
+
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   resource_absent_cleanup(agent, 'cisco_vxlan_vtep',

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -70,9 +70,10 @@ testheader = 'Resource cisco_vxlan_vtep_vni'
 # tests[:agent] - the agent object
 #
 tests = {
-  master:   master,
-  agent:    agent,
-  platform: 'n9k',
+  master:        master,
+  agent:         agent,
+  platform:      'n(8|9)k',
+  resource_name: 'cisco_vxlan_vtep_vni',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:
@@ -289,6 +290,8 @@ end
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{testheader}" do
+  skip_unless_supported(tests)
+
   #-------------------------------------------------------------------
   resource_absent_cleanup(agent, 'cisco_vxlan_vtep_vni',
                           'Setup switch for cisco_vxlan_vtep_vni provider test')

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -999,6 +999,18 @@ def platform_supports_test(tests, id)
   false
 end
 
+# This is a simple top-level skip similar to what exists in the minitests.
+# Callers will skip all tests when true.
+# tests[:platform] - regex of supported platforms
+# tests[:resource_name] - provider name (e.g. 'cisco_vxlan_vtep')
+def skip_unless_supported(tests)
+  return false if platform.match(tests[:platform])
+  msg = "Skipping all tests; '#{tests[:resource_name]}' "\
+        'is unsupported on this node'
+  banner = '#' * msg.length
+  raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
+end
+
 def skipped_tests_summary(tests)
   return unless tests[:skipped]
   logger.info("\n#{'-' * 60}\n  SKIPPED TESTS SUMMARY\n#{'-' * 60}")


### PR DESCRIPTION
* similar to minitest check which skips all tests if platform is excluded
* Initially used with vxlan providers

Test with n3k:
```
-----
Begin beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb

TestCase :: Resource cisco_vxlan_vtep_vni

  Found Platform string: 'Nexus 3048 Chassis', Alias to: 'n3k'

  TestCase ::
  ######################################################################
  Skipping all tests; 'cisco_vxlan_vtep_vni' is unsupported on this node
  ######################################################################
   :: SKIP
  Begin teardown
  End teardown
  Warning: beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb skipped in 11.40 seconds
      Test Suite: tests @ 2016-04-01 12:43:45 -0400

      - Host Configuration Summary -

              - Test Case Summary for suite 'tests' -
       Total Suite Time: 11.40 seconds
      Average Test Time: 11.40 seconds
              Attempted: 1
                 Passed: 0
                 Failed: 0
                Errored: 0
                Skipped: 1
                Pending: 0
                  Total: 1
-----
```