### PR TITLE
Git hooks fixes for puppet-module

### DIFF
--- a/bin/git/hooks/hook_lib
+++ b/bin/git/hooks/hook_lib
@@ -86,6 +86,13 @@ get_last_version() {
 }
 export -f get_last_version
 
+get_staged_ruby_files() {
+  rubocop_target=$(rubocop --list-target-files)
+  staged_files=$(git diff --name-only --staged)
+  printf '%s' "$(printf '%s' "$rubocop_target $staged_files " | tr ' ' '\n' | sort | uniq -d)"
+}
+export -f get_staged_ruby_files
+
 add_changelog_diff_link() {
     local OLD_VERSION=$1
     local NEW_VERSION=$2

--- a/bin/git/hooks/pre-commit/check_unstaged_changes
+++ b/bin/git/hooks/pre-commit/check_unstaged_changes
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+#
+# Check if a staged file has unstaged changes and print a warning
+
+staged_files = `git diff --name-only --staged`.split(' ')
+unstaged_files = `git diff --name-only`.split(' ')
+files = (staged_files << unstaged_files).flatten!
+
+if files.length != files.uniq.length
+  puts 'Warning: a staged file has unstaged changes!'
+  fd = IO.sysopen('/dev/tty', 'w+')
+  a = IO.new(fd, 'w+')
+  a.print 'Continue anyway? [y/N] '
+  input = a.gets.chomp
+  exit input =~ /^y/i ? 0 : -1
+end
+
+exit 0

--- a/bin/git/hooks/pre-commit/rubocop
+++ b/bin/git/hooks/pre-commit/rubocop
@@ -9,12 +9,17 @@
 # rubocop run of all checks as part of the pre-push hook
 
 step_name "Running RuboCop lint checks"
-rubocop --lint
+staged_ruby_files=$(get_staged_ruby_files)
+if [ -z "$staged_ruby_files" ]; then
+  # quit since there are no ruby files to check
+  exit 0
+fi
+rubocop --lint $staged_ruby_files
 check_rc "Please fix RuboCop lint failures before committing."
 
 # Do a full rubocop run to warn the user, but don't block a commit by it.
 step_name "Running all RuboCop checks"
-rubocop
+rubocop $staged_ruby_files
 check_rc_optional "Fix all RuboCop failures before pushing upstream"
 
 exit 0

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -22,6 +22,13 @@ fi
 # Note that the use of brackets around a tr range is ok here, (it's
 # even required, for portability to Solaris 10's /usr/bin/tr), since
 # the square bracket bytes happen to fall in the designated range.
-git diff --cached --name-only --diff-filter=A -z $against |
-        LC_ALL=C tr -d '[ -~]\0' | wc -c
+added_files=$(git diff --cached --name-only --diff-filter=A -z $against | tr '\0' ' ')
+added_files_array=(`echo $added_files`)
+# Print the files that have non-ascii text
+for i in ${added_files_array[@]}; do
+  bad_chars=$(echo -n $i | LC_ALL=C tr -d '[ -~]\0')
+  if [ -n "$bad_chars" ]; then echo $i; fi
+done
+# Fail if any non-ASCII characters are discovered
+(echo -n $added_files | LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))
 check_rc "Rename non-ASCII file name(s) before committing"


### PR DESCRIPTION
Pulls in git-hooks fixes from node-utils repo.

## Changes

### Run rubocop against staged ruby files only

```bash
$ git commit -m "Change ABC metric size to be smaller"
*** Running Git hook script: pre-commit-check_unstaged_changes...
	...[ OK ]
*** Running Git hook script: pre-commit-rubocop...
	Running RuboCop lint checks
Inspecting 3 files
...

3 files inspected, no offenses detected
	Running all RuboCop checks
Inspecting 3 files
...

3 files inspected, no offenses detected
	...[ OK ]
*** Running Git hook script: pre-commit-validate-diffs...
	...[ OK ]
```

### Warn if commiting changes to a file that also has unstaged changes

```bash
$ git status
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	modified:   hook_lib

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   hook_lib

$ git commit -m "Test -- should fail"
*** Running Git hook script: pre-commit-check_unstaged_changes...
Warning: a staged file has unstaged changes!
Continue anyway? [y/N] N
*** Running Git hook script: pre-commit-rubocop...
	Running RuboCop lint checks
Inspecting 1 file
.

1 file inspected, no offenses detected
	Running all RuboCop checks
Inspecting 1 file
.

1 file inspected, no offenses detected
	...[ OK ]
*** Running Git hook script: pre-commit-validate-diffs...
	...[ OK ]
	...[ FAIL ] One or more hook scripts reported an error
```

### Fix validate-diffs to print list of files with bad filenames and exit properly

Old behavior:

```bash
*** Running Git hook script: pre-commit-validate-diffs...
0
	...[ OK ]
```

Post-fix:

```bash
$ git commit -m "Add bad filename"
*** Running Git hook script: pre-commit-check_unstaged_changes...
	...[ OK ]
*** Running Git hook script: pre-commit-rubocop...
	Running RuboCop lint checks
	...[ OK ]
*** Running Git hook script: pre-commit-validate-diffs...
tests/beaker_tests/cisco_interface/test_Δ
	...[ FAIL ] Rename non-ASCII file name(s) before committing
	...[ FAIL ] One or more hook scripts reported an error
```