### PR TITLE
bd remove for interface stp vlan

### DIFF
--- a/tests/beaker_tests/cisco_interface/test_interface_stp.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_stp.rb
@@ -142,6 +142,8 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
+  resource_absent_cleanup(agent, 'cisco_bridge_domain',
+                          'bridge-domain CLEANUP :: ')
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_interface(tests, :default)


### PR DESCRIPTION
This PR is for cleaning up bridge domains if they exist so that vlan tests can pass.
Tested on n7k/n9k/n3k. brdige domains are only available on n7k, on all other nexus platforms, the added line of code is nop.