### PR TITLE
bgp: beaker platform fixes #1

### DIFF
--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -63,6 +63,7 @@ tests[:default] = {
     maxas_limit:                            'default',
     neighbor_down_fib_accelerate:           'default',
     nsr:                                    'default',
+    reconnect_interval:                     'default',
     shutdown:                               'default',
     suppress_fib_pending:                   'default',
     timer_bestpath_limit:                   'default',
@@ -95,6 +96,7 @@ tests[:default] = {
     'maxas_limit'                            => 'false',
     'neighbor_down_fib_accelerate'           => 'false',
     'nsr'                                    => 'false',
+    'reconnect_interval'                     => '60',
     'shutdown'                               => 'false',
     'suppress_fib_pending'                   => 'false',
     'timer_bestpath_limit'                   => '300',
@@ -136,6 +138,7 @@ tests[:non_default] = {
     maxas_limit:                            '50',
     neighbor_down_fib_accelerate:           'true',
     nsr:                                    'true',
+    reconnect_interval:                     '55',
     router_id:                              '192.168.0.66',
     shutdown:                               'true',
     suppress_fib_pending:                   'true',
@@ -216,10 +219,15 @@ def unsupported_properties(tests, id)
         :flush_routes <<
         :neighbor_down_fib_accelerate
     end
+
+    if platform[/n(5|6|7)k/]
+      unprops <<
+        :disable_policy_batching_ipv4 <<
+        :disable_policy_batching_ipv6 <<
+        :neighbor_down_fib_accelerate <<
+        :reconnect_interval
+    end
   end
-
-  unprops << :neighbor_down_fib_accelerate unless /n(3|9)k/.match(platform)
-
   unprops
 end
 

--- a/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
+++ b/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
@@ -208,7 +208,7 @@ tests[:non_def_N] = {
   },
 }
 
-redistribute = Array[%w(static RouteMap), %w(lisp RouteMap)]
+redistribute = Array[%w(lisp RouteMap), %w(static RouteMap)]
 tests[:non_def_R] = {
   desc:           "2.7 Non Default Properties: 'R' commands",
   title_pattern:  '2 default ipv4 unicast',
@@ -337,11 +337,12 @@ def unsupported_properties(tests, id)
         :dampening_routemap <<
         :dampening_suppress_time
     end
-  elsif vrf == 'default'
-    # NX-OS does not support these properties under the default vrf
-    unprops << :advertise_l2vpn_evpn
-  end
+  else
+    unprops << :advertise_l2vpn_evpn if
+      vrf == 'default' || platform[/n(3|6)k/]
 
+    unprops << :additional_paths_install if platform[/n(3|8|9)k/]
+  end
   unprops
 end
 

--- a/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
+++ b/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
@@ -37,18 +37,19 @@ tests[:default] = {
   title_pattern:  '2 default 1.1.1.1',
   preclean:       'cisco_bgp',
   manifest_props: {
-    ebgp_multihop:      'default',
-    local_as:           'default',
-    low_memory_exempt:  'default',
-    remote_as:          'default',
-    suppress_4_byte_as: 'default',
-    timers_keepalive:   'default',
-    timers_holdtime:    'default',
-
+    ebgp_multihop:        'default',
+    local_as:             'default',
+    log_neighbor_changes: 'default',
+    low_memory_exempt:    'default',
+    remote_as:            'default',
+    suppress_4_byte_as:   'default',
+    timers_keepalive:     'default',
+    timers_holdtime:      'default',
   },
   resource:       {
     'ebgp_multihop'          => 'false',
     'local_as'               => '0',
+    'log_neighbor_changes'   => 'inherit',
     'low_memory_exempt'      => 'false',
     'maximum_peers'          => '0',
     'remote_as'              => '0',
@@ -69,6 +70,7 @@ tests[:non_def_uber] = {
     capability_negotiation: 'true',
     dynamic_capability:     'true',
     ebgp_multihop:          '2',
+    log_neighbor_changes:   'enable',
     low_memory_exempt:      'true',
     remote_as:              '12.1',
     remove_private_as:      'all',
@@ -78,10 +80,6 @@ tests[:non_def_uber] = {
     timers_holdtime:        '270',
   },
 }
-
-if platform[/n(3|9)k/]
-  tests[:non_def_uber][:manifest_props][:log_neighbor_changes] = 'enable'
-end
 
 tests[:non_def_local_remote_as] = {
   preclean:       'cisco_bgp_neighbor',
@@ -138,6 +136,9 @@ def unsupported_properties(_tests, _id)
       :low_memory_exempt <<
       :maximum_peers <<
       :remove_private_as
+
+  else
+    unprops << :log_neighbor_changes if platform[/n(5|6|7)/]
   end
 
   unprops


### PR DESCRIPTION
* bgp: reconnect_interval was missing from test
* bgp_af: change redist expected value to sorted
* bgp_neighbor: add log_neighbor_changes