### PR TITLE
test_evpn_vni: add checks for i2_image

### DIFF
--- a/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
+++ b/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
@@ -68,6 +68,13 @@ tests[:non_default] = {
   },
 }
 
+# The harness will remove any "unprops" from the manifests.
+def unsupported_properties(*)
+  unprops = []
+  unprops << :route_target_both if nexus_i2_image
+  unprops
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################

--- a/tests/beaker_tests/cisco_itd_device_group/test_itd_device_group.rb
+++ b/tests/beaker_tests/cisco_itd_device_group/test_itd_device_group.rb
@@ -132,7 +132,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_img(tests)
+  skip_nexus_i2_image(tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)

--- a/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
+++ b/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
@@ -138,7 +138,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_img(tests)
+  skip_nexus_i2_image(tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)

--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -238,7 +238,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_img(tests)
+  skip_nexus_i2_image(tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)


### PR DESCRIPTION
* On i2 images, `route-target both 2:2` does not nvgen and instead nvgens two entrie: `route-target import 2:2 ; route-target export 2:2`
* On i3 images, `route-target both 2:2` nvgens as entered, import/export do not and are treated as separate entities
* Added nexus_i2_image method (named this way to match the minitest method of the same name); renamed skip_nexus_i2_img to reflect new method
* Tested on N9-i2, N9-i3 (all affected beaker tests)