### PR TITLE
Snmp netdev provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Extended the following providers to support `Nexus 56xx`, `Nexus 60xx`, and `Nexus 7xxx`
   - `cisco_aaa_authentication_login`, `cisco_aaa_authorization_login_cfg_svc`, `cisco_aaa_authorization_login_exec_svc`, `cisco_aaa_group_tacacs`, `cisco_fabricpath_global`, `cisco_fabricpath_topology`, `cisco_interface_channel_group`, `cisco_interface_portchannel`, `cisco_portchannel_global`, `cisco_snmp_community`, `cisco_snmp_group`, `cisco_snmp_server`, `cisco_snmp_user`, `cisco_vpc_domain`, `cisco_vtp`
-  - `domain_name`, `name_server`, `network_snmp`, `network_vlan`, `ntp_config`, `ntp_server`, `radius`, `radius_global`, `radius_server`, `radius_server_group`, `search_domain`, `snmp_community`, `snmp_notification`, `snmp_notification_receiver`, `snmp_user`, `tacacs`, `tacacs_global`
+  - `domain_name`, `name_server`, `network_snmp`, `network_vlan`, `ntp_config`, `ntp_server`, `port_channel`, `radius`, `radius_global`, `radius_server`, `radius_server_group`, `search_domain`, `snmp_community`, `snmp_notification`, `snmp_notification_receiver`, `snmp_user`, `tacacs`, `tacacs_global`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`
   - `reconnect_interval`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Extended the following providers to support `Nexus 56xx`, `Nexus 60xx`, and `Nexus 7xxx`
-  - `cisco_aaa_authentication_login`, `cisco_aaa_authorization_login_cfg_svc`, `cisco_aaa_authorization_login_exec_svc`, `cisco_aaa_group_tacacs`
-  - `cisco_vtp`, `domain_name`, `name_server`, `network_vlan`, `radius`, `radius_global`, `radius_server`, `radius_server_group`, `tacacs`, `tacacs_global`
+  - `cisco_aaa_authentication_login`, `cisco_aaa_authorization_login_cfg_svc`, `cisco_aaa_authorization_login_exec_svc`, `cisco_aaa_group_tacacs`, `cisco_fabricpath_global`, `cisco_fabricpath_topology`, `cisco_interface_channel_group`, `cisco_interface_portchannel`, `cisco_portchannel_global`, `cisco_snmp_community`, `cisco_snmp_group`, `cisco_snmp_server`, `cisco_snmp_user`, `cisco_vpc_domain`, `cisco_vtp`
+  - `domain_name`, `name_server`, `network_snmp`, `network_vlan`, `ntp_config`, `ntp_server`, `radius`, `radius_global`, `radius_server`, `radius_server_group`, `search_domain`, `snmp_community`, `snmp_notification`, `snmp_notification_receiver`, `snmp_user`, `tacacs`, `tacacs_global`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`
   - `reconnect_interval`

--- a/README.md
+++ b/README.md
@@ -3931,7 +3931,7 @@ values are true and false.
 --
 ### Type: snmp_notification_receiver
 
-Manages an SNMP user on an cisco SNMP server.
+Manages an SNMP notification receiver on an cisco SNMP server.
 
 | Platform | OS Minimum Version | Module Minimum Version |
 |----------|:------------------:|:----------------------:|

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ The following table indicates which providers are supported on each platform. As
 | [radius_server_group](#type-tacacs_server_group) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [radius_server](#type-radius_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅* | * [caveats](#radius_server-caveats) |
 | [search_domain](#type-search_domain) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| [snmp_community](#type-snmp_community) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [snmp_notification](#type-snmp_notification) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [snmp_notification_receiver](#type-snmp_notification_receiver) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [snmp_user](#type-snmp_user) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| [snmp_community](#type-snmp_community) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| [snmp_notification](#type-snmp_notification) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| [snmp_notification_receiver](#type-snmp_notification_receiver) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| [snmp_user](#type-snmp_user) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [syslog_server](#type-syslog_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [syslog_setting](#type-syslog_setting) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [tacacs](#type-tacacs) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -3885,9 +3885,9 @@ Manages an SNMP community on a Cisco SNMP server.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -3915,9 +3915,9 @@ Manages an SNMP notification on a Cisco SNMP server.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -3937,9 +3937,9 @@ Manages an SNMP user on an cisco SNMP server.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -3983,9 +3983,9 @@ Manages an SNMP user on an cisco SNMP server.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The following table indicates which providers are supported on each platform. As
 | [network_vlan](#type-network_vlan) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [ntp_config](#type-ntp_config) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [ntp_server](#type-ntp_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [port_channel](#type-port_channel) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [radius](#type-radius) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [radius_global](#type-radius_global) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [radius_server_group](#type-tacacs_server_group) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -3703,9 +3704,9 @@ Hostname or IPv4/IPv6 address of the NTP server.  Valid value is a string.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 

--- a/lib/puppet/provider/snmp_notification/cisco.rb
+++ b/lib/puppet/provider/snmp_notification/cisco.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:snmp_notification).provide(:cisco) do
     Cisco::SnmpNotification.notifications.each do |name, v|
       snmpnotification << new(
         name:   name,
-        enable: v.enable,
+        enable: v.enable.to_s,
       )
     end
     snmpnotification
@@ -46,13 +46,12 @@ Puppet::Type.type(:snmp_notification).provide(:cisco) do
     snmpnotification = instances
 
     resources.keys.each do |id|
-      provider = snmpnotification.find { |instance| instance.name == id }
+      provider = snmpnotification.find do |instance|
+        instance.name == resources[id][:name] &&
+        instance.enable.to_s == resources[id][:enable].to_s
+      end
       resources[id].provider = provider unless provider.nil?
     end
-  end
-
-  def exists?
-    true
   end
 
   def flush

--- a/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
@@ -82,20 +82,24 @@ test_name "TestCase :: #{testheader}" do
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
       'agent -t', options)
-    on(agent, cmd_str, acceptable_exit_codes: [2])
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd("sh run snmp all | include \"snmp-server enable traps\"")
+    logger.info("Setup switch for provider test :: #{result}")
+  end
+
+  # @step [Step] Checks snmp_notification resource on agent using resource cmd.
+  step 'TestStep :: Check snmp_notification resource absent on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = get_namespace_cmd(agent, PUPPET_BINPATH +
+      "resource snmp_notification 'aaa server-state-change'", options)
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
-                               [
-                                 /no snmp-server enable traps aaa server-state-change/
-                               ],
+                               { 'enable' => 'false' },
                                false, self, logger)
     end
 
-    logger.info("Setup switch for provider test :: #{result}")
+    logger.info("Check snmp_notification resource absent on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -124,21 +128,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check snmp_notification resource presence on agent :: #{result}")
-  end
-
-  step 'TestStep :: Check snmp_notification instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd("sh run snmp all | include \"snmp-server enable traps\"")
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [
-                                 /snmp-server enable traps aaa server-state-change/
-                               ],
-                               false, self, logger)
-    end
-
-    logger.info("Check snmp_notification instance presence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.


### PR DESCRIPTION
This PR is mainly for snmp netdev and port_channel netdev provider support for n5/6/7k.
1. Changed CHANGELOG.md file (including the changes which were not made for the other providers owned by me).
2. README.md file changes for the n5/6/7k support.
3. snmp_notification provider code changed because of idempotent issue (Thanks a lot Mike for your help!)
4. get_vshell_cmd for show cmd is replaced with puppet resource in the snmp_notification beaker tests because the show commands with piping (for ex: "sh run snmp all | include \"snmp-server enable traps\"") do not work on OAC as the dohost cmd on the OAC simply returns no data for them.