### PR TITLE
Fix things for itd, stp, snmp_comm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2636,7 +2636,7 @@ Manages spanning tree global parameters
 | `bd_priority` | Supported only on N7k |
 | `bd_root_priority` | Supported only on N7k |
 | `domain` | Supported only on N56k, N6k, N7k |
-| `fcoe` | Supported only on N9k, N30xx, N31xx |
+| `fcoe` | Supported only on N9k |
 
 #### Parameters
 

--- a/examples/cisco/demo_itd.pp
+++ b/examples/cisco/demo_itd.pp
@@ -18,183 +18,185 @@
 
 class ciscopuppet::cisco::demo_itd {
 
-  $nat_destination = platform_get() ? {
-    'n7k'   => true,
-    default => undef
-  }
+  if platform_get() =~ /n(7|9)k/ {
+    $nat_destination = platform_get() ? {
+      'n7k'   => true,
+      default => undef
+    }
 
-  $peer_local1 = platform_get() ? {
-    'n9k'   => 'pser1',
-    default => undef
-  }
+    $peer_local1 = platform_get() ? {
+      'n9k'   => 'pser1',
+      default => undef
+    }
 
-  $peer_local2 = platform_get() ? {
-    'n9k'   => 'pser2',
-    default => undef
-  }
+    $peer_local2 = platform_get() ? {
+      'n9k'   => 'pser2',
+      default => undef
+    }
 
-  $peer_vdc1 = platform_get() ? {
-    'n7k'   => ['vdc1', 'pser1'],
-    default => undef
-  }
+    $peer_vdc1 = platform_get() ? {
+      'n7k'   => ['vdc1', 'pser1'],
+      default => undef
+    }
 
-  $peer_vdc2 = platform_get() ? {
-    'n7k'   => ['vdc2', 'pser2'],
-    default => undef
-  }
+    $peer_vdc2 = platform_get() ? {
+      'n7k'   => ['vdc2', 'pser2'],
+      default => undef
+    }
 
-  cisco_itd_device_group {'icmpGroup':
-    ensure           => 'present',
-    probe_frequency  => 1800,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'icmp',
-  }
+    cisco_itd_device_group {'icmpGroup':
+      ensure           => 'present',
+      probe_frequency  => 1800,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'icmp',
+    }
 
-  cisco_itd_device_group {'dnsgroup':
-    ensure           => 'present',
-    probe_dns_host   => '8.8.8.8',
-    probe_frequency  => 1800,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'dns',
-  }
+    cisco_itd_device_group {'dnsgroup':
+      ensure           => 'present',
+      probe_dns_host   => '8.8.8.8',
+      probe_frequency  => 1800,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'dns',
+    }
 
-  cisco_itd_device_group {'tcpGroup':
-    ensure           => 'present',
-    probe_control    => true,
-    probe_frequency  => 1600,
-    probe_port       => 6666,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'tcp',
-  }
+    cisco_itd_device_group {'tcpGroup':
+      ensure           => 'present',
+      probe_control    => true,
+      probe_frequency  => 1600,
+      probe_port       => 6666,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'tcp',
+    }
 
-  cisco_itd_device_group {'udpGroup':
-    ensure           => 'present',
-    probe_control    => true,
-    probe_frequency  => 1600,
-    probe_port       => 6666,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'udp',
-  }
+    cisco_itd_device_group {'udpGroup':
+      ensure           => 'present',
+      probe_control    => true,
+      probe_frequency  => 1600,
+      probe_port       => 6666,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'udp',
+    }
 
-  cisco_itd_device_group_node {'icmpGroup 2.2.2.2':
-    ensure           => 'present',
-    hot_standby      => false,
-    node_type        => 'ip',
-    probe_frequency  => 1600,
-    probe_retry_down => 2,
-    probe_retry_up   => 2,
-    probe_timeout    => 1100,
-    probe_type       => 'icmp',
-    weight           => 20,
-  }
-  cisco_itd_device_group_node {'icmpGroup 1.1.1.1':
-    ensure           => 'present',
-    hot_standby      => false,
-    probe_frequency  => 1800,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'icmp',
-    weight           => 200,
-  }
-  cisco_itd_device_group_node {'udpGroup 2.2.2.2':
-    ensure           => 'present',
-    hot_standby      => true,
-    probe_control    => true,
-    probe_frequency  => 1800,
-    probe_port       => 6666,
-    probe_retry_down => 4,
-    probe_retry_up   => 4,
-    probe_timeout    => 1200,
-    probe_type       => 'udp',
-    weight           => 1,
-  }
-  cisco_itd_device_group_node {'udpGroup 3.3.3.3':
-    ensure           => 'present',
-    hot_standby      => false,
-    probe_control    => false,
-    probe_frequency  => 10,
-    probe_retry_down => 3,
-    probe_retry_up   => 3,
-    probe_timeout    => 5,
-    probe_type       => default,
-    weight           => 1,
-  }
+    cisco_itd_device_group_node {'icmpGroup 2.2.2.2':
+      ensure           => 'present',
+      hot_standby      => false,
+      node_type        => 'ip',
+      probe_frequency  => 1600,
+      probe_retry_down => 2,
+      probe_retry_up   => 2,
+      probe_timeout    => 1100,
+      probe_type       => 'icmp',
+      weight           => 20,
+    }
+    cisco_itd_device_group_node {'icmpGroup 1.1.1.1':
+      ensure           => 'present',
+      hot_standby      => false,
+      probe_frequency  => 1800,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'icmp',
+      weight           => 200,
+    }
+    cisco_itd_device_group_node {'udpGroup 2.2.2.2':
+      ensure           => 'present',
+      hot_standby      => true,
+      probe_control    => true,
+      probe_frequency  => 1800,
+      probe_port       => 6666,
+      probe_retry_down => 4,
+      probe_retry_up   => 4,
+      probe_timeout    => 1200,
+      probe_type       => 'udp',
+      weight           => 1,
+    }
+    cisco_itd_device_group_node {'udpGroup 3.3.3.3':
+      ensure           => 'present',
+      hot_standby      => false,
+      probe_control    => false,
+      probe_frequency  => 10,
+      probe_retry_down => 3,
+      probe_retry_up   => 3,
+      probe_timeout    => 5,
+      probe_type       => default,
+      weight           => 1,
+    }
 
-  cisco_acl { 'ipv4 ial':
-    ensure => present
-  }
+    cisco_acl { 'ipv4 ial':
+      ensure => present
+    }
+  
+    cisco_acl { 'ipv4 eal':
+      ensure => present
+    }
 
-  cisco_acl { 'ipv4 eal':
-    ensure => present
-  }
+    cisco_interface { 'ethernet1/1':
+      switchport_mode => disabled
+    }
 
-  cisco_interface { 'ethernet1/1':
-    switchport_mode => disabled
-  }
+    cisco_interface { 'ethernet1/2':
+      switchport_mode => disabled
+    }
 
-  cisco_interface { 'ethernet1/2':
-    switchport_mode => disabled
-  }
+    cisco_vlan { '2':
+      ensure => present
+    }
 
-  cisco_vlan { '2':
-    ensure => present
-  }
+    cisco_interface { 'vlan2':
+      ensure => present,
+    }
 
-  cisco_interface { 'vlan2':
-    ensure => present,
-  }
+    cisco_interface { 'port-channel100':
+      ensure          => present,
+      switchport_mode => disabled
+    }
 
-  cisco_interface { 'port-channel100':
-    ensure          => present,
-    switchport_mode => disabled
-  }
+    $ingress_interface = [['vlan 2', '4.4.4.4'],
+    ['ethernet 1/1', '6.6.6.6'], ['port-channel 100', '7.7.7.7']]
+  
+    $virtual_ip = ['ip 3.3.3.3 255.0.0.0 tcp 500 advertise enable']
 
-  $ingress_interface = [['vlan 2', '4.4.4.4'],
-  ['ethernet 1/1', '6.6.6.6'], ['port-channel 100', '7.7.7.7']]
+    cisco_itd_service {'myservice1':
+      ensure                        => 'present',
+      device_group                  => 'udpGroup',
+      exclude_access_list           => 'eal',
+      fail_action                   => false,
+      ingress_interface             => $ingress_interface,
+      load_bal_enable               => true,
+      load_bal_buckets              => 8,
+      load_bal_mask_pos             => 4,
+      load_bal_method_bundle_hash   => 'ip-l4port',
+      load_bal_method_bundle_select => 'src',
+      load_bal_method_end_port      => 202,
+      load_bal_method_proto         => 'udp',
+      load_bal_method_start_port    => 101,
+      nat_destination               => $nat_destination,
+      peer_vdc                      => $peer_vdc1,
+      peer_local                    => $peer_local1,
+      shutdown                      => true,
+      virtual_ip                    => $virtual_ip,
+    }
 
-  $virtual_ip = ['ip 3.3.3.3 255.0.0.0 tcp 500 advertise enable']
-
-  cisco_itd_service {'myservice1':
-    ensure                        => 'present',
-    device_group                  => 'udpGroup',
-    exclude_access_list           => 'eal',
-    fail_action                   => false,
-    ingress_interface             => $ingress_interface,
-    load_bal_enable               => true,
-    load_bal_buckets              => 8,
-    load_bal_mask_pos             => 4,
-    load_bal_method_bundle_hash   => 'ip-l4port',
-    load_bal_method_bundle_select => 'src',
-    load_bal_method_end_port      => 202,
-    load_bal_method_proto         => 'udp',
-    load_bal_method_start_port    => 101,
-    nat_destination               => $nat_destination,
-    peer_vdc                      => $peer_vdc1,
-    peer_local                    => $peer_local1,
-    shutdown                      => true,
-    virtual_ip                    => $virtual_ip,
-  }
-
-  cisco_itd_service {'myservice2':
-    ensure                        => 'present',
-    device_group                  => 'udpGroup',
-    ingress_interface             => [['ethernet 1/2', '22.2.2.2']],
-    load_bal_enable               => true,
-    load_bal_buckets              => 16,
-    load_bal_mask_pos             => 10,
-    load_bal_method_bundle_hash   => 'ip',
-    load_bal_method_bundle_select => 'dst',
-    peer_vdc                      => $peer_vdc2,
-    peer_local                    => $peer_local2,
-    shutdown                      => false,
+    cisco_itd_service {'myservice2':
+      ensure                        => 'present',
+      device_group                  => 'udpGroup',
+      ingress_interface             => [['ethernet 1/2', '22.2.2.2']],
+      load_bal_enable               => true,
+      load_bal_buckets              => 16,
+      load_bal_mask_pos             => 10,
+      load_bal_method_bundle_hash   => 'ip',
+      load_bal_method_bundle_select => 'dst',
+      peer_vdc                      => $peer_vdc2,
+      peer_local                    => $peer_local2,
+      shutdown                      => false,
+    }
   }
 }

--- a/examples/cisco/demo_itd.pp
+++ b/examples/cisco/demo_itd.pp
@@ -139,11 +139,11 @@ class ciscopuppet::cisco::demo_itd {
     }
 
     cisco_interface { 'ethernet1/1':
-      switchport_mode => disabled
+      switchport_mode => 'disabled'
     }
 
     cisco_interface { 'ethernet1/2':
-      switchport_mode => disabled
+      switchport_mode => 'disabled'
     }
 
     cisco_vlan { '2':
@@ -156,7 +156,7 @@ class ciscopuppet::cisco::demo_itd {
 
     cisco_interface { 'port-channel100':
       ensure          => present,
-      switchport_mode => disabled
+      switchport_mode => 'disabled'
     }
 
     $ingress_interface = [['vlan 2', '4.4.4.4'],
@@ -198,5 +198,8 @@ class ciscopuppet::cisco::demo_itd {
       peer_local                    => $peer_local2,
       shutdown                      => false,
     }
+  }
+  else {
+    notify{'SKIP: This platform does not support cisco_itd_service': }
   }
 }

--- a/examples/cisco/demo_stp_vlan.pp
+++ b/examples/cisco/demo_stp_vlan.pp
@@ -22,7 +22,7 @@ class ciscopuppet::cisco::demo_stp_vlan {
   }
 
   $fcoe = platform_get() ? {
-    /(n3k|n9k)/ => false,
+    'n9k' => false,
     default => undef
   }
 

--- a/lib/puppet/provider/cisco_snmp_community/cisco.rb
+++ b/lib/puppet/provider/cisco_snmp_community/cisco.rb
@@ -70,6 +70,7 @@ Puppet::Type.type(:cisco_snmp_community).provide(:cisco) do
   end
 
   def group
+    return if @snmp_community.nil?
     value = @snmp_community.group
     value = :default if
       @resource[:group] == :default &&

--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -153,7 +153,7 @@ tests[:non_default] = {
 
 tests[:default_plat_1] = {
   desc:           '1.3 Default Properties platform specific part 1',
-  platform:       'n(3|9)k',
+  platform:       'n9k',
   title_pattern:  'default',
   manifest_props: {
     fcoe: 'default'
@@ -166,7 +166,7 @@ tests[:default_plat_1] = {
 
 tests[:non_default_plat_1] = {
   desc:           '2.2 Non Default Properties platform specific part 1',
-  platform:       'n(3|9)k',
+  platform:       'n9k',
   title_pattern:  'default',
   manifest_props: {
     fcoe: 'false'


### PR DESCRIPTION
These are changes for 3 providers.
1, fcoe attribute in stp_global is not supported on n3k and so it is removed from demo manifest and beaker tests.
2. itd is supported only on n9k and n7k. Added exclude clause in the demo manifest so that the manifest will not throw errors for other nexus switches.
3. snmp_commity provider has an error where if there is a comminuty already existing on the switch, the beaker test is failing when it is trying to remove (because it is accessing group parameter after the community resource is removed). This is fixed. 