### PR TITLE
ace demo manifest fixes

### DIFF
--- a/examples/cisco/demo_acl.pp
+++ b/examples/cisco/demo_acl.pp
@@ -15,10 +15,16 @@
 # limitations under the License.
 
 class ciscopuppet::cisco::demo_acl {
+
+  $fragments = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/  => 'permit',
+    default              => undef
+  }
+
   cisco_acl { 'ipv4 my_ipv4_acl':
     ensure                 => 'present',
     stats_per_entry        => false,
-    fragments              => 'permit'
+    fragments              => $fragments
   }
 
   cisco_ace { 'ipv4 my_ipv4_acl 10':
@@ -31,6 +37,36 @@ class ciscopuppet::cisco::demo_acl {
     dst_port               => 'range 32 56',
   }
 
+  $http_method = platform_get() ? {
+    /(n3k|n8k|n9k)/  => 'post',
+    default          => undef
+  }
+
+  $packet_length = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/  => 'range 80 1000',
+    default              => undef
+  }
+
+  $redirect = platform_get() ? {
+    /(n3k|n8k|n9k)/  => 'Ethernet1/1,Ethernet1/2,port-channel1',
+    default          => undef
+  }
+
+  $tcp_option_length = platform_get() ? {
+    /(n3k|n8k|n9k)/  => '20',
+    default          => undef
+  }
+
+  $time_range = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/  => 'my_range',
+    default              => undef
+  }
+
+  $ttl = platform_get() ? {
+    /(n3k|n8k|n9k)/  => '153', 
+    default          => undef
+  }
+
   cisco_ace { 'ipv4 my_ipv4_acl 20':
     action                 => 'permit',
     proto                  => 'tcp',
@@ -41,15 +77,14 @@ class ciscopuppet::cisco::demo_acl {
     tcp_flags              => 'ack syn fin',
     dscp                   => 'af11',
     established            => false,
-
-    # TBD: These properties need platform checks
-    # http_method            => 'post',
-    # packet_length          => 'range 80 1000',
-    # tcp_option_length      => '20',
-    # time_range             => 'my_range',
-    # ttl                    => '153',
-    # redirect               => 'Ethernet1/1,Ethernet1/2,port-channel1',
-    # log                    => false,
+    http_method            => $http_method,
+    packet_length          => $packet_length,
+    tcp_option_length      => $tcp_option_length,
+    time_range             => $time_range,
+    redirect               => $redirect,
+    log                    => false,
+    # TBD: ttl is currently broken on NX platforms
+    #ttl                    => $ttl,
   }
 
   cisco_acl { 'ipv6 my_ipv6_acl':

--- a/lib/puppet/parser/functions/platform_get.rb
+++ b/lib/puppet/parser/functions/platform_get.rb
@@ -41,9 +41,11 @@ module Puppet
           cisco_hardware = 'n7k'
         when /Nexus\s?8\d\d\d/
           cisco_hardware = 'n8k'
+        when /NX-OSv8K/
+          cisco_hardware = 'n8k'
         when /Nexus\s?9\d\d\d/
           cisco_hardware = 'n9k'
-        when /NX-OSv/
+        when /NX-OSv Chassis/
           cisco_hardware = 'n9k'
         else
           fail Puppet::ParseError, "Unrecognized platform type: #{pi}\n#{__FILE__}"

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -53,7 +53,7 @@ tests[:seq_10_v4] = {
 tests[:seq_10_v6] = {
   desc:           'IPv6 Seq 10',
   title_pattern:  'ipv6 beaker6 10',
-  platform:       'n(3|7|9)k', # TBD: N5k addrs display as 0001:0001::0001/128
+  platform:       'n(3|7|8|9)k', # TBD: N5k addrs display as 0001:0001::0001/128
   manifest_props: {
     action:   'permit',
     proto:    'tcp',

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -53,7 +53,6 @@ tests[:seq_10_v4] = {
 tests[:seq_10_v6] = {
   desc:           'IPv6 Seq 10',
   title_pattern:  'ipv6 beaker6 10',
-  platform:       'n(3|7|8|9)k', # TBD: N5k addrs display as 0001:0001::0001/128
   manifest_props: {
     action:   'permit',
     proto:    'tcp',

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -962,9 +962,11 @@ def platform
     @cisco_hardware = 'n7k'
   when /Nexus\s?8\d\d\d/
     @cisco_hardware = 'n8k'
+  when /NX-OSv8K/
+    @cisco_hardware = 'n8k'
   when /Nexus\s?9\d\d\d/
     @cisco_hardware = 'n9k'
-  when /NX-OSv/
+  when /NX-OSv Chassis/
     @cisco_hardware = 'n9k'
   when /XRv9K/i
     @cisco_hardware = 'xrv9k'


### PR DESCRIPTION
Fixes the following:
- Adds platform checks where needed for the demo manifest.
- Adds n8kv support to platform_get() module function.
- Enable ace test for n8k

Beaker/Demo Manifest Pass on: n3k, n9k (I2 I3), n5k, n9k

n7k not run due to license issue
n6k not run due to availability of testbed.