### PR TITLE
Rel130/acl fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_aaa_authorization_login_cfg_svc](#type-cisco_aaa_authorization_login_cfg_svc) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | [cisco_aaa_authorization_login_exec_svc](#type-cisco_aaa_authorization_login_exec_svc) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | [cisco_aaa_group_tacacs](#type-cisco_aaa_group_tacacs) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [cisco_acl](#type-cisco_acl) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [cisco_ace](#type-cisco_ace) | ✅ | ✅ | ✅ | ❌* | ❌* | ❌* | ✅ | ❌ | * [caveats](#cisco_ace-caveats) |
+| [cisco_acl](#type-cisco_acl) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| [cisco_ace](#type-cisco_ace) | ✅ | ✅ | ✅ | ✅* | ✅* | ✅* | ✅ | ❌ | * [caveats](#cisco_ace-caveats) |
 | [cisco_command_config](#type-cisco_command_config) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [cisco_bgp](#type-cisco_bgp) | ✅ | ✅ | ✅ | ✅* | ✅* | ✅* | ✅ | ✅ | * [caveats](#cisco_bgp-caveats) |
 | [cisco_bgp_af](#type-cisco_bgp_af) | ✅* | ✅* | ✅ | ✅ | ✅*  | ✅ | ✅ | ✅ | * [caveats](#cisco_bgp_af-caveats) |

--- a/README.md
+++ b/README.md
@@ -591,11 +591,17 @@ Manages configuration of a Access Control List (ACL) instance.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
+
+#### <a name="cisco_acl-caveats">Caveats</a>
+
+| Property | Caveat Description |
+|:--------|:-------------|
+| `fragments` | Not supported on N56xx, N6k |
 
 #### Parameters
 
@@ -624,9 +630,9 @@ Manages configuration of an Access Control List (ACL) Access Control Entry (ACE)
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 

--- a/lib/puppet/type/cisco_acl.rb
+++ b/lib/puppet/type/cisco_acl.rb
@@ -125,9 +125,9 @@ Puppet::Type.newtype(:cisco_acl) do
   newproperty(:fragments) do
     desc 'fragments permit-all/deny-all state for the acl.'
 
+    newvalues(:permit, :deny, :default)
     munge do |value|
-      value = :default if value == 'default'
-      value
+      "#{value}-all" unless /default/.match(value)
     end
   end
 end

--- a/tests/beaker_tests/cisco_acl/test_acl.rb
+++ b/tests/beaker_tests/cisco_acl/test_acl.rb
@@ -49,7 +49,7 @@ tests[:non_default] = {
   title_pattern:  'ipv4 beaker',
   manifest_props: {
     stats_per_entry: 'true',
-    fragments:       'permit-all',
+    fragments:       'permit',
   },
 }
 


### PR DESCRIPTION
Changes:
- Update README.md to indicate acl/ace support.
- Fixed idempotency issue with `fragments` property.

Beaker Tests Pass on: n9k(I2 and I3), n3k, n6k, n7k

Waiting on N5k and N8k to become available.