### PR TITLE
test_interface_service_vni: platform cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2033,7 +2033,7 @@ Manages a Cisco Network Interface Service VNI.
 | N56xx    | unsupported        | unsupported            |
 | N6k      | unsupported        | unsupported            |
 | N7k      | 7.3(0)D1(1)        | 1.2.0                  |
-| N8k      | 7.0(3)F1(1)        | 1.3.0                  |
+| N8k      | unsupported        | unsupported            |
 | IOS XR   | unsupported        | unsupported            |
 
 #### Parameters

--- a/examples/cisco/demo_encapsulation.pp
+++ b/examples/cisco/demo_encapsulation.pp
@@ -5,7 +5,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -15,8 +15,12 @@
 # limitations under the License.
 
 class ciscopuppet::cisco::demo_encapsulation {
-  cisco_encapsulation {"PepsiCo" :
-    ensure          => present,
-    dot1q_map       => ['101-150,151, 201-250', '9000, 5102-5150,6000,7000-7050'],
+  if platform_get() =~ /n7k/ {
+    cisco_encapsulation {"test_encap" :
+      ensure          => present,
+      dot1q_map       => ['101-102,151, 201-202', '5101-5104,5202'],
+    }
+  } else {
+     notify{'SKIP: This platform does not support cisco_encapsulation': }
   }
 }

--- a/examples/cisco/demo_interface_service_vni.pp
+++ b/examples/cisco/demo_interface_service_vni.pp
@@ -15,12 +15,27 @@
 # limitations under the License.
 
 class ciscopuppet::cisco::demo_interface_service_vni {
-  cisco_interface_service_vni { 'Ethernet9/2 344' :
-    encapsulation_profile_vni   => 'vni_500_5000',
-    shutdown                    => true,
-  }
-  cisco_interface_service_vni { 'Ethernet9/2 491' :
-    encapsulation_profile_vni   => 'vni_600_6000',
-    shutdown                    => 'default',
+
+  if platform_get() =~ /n7k/ {
+
+    cisco_encapsulation {"vni_500_5000" :
+      ensure          => present,
+      dot1q_map       => ['500', '5000'],
+    }
+    cisco_interface_service_vni { 'Ethernet9/2 344' :
+      encapsulation_profile_vni   => 'vni_500_5000',
+      shutdown                    => true,
+    }
+
+    cisco_encapsulation {"vni_600_6000" :
+      ensure          => present,
+      dot1q_map       => ['600', '6000'],
+    }
+    cisco_interface_service_vni { 'Ethernet9/2 491' :
+      encapsulation_profile_vni   => 'vni_600_6000',
+      shutdown                    => 'default',
+    }
+  } else {
+     notify{'SKIP: This platform does not support cisco_interface_service_vni': }
   }
 }

--- a/examples/cisco/demo_interface_service_vni.pp
+++ b/examples/cisco/demo_interface_service_vni.pp
@@ -17,25 +17,32 @@
 class ciscopuppet::cisco::demo_interface_service_vni {
 
   if platform_get() =~ /n7k/ {
+    $slot = find_linecard('N7K-F3')
+    if $slot == '' {
+      notify{'## SKIP: This provider demo requires an N7K-F3 linecard': }
 
-    cisco_encapsulation {"vni_500_5000" :
-      ensure          => present,
-      dot1q_map       => ['500', '5000'],
-    }
-    cisco_interface_service_vni { 'Ethernet9/2 344' :
-      encapsulation_profile_vni   => 'vni_500_5000',
-      shutdown                    => true,
-    }
+    } else {
+      $intf = "ethernet$slot/2"
 
-    cisco_encapsulation {"vni_600_6000" :
-      ensure          => present,
-      dot1q_map       => ['600', '6000'],
-    }
-    cisco_interface_service_vni { 'Ethernet9/2 491' :
-      encapsulation_profile_vni   => 'vni_600_6000',
-      shutdown                    => 'default',
+      cisco_encapsulation {"vni_500_5000" :
+        ensure          => present,
+        dot1q_map       => ['500', '5000'],
+      }
+      cisco_interface_service_vni { "$intf 344" :
+        encapsulation_profile_vni   => 'vni_500_5000',
+        shutdown                    => true,
+      }
+
+      cisco_encapsulation {"vni_600_6000" :
+        ensure          => present,
+        dot1q_map       => ['600', '6000'],
+      }
+      cisco_interface_service_vni { "$intf 491" :
+        encapsulation_profile_vni   => 'vni_600_6000',
+        shutdown                    => 'default',
+      }
     }
   } else {
-     notify{'SKIP: This platform does not support cisco_interface_service_vni': }
+     notify{'## SKIP: This platform does not support cisco_interface_service_vni': }
   }
 }

--- a/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
+++ b/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
@@ -13,97 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
-# TestCase Name:
-# -------------
-# test_interface_service_vni.rb
 #
-# TestCase Prerequisites:
-# -----------------------
-# This is a Puppet Interface resource testcase of vlan_mapping properties,
-# for use with Puppet Agent on Nexus devices.
-# The test case assumes the following prerequisites are already satisfied:
-#   - Host configuration file contains agent and master information.
-#   - SSH is enabled on the N9K Agent.
-#   - Puppet master/server is started.
-#   - Puppet agent certificate has been signed on the Puppet master/server.
-#
-###############################################################################
-#
-#        ****************************************
-#        ** IMPORTANT ADDITIONAL PREREQUISITES **
-#        ****************************************
-#
-# The interface service vni provider has additional prerequisites.
-#
-#  - VDC support
-#  - F3 linecard
-#  - N7 platforms only
-#
-# This test will need to be updated as the product matures.
-#
-###############################################################################
-#
-# TestCase:
-# ---------
-# This resource test verifies default values for all properties.
-#
-# The following exit_codes are validated for Puppet, Vegas shell and
-# Bash shell commands.
-#
-# Vegas and Bash Shell Commands:
-# 0   - successful command execution
-# > 0 - failed command execution.
-#
-# Puppet Commands:
-# 0 - no changes have occurred
-# 1 - errors have occurred,
-# 2 - changes have occurred
-# 4 - failures have occurred and
-# 6 - changes and failures have occurred.
-#
-# NOTE: 0 is the default exit_code checked in Beaker::DSL::Helpers::on() method.
-#
-# The test cases use RegExp pattern matching on stdout or output IO
-# instance attributes to verify resource properties.
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
 #
 ###############################################################################
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
-# -----------------------------
-# Common settings and variables
-# -----------------------------
-testheader = 'Resource cisco_interface_service_vni'
-
-# The 'tests' hash is used to define all of the test data values and expected
-# results. It is also used to pass optional flags to the test methods when
-# necessary.
-
-# 'tests' hash
-# Top-level keys set by caller:
-# tests[:master] - the master object
-# tests[:agent] - the agent object
-# tests[:encap_prof_global] - the encap profile vni global configuration
-#
+# Test hash top-level keys
 tests = {
-  master:            master,
-  agent:             agent,
-  resource_name:     'cisco_interface_service_vni',
-  sid:               22,
-  encap_prof_global: 'encapsulation profile vni vni_500_5000 ; '\
-                     'dot1q 500 vni 5000',
+  agent:            agent,
+  master:           master,
+  operating_system: 'nexus',
+  platform:         'n7k',
+  resource_name:    'cisco_interface_service_vni',
+  sid:              22,
 }
 
-# tests[id] keys set by caller and used by test_harness_common:
-#
-# tests[id] keys set by caller:
-# tests[id][:desc] - a string to use with logs & debugs
-# tests[id][:manifest] - the complete manifest, as used by test_harness_common
-# tests[id][:resource] - a hash of expected states, used by test_resource
-# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:ensure] - (Optional) set to :present or :absent before calling
-# tests[id][:code] - (Optional) override the default exit code in some tests.
-#
-tests['default_properties'] = {
+# Test hash test cases
+tests[:default] = {
   desc:           '1.1 Default Properties',
   manifest_props: {
     encapsulation_profile_vni: 'default',
@@ -115,70 +46,56 @@ tests['default_properties'] = {
   },
 }
 
-tests['non_default_properties'] = {
+tests[:non_default] = {
   desc:           '2.1 Non Default Properties',
   manifest_props: {
     encapsulation_profile_vni: 'vni_500_5000',
     shutdown:                  'false',
   },
-  resource:       {
-    'encapsulation_profile_vni' => 'vni_500_5000',
-    'shutdown'                  => 'false',
-  },
 }
 
-#################################################################
-# HELPER FUNCTIONS
-#################################################################
+# TEST PRE-REQUISITES
+#   - F3 linecard assigned to admin vdc
+#   - Global encap profile vni config
+def dependency_manifest(*)
+  "
+    cisco_vdc { '#{default_vdc_name}':
+      ensure                     => present,
+      limit_resource_module_type => 'f3',
+    }
 
-def build_manifest_interface_service_vni(tests, id)
-  intf = tests[:intf]
-  sid = tests[:sid]
-  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-  node default {
-    cisco_interface_service_vni { '#{intf} #{sid}':
-    \n#{prop_hash_to_manifest(tests[id][:manifest_props])}
-    }\n  }\nEOF"
-
-  cmd = PUPPET_BINPATH + "resource cisco_interface_service_vni '#{intf} #{sid}'"
-  tests[id][:resource_cmd] =
-    get_namespace_cmd(agent, cmd, options)
-end
-
-def test_harness_interface_service_vni(tests, id)
-  tests[id][:ensure] = :present if tests[id][:ensure].nil?
-
-  # Build the manifest for this test
-  build_manifest_interface_service_vni(tests, id)
-
-  # Workaround for (ioctl) facter bug on n7k ***
-  tests[id][:code] = [0, 2] if platform[/n7k/]
-
-  test_harness_common(tests, id)
-  tests[id][:ensure] = nil
+    cisco_encapsulation { 'vni_500_5000':
+      dot1q_map => #{Array['500', '5000']}
+    }
+  "
 end
 
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
-test_name "TestCase :: #{testheader}" do
-  # -------------------------------------------------------------------
-  logger.info("\n#{'-' * 60}\nSection 0. Testbed Initialization")
-  # -------------------------------------------------------------------
-  setup_mt_full_env(tests, self)
+test_name "TestCase :: #{tests[:resource_name]}" do
+  skip_unless_supported(tests)
+  if (intf = mt_full_interface).nil?
+    prereq_skip(nil, self,
+                'MT-full tests require F3 or compatible line module')
+  end
 
-  # -----------------------------------
+  # Clean up any stale pre-req configs that might conflict with our test
+  resource_absent_cleanup(agent, 'cisco_encapsulation')
+
+  # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  id = 'default_properties'
-  test_harness_interface_service_vni(tests, id)
+
+  id = :default
+  tests[id][:title_pattern] = "#{intf} #{tests[:sid]}"
+  test_harness_run(tests, id)
 
   tests[id][:ensure] = :absent
-  test_harness_interface_service_vni(tests, id)
-  tests[id][:ensure] = :present
+  tests[id].delete(:preclean)
+  test_harness_run(tests, id)
 
-  # -------------------------------------------------------------------
-  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_interface_service_vni(tests, 'non_default_properties')
+  # -----------------------------------
+  resource_absent_cleanup(agent, 'cisco_interface_service_vni')
+  resource_absent_cleanup(agent, 'cisco_encapsulation')
 end
-
-logger.info("TestCase :: #{testheader} :: End")
+logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
* Fixes for interface_service_vni and encapsulation

* Add 'default' support to encapsulation and fixed idempotence issues

* Add pre-reqs and skips to demo manifests and beaker tests

* Reformatted beaker tests to use latest syntax

* Tested on n7k, all other platforms are skipped