### PR TITLE
fix VDC beaker test failures

### DIFF
--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -73,6 +73,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # Restore original testbed settings
   logger.info("\nRestore module type to '#{orig_type}'\n")
-  limit_resource_module_type_set(default_vdc_name, orig_type, true)
+  limit_resource_module_type_set(default_vdc_name, orig_type)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -806,15 +806,15 @@ def limit_resource_module_type_get(vdc, mod)
 end
 
 # Set limit-resource module-type
-def limit_resource_module_type_set(_vdc, mod, default=false)
-  mod = '' if default
+def limit_resource_module_type_set(vdc, mod, default=false)
+  mod = 'default' if default || mod.nil?
   resource_vdc_mod = {
     name:     'cisco_vdc',
-    title:    'default',
+    title:    vdc,
     property: 'limit_resource_module_type',
     value:    mod,
   }
-  resource_set(agent, resource_vdc_mod, "Enable #{mod} card(s)")
+  resource_set(agent, resource_vdc_mod, "Enable module-type #{mod}")
 end
 
 # Check for presence of interface in vdc allocated interfaces


### PR DESCRIPTION
fixing the parameters of the limit_resources_module_type() utility and fix the NU call with the 'default' arg