### PR TITLE
cisco_vtp fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *
 
 ### Added
-- Extended `cisco_vtp` support on the following platforms:
+- Extended `cisco_vtp` to support the following platforms:
     - `Nexus 56xx`, `Nexus 60xx`, `Nexus 7xxx`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *
 
 ### Added
+- Extended `cisco_vtp` support on the following platforms:
+    - `Nexus 56xx`, `Nexus 60xx`, `Nexus 7xxx`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`
   - `reconnect_interval`

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_vpc_domain](#type-cisco_vpc_domain) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ❌ | * [caveats](#cisco_vlan-caveats) |
 | [cisco_vrf](#type-cisco_vrf) | ✅ | ✅* | ✅* | ❌ | ❌ | ❌ | ✅ | ✅* | * [caveats](#cisco_vrf-caveats) |
 | [cisco_vrf_af](#type-cisco_vrf_af) | ✅ | ✅ | ✅ | ✅* | ✅* | ✅* | ✅ | ✅* | * [caveats](#cisco_vrf_af-caveats) |
-| [cisco_vtp](#type-cisco_vtp) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| [cisco_vtp](#type-cisco_vtp) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_vxlan_vtep](#type-cisco_vxlan_vtep) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | [cisco_vxlan_vtep_vni](#type-cisco_vxlan_vtep_vni) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 
@@ -3286,9 +3286,9 @@ There can only be one instance of the cisco_vtp.
 | N9k      | 7.0(3)I2(1)        | 1.0.1                  |
 | N30xx    | 7.0(3)I2(1)        | 1.0.1                  |
 | N31xx    | 7.0(3)I2(1)        | 1.0.1                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 

--- a/lib/puppet/provider/cisco_vtp/cisco.rb
+++ b/lib/puppet/provider/cisco_vtp/cisco.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:cisco_vtp).provide(:cisco) do
 
   def initialize(value={})
     super(value)
-    @vtp = Cisco::Vtp.new if Cisco::Vtp.enabled
+    @vtp = Cisco::Vtp.new
     @property_flush = {}
   end
 
@@ -57,7 +57,7 @@ Puppet::Type.type(:cisco_vtp).provide(:cisco) do
 
   def self.instances
     vtps = []
-    return vtps unless Cisco::Vtp.enabled
+    return vtps unless Cisco::Feature.vtp_enabled?
 
     vtp = Cisco::Vtp.new
 

--- a/lib/puppet/type/cisco_vtp.rb
+++ b/lib/puppet/type/cisco_vtp.rb
@@ -74,10 +74,17 @@ Puppet::Type.newtype(:cisco_vtp) do
   newproperty(:filename) do
     desc "VTP file name. Valid values are string, keyword 'default'."
 
-    munge do |file_name|
-      file_name = :default if file_name == 'default'
+    validate do |file_name|
       fail 'File name is not a string.' unless
         file_name == :default || file_name.is_a?(String)
+    end
+
+    munge do |file_name|
+      file_name = :default if file_name == 'default'
+      unless file_name == :default || /(bootflash:|usb.*:)/.match(file_name)
+        # Use 'bootflash:/' if only the filename is specified.
+        file_name = 'bootflash:/' + file_name
+      end
       file_name
     end
   end # property filename


### PR DESCRIPTION
**Summary of changes:**
- Updated docs to indicate support on n5k, n6k and n7k.
- Append `bootflash:/` to vtp filename if now mount is specified.

Tested on: n3k, n7k, n8k, n9k(I2 & I3).  Waiting on n5|6k to become available.

Note, all tests pass except an idempotence issue for vtp password.  This is a platform issue and the work around will be in a separate PR.