### PR TITLE
netdev tacacs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `port_channel`
   - `radius`, `radius_global`, `radius_server`, `radius_server_group`
   - `network_snmp`, `snmp_community`, `snmp_notification`, `snmp_notification_receiver`, `snmp_user`
-  - `tacacs`, `tacacs_global`
+  - `tacacs`, `tacacs_global`, `tacacs_server`, `tacacs_server_group`
 - Extended `cisco_bgp` with the following attributes:
   - `nsr`
   - `reconnect_interval`

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ The following table indicates which providers are supported on each platform. As
 | [syslog_setting](#type-syslog_setting) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [tacacs](#type-tacacs) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | [tacacs_global](#type-tacacs_global) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| [tacacs_server_group](#type-tacacs_server_group) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| [tacacs_server](#type-tacacs_server) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| [tacacs_server](#type-tacacs_server) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| [tacacs_server_group](#type-tacacs_server_group) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 
 
 ## <a name ="resource-reference">Resource Reference<a>
@@ -3627,7 +3627,7 @@ Array of VLAN names used for tagged packets. Values must be in range of 1 to 409
 Array of VLAN ID numbers used for VLAN pruning. Values must be in range of 1 to 4095. Cisco do not implement the concept of pruned vlans.
 
 --
-### Type: `network_vlan`
+### Type: network_vlan
 
 Manages a puppet netdev_stdlib Network Vlan.
 
@@ -4084,9 +4084,9 @@ The unit of measurement for log time values.  Valid values are 'seconds' and 'mi
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
 | N6k      | 7.3(0)N1(1)        | 1.3.0                  |
 | N7k      | 7.3(0)D1(1)        | 1.3.0                  |
-| N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -4103,9 +4103,9 @@ Enable or disable radius functionality [true|false]
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
 | N6k      | 7.3(0)N1(1)        | 1.3.0                  |
 | N7k      | 7.3(0)D1(1)        | 1.3.0                  |
-| N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -4131,9 +4131,9 @@ Number of seconds before the timeout period ends
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 
@@ -4163,9 +4163,9 @@ Number of seconds before the timeout period ends
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | 7.0(3)I2(1)        | 1.2.0                  |
 | N31xx    | 7.0(3)I2(1)        | 1.2.0                  |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | unsupported        | unsupported            |
 

--- a/examples/netdev/demo_tacacs.pp
+++ b/examples/netdev/demo_tacacs.pp
@@ -16,7 +16,7 @@
 
 class ciscopuppet::netdev::demo_tacacs {
   tacacs {'default':
-    enable => true,
+    enable => false,
   }
 
   tacacs_global { 'default':
@@ -26,16 +26,24 @@ class ciscopuppet::netdev::demo_tacacs {
     timeout             => '2',
   }
 
-  tacacs_server_group { 'red':
-    ensure    => 'present',
-    servers   => ['2.2.2.2','3.3.3.3']
-  }
-
-  tacacs_server { '8.8.8.8':
+  tacacs_server { '2.2.2.2':
     ensure              => 'present',
     key                 => '44444444',
     key_format          => '7',
     port                => '48',
     timeout             => '2',
+  }
+
+  tacacs_server { '3.3.3.3':
+    ensure              => 'present',
+    key                 => '44444444',
+    key_format          => '7',
+    port                => '48',
+    timeout             => '2',
+  }
+
+  tacacs_server_group { 'red':
+    ensure    => 'present',
+    servers   => ['2.2.2.2','3.3.3.3']
   }
 }

--- a/examples/netdev/demo_tacacs.pp
+++ b/examples/netdev/demo_tacacs.pp
@@ -16,7 +16,7 @@
 
 class ciscopuppet::netdev::demo_tacacs {
   tacacs {'default':
-    enable => false,
+    enable => true,
   }
 
   tacacs_global { 'default':

--- a/tests/beaker_tests/tacacs/tacacs_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs/tacacs_provider_defaults.rb
@@ -65,8 +65,6 @@ test_name "TestCase :: #{testheader}" do
     on(master, TacacsLib.create_tacacs_manifest_change_disabled)
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
-
-    logger.info('Setup switch for provider')
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -117,6 +115,12 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check tacacs resource presence on agent :: #{result}")
+  end
+
+  step 'TestStep :: Cleanup' do
+    on(master, TacacsLib.create_tacacs_manifest_change_disabled)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
@@ -53,6 +53,7 @@
 
 # Require UtilityLib.rb and SnmpGroupLib.rb paths.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+require File.expand_path('../../tacacs/tacacslib.rb', __FILE__)
 require File.expand_path('../tacacs_globallib.rb', __FILE__)
 
 result = 'PASS'
@@ -62,7 +63,9 @@ testheader = 'tacacs_global Resource :: All Attributes Defaults'
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider' do
-    logger.info('Setup switch for provider')
+    on(master, TacacsLib.create_tacacs_manifest_change_disabled)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -150,6 +153,12 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check tacacs_global resource presence on agent :: #{result}")
+  end
+
+  step 'TestStep :: Cleanup' do
+    on(master, TacacsLib.create_tacacs_manifest_change_disabled)
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
@@ -210,6 +210,10 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check tacacs_server resource presence on agent :: #{result}")
   end
 
+  step 'TestStep :: Cleanup' do
+    resource_absent_cleanup(agent, 'tacacs_server')
+  end
+
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)
 end

--- a/tests/beaker_tests/tacacs_server_group/tacacs_server_group_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_server_group/tacacs_server_group_provider_defaults.rb
@@ -181,6 +181,11 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check tacacs_server_group resource presence on agent :: #{result}")
   end
 
+  step 'TestStep :: Cleanup' do
+    resource_absent_cleanup(agent, 'tacacs_server')
+    resource_absent_cleanup(agent, 'tacacs_server_group')
+  end
+
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)
 end


### PR DESCRIPTION
**Summary:**
- Updated docs for `tacacs_server` and `tacacs_server_group`
- Fixed manifest
- Added cleanup steps for beaker tests.
  - Note, `tacacs` and `tacacs_global` are not ensurable so the cleanup step differs a bit.

Tests Pass On: n3k, n5k, n6k, n7k, n8k, n9k (I2 and I3)