### PR TITLE
pc for n8k

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_pim](#type-cisco_pim) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_pim_rp_address](#type-cisco_pim_rp_address) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_pim_grouplist](#type-cisco_pim_grouplist) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| [cisco_portchannel_global](#type-cisco_portchannel_global) | ❌* | ✅* | ✅* | ❌* | ❌* | ❌ | ✅ | ❌ | * [caveats](#cisco_portchannel_global-caveats) |
+| [cisco_portchannel_global](#type-cisco_portchannel_global) | ✅* | ❌* | ❌* | ✅* | ✅* | ✅* | ✅* | ❌ | * [caveats](#cisco_portchannel_global-caveats) |
 | [cisco_stp_global](#type-cisco_stp_global) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅ | ✅ | ❌ | * [caveats](#cisco_stp_global-caveats) |
 | [cisco_snmp_community](#type-cisco_snmp_community) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_snmp_group](#type-cisco_snmp_group) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -2557,12 +2557,12 @@ Manages configuration of a portchannel global parameters
 
 | Platform | OS Minimum Version | Module Minimum Version |
 |----------|:------------------:|:----------------------:|
-| N9k      | unsupported        | unsupported            |
-| N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N9k      | 7.0(3)I2(1)        | 1.2.0                  |
+| N30xx    | unsupported        | unsupported            |
+| N31xx    | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.2.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -2572,43 +2572,43 @@ Manages configuration of a portchannel global parameters
 |:--------|:-------------|
 | `hash_poly` | Supported only on N56xx, N6k |
 | `asymmetric` <br> `hash_distribution` <br> `load_defer` | Supported only on N7k |
-| `concatenation` <br> `resilient` <br> `symmetry`| Supported only on N9k, N30xx, N31xx |
-| `rotate` | Supported only on N9k, N30xx, N31xx and N7k |
+| `concatenation` <br> `resilient` <br> `symmetry`| Supported only on N9k|
+| `rotate` | Supported only on N7k, N8k, N9k |
 
 #### Parameters
 
 ##### `asymmetric`
-port-channel asymmetric hash. Valid values are true, false or 'default'. This property is supported only on N7k.
+port-channel asymmetric hash. Valid values are true, false or 'default'.
 
 ##### `bundle_hash`
 port-channel bundle hash. Valid values are 'ip', 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port', 'mac', 'port', 'ip-only', 'port-only', 'ip-gre' or 'default'.
-* 'port', 'ip-only', 'port-only', 'ip-gre' are only supported on N9k, N30xx, N31xx, N56xx, N6k.
-* 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port', 'ip-gre' are only supported on N9k, N30xx, N31xx, N7k.
-* 'port', 'ip-only', 'port-only' are only supported on N56xx, N6k, N7k.
+* port, 'ip-only', 'port-only' are only supported on N56xx, N6k.
+* 'ip-gre' is only supported on N9k.
+* 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k.
 
 ##### `bundle_select`
 port-channel bundle select. Valid values are 'src', 'dst', 'src-dst' or 'default'.
 
 ##### `concatenation`
-port-channel concatenation enable or disable. Valid values are true, false or 'default'. This property is only supported on N9k, N30xx, N31xx.
+port-channel concatenation enable or disable. Valid values are true, false or 'default'.
 
 ##### `hash_distribution`
-port-channel hash-distribution. Valid values are 'adaptive', 'fixed' or the keyword 'default'. This property is only supported on N7k.
+port-channel hash-distribution. Valid values are 'adaptive', 'fixed' or the keyword 'default'.
 
 ##### `hash_poly`
-port-channel hash-polynomial. Valid values are 'CRC10a', 'CRC10b', 'CRC10c' or 'CRC10d'. Note: This property does not support the keyword 'default' and it is only supported on N56xx and N6k.
+port-channel hash-polynomial. Valid values are 'CRC10a', 'CRC10b', 'CRC10c' or 'CRC10d'. Note: This property does not support the keyword 'default'.
 
 ##### `load_defer`
-port-channel load-defer time interval. Valid values are integer or 'default'. This property is only supported on N7k.
+port-channel load-defer time interval. Valid values are integer or 'default'.
 
 ##### `resilient`
-port-channel resilient mode. Valid values are true, false or 'default'. This property is only supported on N9k, N30xx, N31xx.
+port-channel resilient mode. Valid values are true, false or 'default'.
 
 ##### `rotate`
-port-channel hash input offset. Valid values are integer or 'default'. This property is only supported on N9k, N30xx, N31xx, N7k.
+port-channel hash input offset. Valid values are integer or 'default'.
 
 ##### `symmetry`
-port-channel symmetry hash. Valid values are true, false or 'default'. This property is only supported on N9k, N30xx, N31xx.
+port-channel symmetry hash. Valid values are true, false or 'default'.
 
 --
 ### Type: cisco_stp_global

--- a/README.md
+++ b/README.md
@@ -249,10 +249,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_interface`](#type-cisco_interface)
   * [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
   * [`cisco_interface_ospf`](#type-cisco_interface_ospf)
-  * [`cisco_interface_
-  * 
-  * 
-  * `](#type-cisco_interface_portchannel)
+  * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
   * [`cisco_interface_service_vni`](#type-cisco_interface_service_vni)
   * [`network_interface (netdev_stdlib)`](#type-network_interface)
 
@@ -2577,6 +2574,7 @@ Manages configuration of a portchannel global parameters
 | `asymmetric` <br> `hash_distribution` <br> `load_defer` | Supported only on N7k |
 | `concatenation` <br> `resilient` <br> `symmetry`| Supported only on N9k|
 | `rotate` | Supported only on N7k, N8k, N9k |
+| `bundle_hash` | 'port', 'ip-only', 'port-only' are only supported on N56xx, N6k. 'ip-gre' is only supported on N9k. 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k. |
 
 #### Parameters
 
@@ -2585,9 +2583,6 @@ port-channel asymmetric hash. Valid values are true, false or 'default'.
 
 ##### `bundle_hash`
 port-channel bundle hash. Valid values are 'ip', 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port', 'mac', 'port', 'ip-only', 'port-only', 'ip-gre' or 'default'.
-* 'port', 'ip-only', 'port-only' are only supported on N56xx, N6k.
-* 'ip-gre' is only supported on N9k.
-* 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k.
 
 ##### `bundle_select`
 port-channel bundle select. Valid values are 'src', 'dst', 'src-dst' or 'default'.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_interface`](#type-cisco_interface)
   * [`cisco_interface_channel_group`](#type-cisco_interface_channel_group)
   * [`cisco_interface_ospf`](#type-cisco_interface_ospf)
-  * [`cisco_interface_portchannel`](#type-cisco_interface_portchannel)
+  * [`cisco_interface_
+  * 
+  * 
+  * `](#type-cisco_interface_portchannel)
   * [`cisco_interface_service_vni`](#type-cisco_interface_service_vni)
   * [`network_interface (netdev_stdlib)`](#type-network_interface)
 
@@ -2582,7 +2585,7 @@ port-channel asymmetric hash. Valid values are true, false or 'default'.
 
 ##### `bundle_hash`
 port-channel bundle hash. Valid values are 'ip', 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port', 'mac', 'port', 'ip-only', 'port-only', 'ip-gre' or 'default'.
-* port, 'ip-only', 'port-only' are only supported on N56xx, N6k.
+* 'port', 'ip-only', 'port-only' are only supported on N56xx, N6k.
 * 'ip-gre' is only supported on N9k.
 * 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k.
 

--- a/examples/cisco/demo_portchannel.pp
+++ b/examples/cisco/demo_portchannel.pp
@@ -42,12 +42,12 @@ class ciscopuppet::cisco::demo_portchannel {
   }
 
   $port_hash_distribution = platform_get() ? {
-    /(n3k|n7k|n9k)/ => 'adaptive',
+    /(n3k|n7k|n8k|n9k)/ => 'adaptive',
     default => undef
   }
 
   $port_load_defer = platform_get() ? {
-    /(n3k|n7k|n9k)/ => true,
+    /(n3k|n7k|n8k|n9k)/ => true,
     default => undef
   }
 
@@ -57,7 +57,7 @@ class ciscopuppet::cisco::demo_portchannel {
   }
 
   $rotate = platform_get() ? {
-    /(n3k|n7k|n9k)/ => '4',
+    /(n3k|n7k|n8k|n9k)/ => '4',
     default => undef
   }
 

--- a/lib/puppet/provider/cisco_portchannel_global/cisco.rb
+++ b/lib/puppet/provider/cisco_portchannel_global/cisco.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
     :bundle_select,
     :hash_distribution,
     :hash_poly,
+    :load_balance_type,
     :load_defer,
     :rotate,
   ]
@@ -104,6 +105,7 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
 
   def properties_set
     PC_GLOBAL_ALL_PROPS.each do |prop|
+      next if prop == :load_balance_type
       next unless @resource[prop]
       unless @property_flush[prop].nil?
         @nu.send("#{prop}=", @property_flush[prop]) if
@@ -111,9 +113,10 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
       end
     end
     # custom setters which require one-shot multi-param setters
-    port_channel_load_balance_sym_concat_rot_set
-    port_channel_load_balance_hash_poly_set
-    port_channel_load_balance_asym_rot_set
+    port_channel_load_balance_sym_concat_rot_set if @nu.load_balance_type == 'symmetry'
+    port_channel_load_balance_hash_poly_set if @nu.load_balance_type == 'ethernet'
+    port_channel_load_balance_asym_rot_set if @nu.load_balance_type == 'asymmetric'
+    port_channel_load_balance_no_hash_set if @nu.load_balance_type == 'no_hash'
   end
 
   # We need special handling for boolean properties in our custom
@@ -239,6 +242,37 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
     end
     @nu.send(:port_channel_load_balance=,
              bs.to_s, bh.to_s, nil, as, nil, nil, ro)
+  end
+
+  # some platforms require all 3 properties to be set in the manifest
+  # port-channel load-balance src-dst ip rotate 4
+  # all the above properties will be set all at once so make sure
+  # all the needed resources are present
+  def port_channel_load_balance_no_hash_all?
+    @resource[:bundle_hash] &&
+      @resource[:bundle_select] &&
+      @resource[:rotate]
+  end
+
+  def port_channel_load_balance_no_hash_set
+    return unless port_channel_load_balance_no_hash_all?
+    if @property_flush[:bundle_hash]
+      bh = @property_flush[:bundle_hash]
+    else
+      bh = @nu.bundle_hash
+    end
+    if @property_flush[:bundle_select]
+      bs = @property_flush[:bundle_select]
+    else
+      bs = @nu.bundle_select
+    end
+    if @property_flush[:rotate]
+      ro = @property_flush[:rotate]
+    else
+      ro = @nu.rotate
+    end
+    @nu.send(:port_channel_load_balance=,
+             bs.to_s, bh.to_s, nil, nil, nil, nil, ro)
   end
 
   def flush

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -213,6 +213,35 @@ tests['non_default_properties_sym'] = {
   },
 }
 
+tests['default_properties_no_hash'] = {
+  title_pattern:  'default',
+  manifest_props: "
+    bundle_hash                  => 'default',
+    bundle_select                => 'default',
+    rotate                       => 'default',
+  ",
+  code:           [0, 2],
+  resource_props: {
+    'bundle_hash'   => 'ip-l4port',
+    'bundle_select' => 'src-dst',
+    'rotate'        => '0',
+  },
+}
+
+tests['non_default_properties_no_hash'] = {
+  title_pattern:  'default',
+  manifest_props: "
+    bundle_hash                  => 'ip',
+    bundle_select                => 'dst',
+    rotate                       => '4',
+  ",
+  resource_props: {
+    'bundle_hash'   => 'ip',
+    'bundle_select' => 'dst',
+    'rotate'        => '4',
+  },
+}
+
 #################################################################
 # HELPER FUNCTIONS
 #################################################################
@@ -271,6 +300,8 @@ test_name "TestCase :: #{testheader}" do
     id = 'default_properties_eth'
   when /n3k|n9k/
     id = 'default_properties_sym'
+  when /n8k/
+    id = 'default_properties_no_hash'
   end
 
   tests[id][:desc] = '1.1 Default Properties'
@@ -317,8 +348,8 @@ test_name "TestCase :: #{testheader}" do
     tests['non_default_properties_eth'][:resource_props]['bundle_hash'] = 'port'
     tests['non_default_properties_eth'][:manifest_props]['dst'] = 'src'
     tests['non_default_properties_eth'][:resource_props]['bundle_select'] = 'src'
-    tests['non_default_properties_eth'][:manifest_props]['CRC10c'] = 'CRC10a'
-    tests['non_default_properties_eth'][:resource_props]['hash_poly'] = 'CRC10a'
+    tests['non_default_properties_eth'][:manifest_props]['CRC10c'] = 'CRC10a' if device == 'n6k'
+    tests['non_default_properties_eth'][:resource_props]['hash_poly'] = 'CRC10a' if device == 'n6k'
     test_harness_portchannel_global(tests, id)
 
     tests[id][:desc] = '2.3 Non Default Properties'
@@ -326,7 +357,8 @@ test_name "TestCase :: #{testheader}" do
     tests['non_default_properties_eth'][:resource_props]['bundle_hash'] = 'port-only'
     tests['non_default_properties_eth'][:manifest_props]['src'] = 'src-dst'
     tests['non_default_properties_eth'][:resource_props]['bundle_select'] = 'src-dst'
-    tests['non_default_properties_eth'][:manifest_props]['CRC10a'] = 'CRC10d'
+    tests['non_default_properties_eth'][:manifest_props]['CRC10a'] = 'CRC10d' if device == 'n6k'
+    tests['non_default_properties_eth'][:manifest_props]['CRC10c'] = 'CRC10d' if device == 'n5k'
     tests['non_default_properties_eth'][:resource_props]['hash_poly'] = 'CRC10d'
     test_harness_portchannel_global(tests, id)
 
@@ -379,6 +411,32 @@ test_name "TestCase :: #{testheader}" do
     tests['non_default_properties_sym'][:resource_props]['bundle_hash'] = 'ip-gre'
     test_harness_portchannel_global(tests, id)
 
+  elsif device == 'n8k'
+    id = 'non_default_properties_no_hash'
+    tests[id][:desc] = '2.1 Non Default Properties'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.2 Non Default Properties'
+    tests['non_default_properties_no_hash'][:manifest_props]['ip'] = 'ip-l4port-vlan'
+    tests['non_default_properties_no_hash'][:resource_props]['bundle_hash'] = 'ip-l4port-vlan'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.3 Non Default Properties'
+    tests['non_default_properties_no_hash'][:manifest_props]['ip-l4port-vlan'] = 'ip-vlan'
+    tests['non_default_properties_no_hash'][:resource_props]['bundle_hash'] = 'ip-vlan'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.4 Non Default Properties'
+    tests['non_default_properties_no_hash'][:manifest_props]['ip-vlan'] = 'l4port'
+    tests['non_default_properties_no_hash'][:resource_props]['bundle_hash'] = 'l4port'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.5 Non Default Properties'
+    tests['non_default_properties_no_hash'][:manifest_props]['l4port'] = 'mac'
+    tests['non_default_properties_no_hash'][:resource_props]['bundle_hash'] = 'mac'
+    tests['non_default_properties_no_hash'][:manifest_props]['dst'] = 'src'
+    tests['non_default_properties_no_hash'][:resource_props]['bundle_select'] = 'src'
+    test_harness_portchannel_global(tests, id)
   end
 
   # no absent test for portchannel_global


### PR DESCRIPTION
This is mainly portchannel_global provider support for n8k. Mike has the complete context of this, it is better if he reviews this. All tests are run on all switches and they all pass (including demo manifests)
1. There are lot of mistakes in the README.md file for this provider and they are corrected.
2. portchannel_global n8k support is added to demo manifest and the actual provider code is added and this utilizes the load_balance_type param from NU (the PR for that is already opened).
3. For n5k, the defaults are different from n6k (in fact they are very different within n5k flavors themsevles) which is causing some issues in the beaker tests. That is corrected.
Please check the comment put by Chris long back in the NU.
https://github.com/cisco/cisco-network-node-utils/blob/develop/lib/cisco_node_utils/portchannel_global.rb#L212