### PR TITLE
netdev vlan fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Extended the following providers to support `Nexus 56xx`, `Nexus 60xx`, and `Nexus 7xxx`
   - `cisco_aaa_authentication_login`, `cisco_aaa_authorization_login_cfg_svc`, `cisco_aaa_authorization_login_exec_svc`, `cisco_aaa_group_tacacs`
-  - `cisco_vtp`, `domain_name`, `name_server`
+  - `cisco_vtp`, `domain_name`, `name_server`, `network_vlan`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`
   - `reconnect_interval`

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following table indicates which providers are supported on each platform. As
 | [network_interface](#type-network_interface) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | [network_snmp](#type-network_snmp) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [network_trunk](#type-network_trunk) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| [network_vlan](#type-network_vlan) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [ntp_config](#type-ntp_config) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [ntp_server](#type-ntp_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [radius](#type-radius) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
@@ -314,6 +315,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_vlan`](#type-cisco_vlan)
   * [`cisco_vtp`](#type-cisco_vtp)
   * [`network_trunk (netdev_stdlib)`](#type-network_trunk)
+  * [`network_vlan (netdev_stdlib)`](#type-network_vlan)
 
 * VPC Types
   * [`cisco_vpc_domain`](#type-cisco_vpc_domain)
@@ -391,8 +393,9 @@ The following resources include cisco types and providers along with cisco provi
 * [`name_server`](#type-name_server)
 * [`network_dns`](#type-network_dns)
 * [`network_interface`](#type-network_interface)
-* [`network_trunk`](#type-network_trunk)
 * [`network_snmp`](#type-network_snmp)
+* [`network_trunk`](#type-network_trunk)
+* [`network_vlan`](#type-network_vlan)
 * [`ntp_config`](#type-ntp_config)
 * [`ntp_server`](#type-ntp_server)
 * [`port_channel`](#type-port_channel)
@@ -3613,6 +3616,36 @@ Array of VLAN names used for tagged packets. Values must be in range of 1 to 409
 
 ###### `pruned_vlans`
 Array of VLAN ID numbers used for VLAN pruning. Values must be in range of 1 to 4095. Cisco do not implement the concept of pruned vlans.
+
+--
+### Type: `network_vlan`
+
+Manages a puppet netdev_stdlib Network Vlan.
+
+| Platform | OS Minimum Version | Module Minimum Version |
+|----------|:------------------:|:----------------------:|
+| N9k      | 7.0(3)I2(1)        | 1.2.0                  |
+| N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
+| N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
+| N8k      | 7.0(3)F1(1)        | 1.3.0                  |
+| IOS XR   | unsupported        | unsupported            |
+
+#### Parameters
+
+##### `ensure`
+Determines whether or not the config should be present on the device. Valid values are 'present' and 'absent'.
+
+###### `id`
+ID of the Virtual LAN. Valid value is a string.
+
+###### `shutdown`
+Whether or not the vlan is shutdown. Valid values are 'true' or 'false'.
+
+###### `vlan_name`
+The name of the VLAN.  Valid value is a string.
 
 --
 ### Type: ntp_config

--- a/examples/demo_all_netdev.pp
+++ b/examples/demo_all_netdev.pp
@@ -30,6 +30,7 @@ class ciscopuppet::demo_all_netdev {
   include ciscopuppet::netdev::demo_interface
   include ciscopuppet::netdev::demo_port_channel
   include ciscopuppet::netdev::demo_network_trunk
+  include ciscopuppet::netdev::demo_network_vlan
   include ciscopuppet::netdev::demo_ntp
   include ciscopuppet::netdev::demo_radius
   include ciscopuppet::netdev::demo_snmp

--- a/examples/netdev/demo_network_vlan.pp
+++ b/examples/netdev/demo_network_vlan.pp
@@ -1,0 +1,23 @@
+# Manifest to demo cisco_interface provider
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::netdev::demo_network_vlan {
+  network_vlan { '128':
+    ensure        => 'present',
+    vlan_name     => 'netdev_vlan',
+    shutdown      => false,
+  } 
+}

--- a/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
@@ -136,6 +136,13 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check network_vlan resource on agent :: #{result}")
   end
 
+  step 'TestStep :: Cleanup' do
+    resource_absent_cleanup(agent, 'network_vlan',
+                            'Cleanup switch after network_vlan provider test')
+
+    logger.info("Cleanup switch after provider test :: #{result}")
+  end
+
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)
 end

--- a/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/network_vlan_provider_nondefaults.rb
@@ -62,17 +62,9 @@ testheader = 'network_vlan Resource :: All Attributes NonDefaults'
 test_name "TestCase :: #{testheader}" do
   ## @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    cmd_str = get_vshell_cmd('conf t ; no vlan 666')
-    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+    resource_absent_cleanup(agent, 'network_vlan',
+                            'Setup switch for network_vlan provider test')
 
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, [/vlan (\d+,)*666\D/],
-                               true, self, logger)
-    end
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -110,24 +102,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check network_vlan resource on agent :: #{result}")
   end
 
-  # @step [Step] Checks network_vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check network_vlan settings on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config vlan')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [
-                                 /vlan (\d+,)*666\D/,
-                                 /vlan 666/,
-                                 /  name somename/,
-                               ],
-                               false, self, logger)
-    end
-
-    logger.info("Check network_vlan resource on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Set the properties in a manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -156,25 +130,6 @@ test_name "TestCase :: #{testheader}" do
                                { 'ensure'    => 'present',
                                  'shutdown'  => 'true',
                                  'vlan_name' => 'othername' },
-                               false, self, logger)
-    end
-
-    logger.info("Check network_vlan resource on agent :: #{result}")
-  end
-
-  # @step [Step] Checks network_vlan instance on agent using switch show cli cmds.
-  step 'TestStep :: Check network_vlan settings on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [
-                                 /vlan (\d+,)*666\D/,
-                                 /vlan 666/,
-                                 /  name othername/,
-                                 /  shutdown/,
-                               ],
                                false, self, logger)
     end
 


### PR DESCRIPTION
- Doc Updates
- Removal of vsh commands in beaker tests.

**Beaker/Manifest Tests Pass On:** n3k, n5k, n6k, n7k, n8k, n9k (I2 and I3)