### PR TITLE
Rel/fp

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_tacacs_server_host](#type-cisco_tacacs_server_host) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_vdc](#type-cisco_vdc) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | [cisco_vlan](#type-cisco_vlan) | ✅* | ✅* | ✅* | ✅ | ✅ | ✅ | ✅ | ❌ | * [caveats](#cisco_vlan-caveats) |
-| [cisco_vpc_domain](#type-cisco_vpc_domain) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ❌ | * [caveats](#cisco_vlan-caveats) |
+| [cisco_vpc_domain](#type-cisco_vpc_domain) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ❌ | ❌ | * [caveats](#cisco_vpc_domain-caveats) |
 | [cisco_vrf](#type-cisco_vrf) | ✅ | ✅* | ✅* | ✅ | ✅ | ✅ | ✅ | ✅* | * [caveats](#cisco_vrf-caveats) |
 | [cisco_vrf_af](#type-cisco_vrf_af) | ✅ | ✅* | ✅* | ✅* | ✅* | ✅* | ✅ | ✅* | * [caveats](#cisco_vrf_af-caveats) |
 | [cisco_vtp](#type-cisco_vtp) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |

--- a/README.md
+++ b/README.md
@@ -3466,9 +3466,9 @@ Domain name of the device. Valid value is a string.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | TODO               | TODO                   |
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The following table indicates which providers are supported on each platform. As
 | ✅ = Supported <br> ❌ = Unsupported  | N9k | N30xx | N31xx | N56xx | N6k | N7k | N8k | IOS XR |
 |:---|:---:|:-----:|:-----:|:-----:|:---:|:---:|:---:|:---:|
 | [domain_name](#type-domain_name) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| [name_server](#type-name_server) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| [name_server](#type-name_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [network_dns](#type-network_dns) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | [network_interface](#type-network_interface) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | [network_snmp](#type-network_snmp) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |

--- a/examples/cisco/demo_vpc_plus.pp
+++ b/examples/cisco/demo_vpc_plus.pp
@@ -16,7 +16,7 @@
 
 class ciscopuppet::cisco::demo_vpc_plus {
 
-  if platform_get() =~ /n(5|6|7)k/ {
+  if platform_get() =~ /n7k/ {
     if platform_get() == 'n7k' {
       $fabricpath_multicast_load_balance = true
       $port_channel_limit = false

--- a/examples/cisco/demo_vpc_plus.pp
+++ b/examples/cisco/demo_vpc_plus.pp
@@ -17,6 +17,7 @@
 class ciscopuppet::cisco::demo_vpc_plus {
 
   if platform_get() =~ /n7k/ {
+    # this next block is for future use when n5k and n6k support gets added
     if platform_get() == 'n7k' {
       $fabricpath_multicast_load_balance = true
       $port_channel_limit = false

--- a/lib/puppet/provider/cisco_portchannel_global/cisco.rb
+++ b/lib/puppet/provider/cisco_portchannel_global/cisco.rb
@@ -131,8 +131,11 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
   # port-channel load-balance src-dst ip rotate 4 concatenation symmetric
   # all the above properties will be set all at once so make sure
   # all the needed resources are present
-  def port_channel_load_balance_sym_concat_rot_all?
-    @resource[:bundle_hash] &&
+  def check_port_channel_load_balance_sym_concat_rot_all
+    fail ArgumentError, 'Invalid arguments present in manifest' if
+      @resource[:asymmetric] || @resource[:hash_poly]
+    fail ArgumentError, 'Required arguments not present in manifest' unless
+      @resource[:bundle_hash] &&
       @resource[:bundle_select] &&
       @resource[:concatenation] &&
       @resource[:symmetry] &&
@@ -140,7 +143,7 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
   end
 
   def port_channel_load_balance_sym_concat_rot_set
-    return unless port_channel_load_balance_sym_concat_rot_all?
+    check_port_channel_load_balance_sym_concat_rot_all
     if @property_flush[:bundle_hash]
       bh = @property_flush[:bundle_hash]
     else
@@ -180,14 +183,18 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
   # port-channel load-balance ethernet source-dest-ip CRC10c
   # all the above properties will be set all at once so make sure
   # all the needed resources are present
-  def port_channel_load_balance_hash_poly_all?
-    @resource[:bundle_hash] &&
+  def check_port_channel_load_balance_hash_poly_all
+    fail ArgumentError, 'Invalid arguments present in manifest' if
+      @resource[:asymmetric] || @resource[:concatenation] ||
+      @resource[:rotate] || @resource[:symmetry]
+    fail ArgumentError, 'Required arguments not present in manifest' unless
+      @resource[:bundle_hash] &&
       @resource[:bundle_select] &&
       @resource[:hash_poly]
   end
 
   def port_channel_load_balance_hash_poly_set
-    return unless port_channel_load_balance_hash_poly_all?
+    check_port_channel_load_balance_hash_poly_all
     if @property_flush[:bundle_hash]
       bh = @property_flush[:bundle_hash]
     else
@@ -211,15 +218,19 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
   # port-channel load-balance src-dst ip rotate 4 asymmetric
   # all the above properties will be set all at once so make sure
   # all the needed resources are present
-  def port_channel_load_balance_asym_rot_all?
-    @resource[:bundle_hash] &&
+  def check_port_channel_load_balance_asym_rot_all
+    fail ArgumentError, 'Invalid arguments present in manifest' if
+      @resource[:hash_poly] || @resource[:concatenation] ||
+      @resource[:symmetry]
+    fail ArgumentError, 'Required arguments not present in manifest' unless
+      @resource[:bundle_hash] &&
       @resource[:bundle_select] &&
       @resource[:asymmetric] &&
       @resource[:rotate]
   end
 
   def port_channel_load_balance_asym_rot_set
-    return unless port_channel_load_balance_asym_rot_all?
+    check_port_channel_load_balance_asym_rot_all
     if @property_flush[:bundle_hash]
       bh = @property_flush[:bundle_hash]
     else
@@ -248,14 +259,18 @@ Puppet::Type.type(:cisco_portchannel_global).provide(:cisco) do
   # port-channel load-balance src-dst ip rotate 4
   # all the above properties will be set all at once so make sure
   # all the needed resources are present
-  def port_channel_load_balance_no_hash_all?
-    @resource[:bundle_hash] &&
+  def check_port_channel_load_balance_no_hash_all
+    fail ArgumentError, 'Invalid arguments present in manifest' if
+      @resource[:hash_poly] || @resource[:concatenation] ||
+      @resource[:symmetry] || @resource[:asymmetric]
+    fail ArgumentError, 'Required arguments not present in manifest' unless
+      @resource[:bundle_hash] &&
       @resource[:bundle_select] &&
       @resource[:rotate]
   end
 
   def port_channel_load_balance_no_hash_set
-    return unless port_channel_load_balance_no_hash_all?
+    check_port_channel_load_balance_no_hash_all
     if @property_flush[:bundle_hash]
       bh = @property_flush[:bundle_hash]
     else

--- a/lib/puppet/provider/cisco_vpc_domain/cisco.rb
+++ b/lib/puppet/provider/cisco_vpc_domain/cisco.rb
@@ -51,22 +51,26 @@ Puppet::Type.type(:cisco_vpc_domain).provide(:cisco) do
     :system_mac,
     :system_priority,
   ]
-  VPC_BOOL_PROPS = [
+  VPC_BOOL_PROPS1 = [
     :auto_recovery,
+    :peer_gateway,
+  ]
+  VPC_BOOL_PROPS2 = [
     :fabricpath_multicast_load_balance,
     :graceful_consistency_check,
     :layer3_peer_routing,
-    :peer_gateway,
     :port_channel_limit,
     :self_isolation,
     :shutdown,
   ]
-  VPC_PROPS = VPC_NON_BOOL_PROPS + VPC_BOOL_PROPS
+  VPC_PROPS = VPC_BOOL_PROPS1 + VPC_NON_BOOL_PROPS + VPC_BOOL_PROPS2
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@vpc_domain',
                                             VPC_NON_BOOL_PROPS)
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@vpc_domain',
-                                            VPC_BOOL_PROPS)
+                                            VPC_BOOL_PROPS1)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@vpc_domain',
+                                            VPC_BOOL_PROPS2)
 
   def initialize(value={})
     super(value)

--- a/lib/puppet/provider/cisco_vpc_domain/cisco.rb
+++ b/lib/puppet/provider/cisco_vpc_domain/cisco.rb
@@ -51,15 +51,12 @@ Puppet::Type.type(:cisco_vpc_domain).provide(:cisco) do
     :system_mac,
     :system_priority,
   ]
-  # auto_recovery and peer_gateway need to be set before non_boolean
-  # properties like auto_recovery_reload_delay and peer_gateway_exclude_vlan
-  # so making it into a new array
+  # There are multiple BOOL arrays due to dependency requirements. The order of
+  # these property arrays is important for proper processing by properties_set.
   VPC_BOOL_PROPS1 = [
     :auto_recovery,
     :peer_gateway,
   ]
-  # these properties like port_channel_limit need to be set after non_boolean
-  # properties like fabricpath_emulated_switch_id
   VPC_BOOL_PROPS2 = [
     :fabricpath_multicast_load_balance,
     :graceful_consistency_check,
@@ -68,9 +65,6 @@ Puppet::Type.type(:cisco_vpc_domain).provide(:cisco) do
     :self_isolation,
     :shutdown,
   ]
-  # set the boolean properties which need to be set first and then the
-  # non_boolean properties and finally the rest of the boolean
-  # properties to maintain correct order.
   VPC_PROPS = VPC_BOOL_PROPS1 + VPC_NON_BOOL_PROPS + VPC_BOOL_PROPS2
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@vpc_domain',

--- a/lib/puppet/provider/cisco_vpc_domain/cisco.rb
+++ b/lib/puppet/provider/cisco_vpc_domain/cisco.rb
@@ -51,10 +51,15 @@ Puppet::Type.type(:cisco_vpc_domain).provide(:cisco) do
     :system_mac,
     :system_priority,
   ]
+  # auto_recovery and peer_gateway need to be set before non_boolean
+  # properties like auto_recovery_reload_delay and peer_gateway_exclude_vlan
+  # so making it into a new array
   VPC_BOOL_PROPS1 = [
     :auto_recovery,
     :peer_gateway,
   ]
+  # these properties like port_channel_limit need to be set after non_boolean
+  # properties like fabricpath_emulated_switch_id
   VPC_BOOL_PROPS2 = [
     :fabricpath_multicast_load_balance,
     :graceful_consistency_check,
@@ -63,6 +68,9 @@ Puppet::Type.type(:cisco_vpc_domain).provide(:cisco) do
     :self_isolation,
     :shutdown,
   ]
+  # set the boolean properties which need to be set first and then the
+  # non_boolean properties and finally the rest of the boolean
+  # properties to maintain correct order.
   VPC_PROPS = VPC_BOOL_PROPS1 + VPC_NON_BOOL_PROPS + VPC_BOOL_PROPS2
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@vpc_domain',


### PR DESCRIPTION
This is for vpc, name_server of netdev (and portchannel_global changes requested by Mike) 
1. README.md changed to remove vpc support for n8k (and add support for netdev)
2. demo_vpc_plus.pp has now only n7k support. Deepak said there is no support for n5k or n6k for vpc plus. (The demo_manitests are failing for attrubutes which are excluded in the NU but not in manifest fir n5/6k). The platform check is left in regex format and also another platform check for n7k vs others are left as they were, as requested by Deepak, because once the support for n5/6k is in, all we need to change a single line of manifest.
3. The order of set attributes is causing issues and 2 variables are getting overwritten and this is fixed now in the provider file. Basically, auto_recovery, peer_gateway need to be set first before any non-bool variables. The other bool variables have to be set after the non-bool variables.
4. For portchannel_global, "fail arg" cases are added to ensure that if wrong type of arguments are present or required arguments are absent in the manifest, the sets will not go through.