### PR TITLE
Add interface_capabilities helper

### DIFF
--- a/lib/puppet/provider/cisco_interface_capabilities/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_capabilities/cisco.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:cisco_interface_capabilities).provide(:cisco) do
   def self.instances
     interfaces = []
     Cisco::Interface.interfaces.each do |intf, _|
-      next if intf.match(/mgmt/i)
+      next unless intf.match(/ethernet/i)
       current = { name: intf }
       interfaces << new(current)
     end

--- a/lib/puppet/provider/cisco_interface_capabilities/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_capabilities/cisco.rb
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# April 2016, Chris Van Heuveln
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########################################################################
+#
+# Please note: This provider is a helper utility for test purposes only.
+#
+#########################################################################
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_interface_capabilities).provide(:cisco) do
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: [:ios_xr, :nexus]
+
+  def self.instances
+    interfaces = []
+    Cisco::Interface.interfaces.each do |intf, _|
+      next if intf.match(/mgmt/i)
+      current = { name: intf }
+      interfaces << new(current)
+    end
+    interfaces
+  end
+
+  def capabilities
+    Cisco::Interface.capabilities(@resource[:name], :raw)
+  end
+end

--- a/lib/puppet/type/cisco_interface_capabilities.rb
+++ b/lib/puppet/type/cisco_interface_capabilities.rb
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# April 2016, Chris Van Heuveln
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#########################################################################
+#
+# Please note: This resource is a helper utility for test purposes only.
+#
+#########################################################################
+
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
+
+Puppet::Type.newtype(:cisco_interface_capabilities) do
+  @doc = 'Interface capabilities utility. This is a test-only resource.'
+
+  newparam(:name, namevar: :true) do
+    munge(&:downcase)
+  end
+
+  newproperty(:capabilities) do
+    desc 'This is a getter-only property used by the test facility to '\
+         'determine interface capabilities.'
+  end
+end

--- a/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
@@ -1,0 +1,74 @@
+###############################################################################
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
+#
+###############################################################################
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Test hash top-level keys
+tests = {
+  agent:            agent,
+  master:           master,
+  intf_type:        'ethernet',
+  operating_system: 'nexus',
+  resource_name:    'cisco_interface_capabilities',
+}
+
+def parse_capabilities(agent, cmd)
+  on(agent, cmd)
+  caps = {}
+  caps['Speed'] = Regexp.last_match[1] if stdout[/Speed:\s+([\d,]+)/]
+  caps['Duplex'] = Regexp.last_match[1] if stdout[/Duplex:\s+([\w,-]+)/]
+  logger.debug("\ncapabilities hash: #{caps}")
+  caps
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{tests[:resource_name]}" do
+  skip_unless_supported(tests)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\n1.1 Test puppet resource vs vsh results")
+
+  intf = find_interface(tests)
+
+  vsh_cmd = get_vshell_cmd("show interface #{intf} capabilities")
+  vsh_caps = parse_capabilities(agent, vsh_cmd)
+
+  resource_cmd = get_namespace_cmd(agent, PUPPET_BINPATH +
+                   "resource cisco_interface_capabilities '#{intf}'", options)
+  resource_caps = parse_capabilities(agent, resource_cmd)
+
+  testcase.fail_test('puppet resource mismatch with vsh :: FAIL') unless
+    vsh_caps == resource_caps
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\n1.2 Test with utilitylib helper results")
+  util_caps = interface_capabilities(agent, intf)
+
+  vsh_caps.keys.each do |k|
+    next if vsh_caps[k] == util_caps[k]
+    testcase.fail_test('utilitylib helper results mismatch with vsh')
+  end
+end
+logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
* New Type, Provider, and beaker utility; for use with interface testing.
* Tested mainly on n7k.
* Considered using facter for this but the overhead in processing time was more than desired and I didn't want to penalize every single puppet run; therefore it made more sense to make this an on-demand utility since it's only going to be used by beaker.
* Manual test:

```
    cap = interface_capabilities(agent, 'ethernet9/1')
    puts 'Speed: ' + cap['Speed']
    puts 'Duplex: ' + cap['Duplex']
```

Result:

```
Speed: 10000,40000
Duplex: full
```