### PR TITLE
portchannel_global support for n3k native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `stp_bpdufilter`, `stp_bpduguard`, `stp_cost`, `stp_guard`, `stp_link_type`, `stp_mst_cost`
   - `stp_mst_port_priority`, `stp_port_priority`, `stp_port_type`, `stp_vlan_cost`, `stp_vlan_port_priority`
   - `modify switchport_trunk_allowed_vlan to use range_summarize() which takes care of idempotency issues with vlan ranges`
+- Extended `cisco_portchannel_global` provider to support `Nexus 3xxx`
 - Extended `cisco_vlan` with the following attributes:
   - `mode`
 - Extended `cisco_vpc_domain` with the following attributes:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_pim](#type-cisco_pim) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_pim_rp_address](#type-cisco_pim_rp_address) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_pim_grouplist](#type-cisco_pim_grouplist) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| [cisco_portchannel_global](#type-cisco_portchannel_global) | ✅* | ❌* | ❌* | ✅* | ✅* | ✅* | ✅* | ❌ | * [caveats](#cisco_portchannel_global-caveats) |
+| [cisco_portchannel_global](#type-cisco_portchannel_global) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ❌ | * [caveats](#cisco_portchannel_global-caveats) |
 | [cisco_stp_global](#type-cisco_stp_global) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅ | ✅ | ❌ | * [caveats](#cisco_stp_global-caveats) |
 | [cisco_snmp_community](#type-cisco_snmp_community) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [cisco_snmp_group](#type-cisco_snmp_group) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -2567,8 +2567,8 @@ Manages configuration of a portchannel global parameters
 | Platform | OS Minimum Version | Module Minimum Version |
 |----------|:------------------:|:----------------------:|
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
-| N30xx    | unsupported        | unsupported            |
-| N31xx    | unsupported        | unsupported            |
+| N30xx    | 7.0(3)I2(1)        | 1.3.0                  |
+| N31xx    | 7.0(3)I2(1)        | 1.3.0                  |
 | N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
 | N6k      | 7.3(0)N1(1)        | 1.3.0                  |
 | N7k      | 7.3(0)D1(1)        | 1.2.0                  |
@@ -2581,9 +2581,10 @@ Manages configuration of a portchannel global parameters
 |:--------|:-------------|
 | `hash_poly` | Supported only on N56xx, N6k |
 | `asymmetric` <br> `hash_distribution` <br> `load_defer` | Supported only on N7k |
-| `concatenation` <br> `resilient` <br> `symmetry`| Supported only on N9k|
+| `concatenation` | Supported only on N9k|
+| `resilient` <br> `symmetry` | Supported only on N30xx, N31xx, N9k |
 | `rotate` | Supported only on N7k, N8k, N9k |
-| `bundle_hash` | 'port', 'ip-only', 'port-only' are only supported on N56xx, N6k. 'ip-gre' is only supported on N9k. 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k. |
+| `bundle_hash` | 'port', 'ip-only', 'port-only' are only supported on N30xx, N31xx, N56xx, N6k. 'ip-gre' is only supported on N30xx, N31xx, N9k. 'ip-l4port', 'ip-l4port-vlan', 'ip-vlan', 'l4port' are only supported on N9k, N7k. |
 
 #### Parameters
 

--- a/examples/cisco/demo_portchannel.pp
+++ b/examples/cisco/demo_portchannel.pp
@@ -22,7 +22,7 @@ class ciscopuppet::cisco::demo_portchannel {
   }
 
   $concatenation = platform_get() ? {
-    /(n3k|n9k)/ => true,
+    'n9k' => true,
     default => undef
   }
 
@@ -57,7 +57,7 @@ class ciscopuppet::cisco::demo_portchannel {
   }
 
   $rotate = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => '4',
+    /(n7k|n8k|n9k)/ => '4',
     default => undef
   }
 

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -240,6 +240,39 @@ tests['non_default_properties_no_hash'] = {
   },
 }
 
+tests['default_properties_no_rotate'] = {
+  title_pattern:  'default',
+  manifest_props: "
+    bundle_hash                  => 'default',
+    bundle_select                => 'default',
+    resilient                    => 'default',
+    symmetry                     => 'default',
+  ",
+  code:           [0, 2],
+  resource_props: {
+    'bundle_hash'   => 'ip',
+    'bundle_select' => 'src-dst',
+    'resilient'     => 'true',
+    'symmetry'      => 'false',
+  },
+}
+
+tests['non_default_properties_no_rotate'] = {
+  title_pattern:  'default',
+  manifest_props: "
+    bundle_hash                  => 'ip-only',
+    bundle_select                => 'src-dst',
+    resilient                    => 'false',
+    symmetry                     => 'true',
+  ",
+  resource_props: {
+    'bundle_hash'   => 'ip-only',
+    'bundle_select' => 'src-dst',
+    'resilient'     => 'false',
+    'symmetry'      => 'true',
+  },
+}
+
 #################################################################
 # HELPER FUNCTIONS
 #################################################################
@@ -294,10 +327,12 @@ test_name "TestCase :: #{testheader}" do
     id = 'default_properties_asym'
   when /n5k|n6k/
     id = 'default_properties_eth'
-  when /n3k|n9k/
+  when /n9k/
     id = 'default_properties_sym'
   when /n8k/
     id = 'default_properties_no_hash'
+  when /n3k/
+    id = 'default_properties_no_rotate'
   end
 
   tests[id][:desc] = '1.1 Default Properties'
@@ -363,7 +398,7 @@ test_name "TestCase :: #{testheader}" do
     tests['non_default_properties_eth'][:resource_props]['bundle_hash'] = 'ip-only'
     test_harness_portchannel_global(tests, id)
 
-  elsif device == 'n3k' || device == 'n9k'
+  elsif device == 'n9k'
     id = 'non_default_properties_sym'
     tests[id][:desc] = '2.1 Non Default Properties'
     test_harness_portchannel_global(tests, id)
@@ -432,6 +467,50 @@ test_name "TestCase :: #{testheader}" do
     tests['non_default_properties_no_hash'][:resource_props]['bundle_hash'] = 'mac'
     tests['non_default_properties_no_hash'][:manifest_props]['dst'] = 'src'
     tests['non_default_properties_no_hash'][:resource_props]['bundle_select'] = 'src'
+    test_harness_portchannel_global(tests, id)
+  elsif device == 'n3k'
+    id = 'non_default_properties_no_rotate'
+    tests[id][:desc] = '2.1 Non Default Properties'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.2 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['true'] = 'false'
+    tests['non_default_properties_no_rotate'][:manifest_props]['false'] = 'true'
+    tests['non_default_properties_no_rotate'][:manifest_props]['ip-only'] = 'ip-gre'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_hash'] = 'ip-gre'
+    tests['non_default_properties_no_rotate'][:manifest_props]['src-dst'] = 'src'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_select'] = 'src'
+    tests['non_default_properties_no_rotate'][:resource_props]['resilient'] = 'true'
+    tests['non_default_properties_no_rotate'][:resource_props]['symmetry'] = 'false'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.3 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['ip-gre'] = 'mac'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_hash'] = 'mac'
+    tests['non_default_properties_no_rotate'][:manifest_props]['src'] = 'dst'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_select'] = 'dst'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.4 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['mac'] = 'port'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_hash'] = 'port'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.5 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['port'] = 'port-only'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_hash'] = 'port-only'
+    tests['non_default_properties_no_rotate'][:manifest_props]['dst'] = 'src-dst'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_select'] = 'src-dst'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.6 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['port-only'] = 'ip-gre'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_hash'] = 'ip-gre'
+    test_harness_portchannel_global(tests, id)
+
+    tests[id][:desc] = '2.7 Non Default Properties'
+    tests['non_default_properties_no_rotate'][:manifest_props]['src-dst'] = 'dst'
+    tests['non_default_properties_no_rotate'][:resource_props]['bundle_select'] = 'dst'
     test_harness_portchannel_global(tests, id)
   end
 


### PR DESCRIPTION
This PR is for adding support of portchannel_global provider to n3k natively.
1. Changed README.md and CHANGELOG.md to reflect this.
2. demo manifest is changed to remove any discrepancies.
3. beaker tests are fixed for n3k to run separately from n9k since the CLIs are different now.