### PR TITLE
Feature/aaa fixup release

### DIFF
--- a/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
@@ -94,7 +94,7 @@ test_name "TestCase :: #{testheader}" do
     tests[id][:resource_cmd] =
       get_namespace_cmd(agent, resource_cmd_str, options)
 
-    tests[id][:code] = [0, 2]
+    tests[id][:code] = [2]
     tests[id][:desc] =
       "1.1 Apply manifest with non-default #{prop}, and test harness"
     create_aaaauthelogin_manifest(tests, id)

--- a/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_authentication_login/test_aaaauthelogin_nondefaults.rb
@@ -71,7 +71,6 @@ test_name "TestCase :: #{testheader}" do
   vals = [:true, :false, :false, :false]
   ['ascii-authentication', 'chap', 'mschap', 'mschapv2'].each do |prop|
     ascii, chap, mschap, mschapv2 = vals
-    vals.rotate! # vals => [:false, :true, :false, :false]
 
     tests[id] = {
       :manifest_props => {
@@ -97,12 +96,12 @@ test_name "TestCase :: #{testheader}" do
 
     tests[id][:code] = [0, 2]
     tests[id][:desc] =
-      '1.1 Apply manifest with non-default attributes, and test harness'
+      "1.1 Apply manifest with non-default #{prop}, and test harness"
     create_aaaauthelogin_manifest(tests, id)
     test_harness_common(tests, id)
 
     tests[id][:desc] =
-      '1.2 Apply manifest with string format non-default attributes'
+      "1.2 Apply manifest with string format non-default #{prop}"
     tests[id][:manifest_props] = {
       :ascii_authentication => ascii.to_s,
       :chap                 => chap.to_s,
@@ -111,13 +110,12 @@ test_name "TestCase :: #{testheader}" do
       :mschapv2             => mschapv2.to_s,
     }
     create_aaaauthelogin_manifest(tests, id)
-    tests[id][:show_cmd] = 'show run aaa all | section login'
-    # this will check existence of each prop enablement in turn
-    tests[id][:show_pattern] = [/^aaa authentication login #{prop} enable/]
-    tests[id][:state] = true
     # In this case, nothing changed, we would expect the puppet run return 0,
     tests[id][:code] = [0]
     test_harness_common(tests, id)
+
+    # rotate values to the right to set the next prop to :true
+    vals.rotate!(-1)
   end
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -63,12 +63,6 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Defaults'
 
-# Check platform type and skip if necessary.
-unless /n(3|9)k/.match(platform)
-  msg = "Test not supported on this platform: #{platform}"
-  prereq_skip(testheader, self, msg)
-end
-
 # @test_name [TestCase] Executes defaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -82,15 +82,6 @@ test_name "TestCase :: #{testheader}" do
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -124,20 +115,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_aaa_group resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/aaa group server tacacs\+ test/],
-                               false, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -166,20 +143,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/aaa group server tacacs\+ test/],
-                               true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -80,15 +80,6 @@ test_name "TestCase :: #{testheader}" do
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, TacacsServerLib.create_tacacsserver_present)
 
@@ -129,22 +120,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs all')
-    on(agent, cmd_str) do
-      search_pattern_in_output(
-        stdout,
-        [/aaa group server tacacs\+ test/,
-         /^\s+deadtime #{AaaGroupLib::DEADTIME_NEGATIVE}/],
-        true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -172,22 +147,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs all')
-    on(agent, cmd_str) do
-      search_pattern_in_output(
-        stdout,
-        [/aaa group server tacacs\+ test/,
-         /^\s+use-vrf #{AaaGroupLib::VRF_NAME_NEGATIVE}/],
-        true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -220,22 +179,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs all')
-    on(agent, cmd_str) do
-      search_pattern_in_output(
-        stdout,
-        [/aaa group server tacacs\+ test/,
-         /^\s+source-interface #{AaaGroupLib::SOURCE_INTERFACE_NEGATIVE}/],
-        true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -264,22 +207,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs all')
-    on(agent, cmd_str) do
-      search_pattern_in_output(
-        stdout,
-        [/aaa group server tacacs\+ test/,
-         /^\s+server #{AaaGroupLib::SERVER_HOSTS_NEGATIVE}/],
-        true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -61,12 +61,6 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Negatives'
 
-# Check platform type and skip if necessary.
-unless /n(3|9)k/.match(platform)
-  msg = "Test not supported on this platform: #{platform}"
-  prereq_skip(testheader, self, msg)
-end
-
 # @test_name [TestCase] Executes negatives testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -82,15 +82,6 @@ test_name "TestCase :: #{testheader}" do
       'agent -t', options)
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -127,20 +118,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_aaa_group resource presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/aaa group server tacacs\+ test/],
-                               false, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -172,20 +149,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks aaagroup instance on agent using switch show cli cmds.
-  step 'TestStep :: Check cisco_aaa_group instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/aaa group server tacacs\+ test/],
-                               true, self, logger)
-    end
-
-    logger.info("Check cisco_aaa_group instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -63,12 +63,6 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes NonDefaults'
 
-# Check platform type and skip if necessary.
-unless /n(3|9)k/.match(platform)
-  msg = "Test not supported on this platform: #{platform}"
-  prereq_skip(testheader, self, msg)
-end
-
 # @test_name [TestCase] Executes nondefaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.

--- a/tests/beaker_tests/cisco_command_config/test_command_config.rb
+++ b/tests/beaker_tests/cisco_command_config/test_command_config.rb
@@ -65,7 +65,6 @@ testheader = 'Resource cisco_command_config'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master: master,

--- a/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
+++ b/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
@@ -67,7 +67,6 @@ testheader = 'Resource cisco_fabricpath_global'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master:   master,

--- a/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
+++ b/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
@@ -67,7 +67,6 @@ testheader = 'Resource cisco_fabricpath_topology'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master:   master,

--- a/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
+++ b/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
@@ -70,7 +70,6 @@ testheader = 'Resource cisco_interface_portchannel'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master: master,
@@ -84,7 +83,6 @@ tests = {
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:ensure] - (Optional) set to :present or :absent before calling
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #

--- a/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
+++ b/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
@@ -69,7 +69,6 @@ testheader = 'Resource cisco_overlay_global'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master:   master,
@@ -84,7 +83,6 @@ tests = {
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #
 # These keys are local use only and not used by test_harness_common:

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -70,7 +70,6 @@ testheader = 'Resource cisco_portchannel_global'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master: master,
@@ -84,7 +83,6 @@ tests = {
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:ensure] - (Optional) set to :present or :absent before calling
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #

--- a/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
+++ b/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
@@ -70,7 +70,6 @@ testheader = 'Resource cisco_vpc_domain'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master:           master,
@@ -87,7 +86,6 @@ tests = {
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:ensure] - (Optional) set to :present or :absent before calling
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -190,14 +190,12 @@ end
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 # tests[id] keys set by caller:
 # tests[id][:desc] - a string to use with logs & debugs
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:ensure] - (Optional) set to :present or :absent before calling
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #
@@ -213,7 +211,6 @@ def test_harness_common(tests, id)
 
   test_manifest(tests, id)
   test_resource(tests, id)
-  test_show_cmd(tests, id, tests[id][:state]) unless tests[id][:show_pattern].nil?
   test_idempotence(tests, id)
   tests[id].delete(:log_desc)
 end
@@ -259,23 +256,6 @@ def test_resource(tests, id, state=false)
       search_pattern_in_output(
         stdout, supported_property_hash(tests, id, tests[id][:resource]),
         state, self, logger)
-    end
-    logger.info("#{stepinfo} :: PASS")
-    tests[id].delete(:log_desc)
-  end
-end
-
-# Wrapper for config pattern-match tests
-def test_show_cmd(tests, id, state=false)
-  stepinfo = format_stepinfo(tests, id, 'SHOW CMD')
-  show_cmd = get_vshell_cmd(tests[id][:show_cmd])
-  step "TestStep :: #{stepinfo}" do
-    logger.debug('test_show_cmd :: BEGIN')
-    on(tests[:agent], show_cmd) do
-      logger.debug("test_show_cmd :: cmd:\n#{show_cmd}")
-      logger.debug("test_show_cmd :: pattern:\n#{tests[id][:show_pattern]}")
-      search_pattern_in_output(stdout, tests[id][:show_pattern],
-                               state, self, logger)
     end
     logger.info("#{stepinfo} :: PASS")
     tests[id].delete(:log_desc)

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -268,7 +268,7 @@ end
 # Wrapper for config pattern-match tests
 def test_show_cmd(tests, id, state=false)
   stepinfo = format_stepinfo(tests, id, 'SHOW CMD')
-  show_cmd = get_vshell_cmd(tests[:show_cmd])
+  show_cmd = get_vshell_cmd(tests[id][:show_cmd])
   step "TestStep :: #{stepinfo}" do
     logger.debug('test_show_cmd :: BEGIN')
     on(tests[:agent], show_cmd) do

--- a/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/port_channel_provider_defaults.rb
@@ -70,7 +70,6 @@ testheader = 'Resource port_channel'
 # Top-level keys set by caller:
 # tests[:master] - the master object
 # tests[:agent] - the agent object
-# tests[:show_cmd] - the common show command to use for test_show_run
 #
 tests = {
   master: master,
@@ -84,7 +83,6 @@ tests = {
 # tests[id][:manifest] - the complete manifest, as used by test_harness_common
 # tests[id][:resource] - a hash of expected states, used by test_resource
 # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:show_pattern] - array of regexp patterns to use with test_show_cmd
 # tests[id][:ensure] - (Optional) set to :present or :absent before calling
 # tests[id][:code] - (Optional) override the default exit code in some tests.
 #


### PR DESCRIPTION
* Remove vshell commands from tests
* Remove platform check that failed for non-3k and non-9k platforms
* Fix `authentication_login` test that rotated values the incorrect way

Tests passing all platforms:

* `cisco_aaa_group_tacacs`
* `cisco_aaa_authentication_login`
* `cisco_aaa_login_cfg_svc`
* `cisco_aaa_login_exec`