### PR TITLE
cisco_vlan beaker fix

### DIFF
--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_defaults.rb
@@ -66,6 +66,8 @@ testheader = 'EXTVLAN Resource :: All Attributes Defaults'
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
+    resource_absent_cleanup(agent, 'cisco_bridge_domain',
+                            'bridge-domain CLEANUP :: ')
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VlanLib.create_extvlan_manifest_absent)
 

--- a/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/extendedvlan_provider_nondefaults.rb
@@ -66,6 +66,8 @@ testheader = 'EXTVLAN Resource :: All Attributes NonDefaults'
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
+    resource_absent_cleanup(agent, 'cisco_bridge_domain',
+                            'bridge-domain CLEANUP :: ')
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VlanLib.create_extvlan_manifest_absent)
 

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_defaults.rb
@@ -70,6 +70,8 @@ test_properties = {
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
+    resource_absent_cleanup(agent, 'cisco_bridge_domain',
+                            'bridge-domain CLEANUP :: ')
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VlanLib.create_stdvlan_manifest_absent)
 

--- a/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vlan/vlan/standardvlan_provider_nondefaults.rb
@@ -70,6 +70,8 @@ test_properties = {
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
+    resource_absent_cleanup(agent, 'cisco_bridge_domain',
+                            'bridge-domain CLEANUP :: ')
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, VlanLib.create_stdvlan_manifest_absent)
 


### PR DESCRIPTION
This PR is for removing bridge domains if they exist so that vlan tests pass.