### PR TITLE
beaker: bgpneighboraf: soft-reconfig

### DIFF
--- a/tests/beaker_tests/cisco_bgp_neighbor_af/test_bgpneighboraf.rb
+++ b/tests/beaker_tests/cisco_bgp_neighbor_af/test_bgpneighboraf.rb
@@ -209,15 +209,8 @@ tests[:non_def_S1] = {
   },
 }
 
-tests[:non_def_S2] = {
-  desc:           'Non Default: (S2) soft-reconfig always',
-  platform:       'n(3|9)k',
-  manifest_props: { soft_reconfiguration_in: 'always' },
-}
-
 tests[:non_def_S3] = {
   desc:           'Non Default: (S3) soft-reconfig enable',
-  platform:       'n(3|9)k',
   manifest_props: { soft_reconfiguration_in: 'enable' },
 }
 
@@ -342,7 +335,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
     :non_def_M,
     :non_def_N,
     :non_def_S1,
-    :non_def_S2,
     :non_def_S3,
     :non_def_S4,
     :non_def_W,
@@ -359,19 +351,21 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :non_def_ibgp_only)
 
   # -------------------------------------------------------------------
-  if operating_system == 'ios_xr' || platform[/n(5|6|7|9)k/]
+  unless platform[/n3k/]
     logger.info("\n#{'-' * 60}\nSection 3. L2VPN Property Testing")
     resource_absent_cleanup(agent, 'cisco_bgp', 'BGP CLEAN :: ')
     title = '2 default 1.1.1.1 l2vpn evpn'
-    [
+    array = [
       :non_def_A1,
       :non_def_D2,
       :non_def_M,
       :non_def_S1,
-      :non_def_S2,
       :non_def_S3,
       :non_def_misc_maps_1,
-    ].each do |id|
+    ]
+    array.delete(:non_def_S3) if platform[/n(8|9)k/]
+
+    array.each do |id|
       tests[id][:title_pattern] = title
       test_harness_run(tests, id)
     end


### PR DESCRIPTION
* The 'always' keyword on soft-reconfig is only supported on certain NX platforms
* I considered adding platform checks for it but decided instead to just remove it altogether since beaker is already testing soft-reconfig with other values and minitest does the full range of possible values.
* Also found that soft-reconfig is not supported at all on n8/9k when l2vpn is used