### PR TITLE
Vxlan Puppet changes for release 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ The following table indicates which providers are supported on each platform. As
 | [cisco_vrf](#type-cisco_vrf) | ✅ | ✅* | ✅* | ✅ | ✅ | ✅ | ✅ | ✅* | * [caveats](#cisco_vrf-caveats) |
 | [cisco_vrf_af](#type-cisco_vrf_af) | ✅ | ✅* | ✅* | ✅* | ✅* | ✅* | ✅ | ✅* | * [caveats](#cisco_vrf_af-caveats) |
 | [cisco_vtp](#type-cisco_vtp) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| [cisco_vxlan_vtep](#type-cisco_vxlan_vtep) | ✅ | :heavy_minus_sign: | :heavy_minus_sign: | ❌ | ❌ | ❌ | ✅ | :heavy_minus_sign: |
-| [cisco_vxlan_vtep_vni](#type-cisco_vxlan_vtep_vni) | ✅ | :heavy_minus_sign: | :heavy_minus_sign: | ❌ | ❌ | ❌ | ✅ | :heavy_minus_sign: |
+| [cisco_vxlan_vtep](#type-cisco_vxlan_vtep) | ✅ | :heavy_minus_sign: | :heavy_minus_sign: | ✅ | ✅ | ✅ | ✅ | :heavy_minus_sign: |
+| [cisco_vxlan_vtep_vni](#type-cisco_vxlan_vtep_vni) | ✅ | :heavy_minus_sign: | :heavy_minus_sign: | ✅ | ✅ | ✅ | ✅ | :heavy_minus_sign: |
 
 ##### NetDev Providers
 
@@ -3375,9 +3375,9 @@ Creates a VXLAN Network Virtualization Endpoint (NVE) overlay interface that ter
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | not applicable     | not applicable         |
 | N31xx    | not applicable     | not applicable         |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | not applicable     | not applicable         |
 
@@ -3410,9 +3410,9 @@ Creates a Virtual Network Identifier member (VNI) for an NVE overlay interface.
 | N9k      | 7.0(3)I2(1)        | 1.2.0                  |
 | N30xx    | not applicable     | not applicable         |
 | N31xx    | not applicable     | not applicable         |
-| N56xx    | unsupported        | unsupported            |
-| N6k      | unsupported        | unsupported            |
-| N7k      | unsupported        | unsupported            |
+| N56xx    | 7.3(0)N1(1)        | 1.3.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.3.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N8k      | 7.0(3)F1(1)        | 1.3.0                  |
 | IOS XR   | not applicable     | not applicable         |
 

--- a/examples/cisco/demo_vxlan.pp
+++ b/examples/cisco/demo_vxlan.pp
@@ -17,80 +17,88 @@
 # limitations under the License.
 
 class ciscopuppet::cisco::demo_vxlan {
-  cisco_overlay_global { 'default':
-    dup_host_ip_addr_detection_host_moves => '100',
-    dup_host_ip_addr_detection_timeout    => '10',
-    anycast_gateway_mac                   => '1234.4567.6789',
-    dup_host_mac_detection_host_moves     => '100',
-    dup_host_mac_detection_timeout        => '10',
-  }
 
-  if platform_get() =~ /n7k/ {
-    cisco_vdc { 'default':
-      ensure                     => present,
-      limit_resource_module_type => 'f3'
+  if platform_get() =~ /n(5|6|7|8|9)k/ {
+
+    if platform_get() =~ /n7k/ {
+      cisco_vdc { 'default':
+        ensure                     => present,
+        limit_resource_module_type => 'f3'
+      }
     }
+
+    cisco_overlay_global { 'default':
+      dup_host_ip_addr_detection_host_moves => '100',
+      dup_host_ip_addr_detection_timeout    => '10',
+      anycast_gateway_mac                   => '1234.4567.6789',
+      dup_host_mac_detection_host_moves     => '100',
+      dup_host_mac_detection_timeout        => '10',
+    }
+
+    $source_interface_hold_down_time = platform_get() ? {
+      /n(8|9)k/  => '50',
+      default    => undef,
+    }
+
+    $ingress_replication = platform_get() ? {
+      /n(8|9)k/  => 'static',
+      default    => undef,
+    }
+
+    $peer_list = platform_get() ? {
+      /n(8|9)k/  => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
+      default    => undef,
+    }
+
+    $suppress_uuc = platform_get() ? {
+      /n(5|6)k/  => 'default',
+      default    => undef,
+     }
+
+    cisco_vxlan_vtep { 'nve1':
+      ensure                          => present,
+      description                     => 'Configured by puppet',
+      host_reachability               => 'evpn',
+      shutdown                        => 'false',
+      source_interface                => 'loopback55',
+      source_interface_hold_down_time => $source_interface_hold_down_time,
+    }
+
+    cisco_vxlan_vtep_vni {'nve1 10000':
+      ensure              => present,
+      assoc_vrf           => false,
+      multicast_group     => undef,
+      ingress_replication => $ingress_replication,
+      peer_list           => $peer_list,
+      suppress_uuc        => $suppress_uuc,
+    }
+
+    cisco_vxlan_vtep_vni {'nve1 20000':
+      ensure              => present,
+      assoc_vrf           => false,
+      multicast_group     => '224.1.1.1',
+      suppress_arp        => 'default',
+    }
+
+    # TBD: Anycast gateway mode
+    # if platform_get() =~ /n7k/ {
+    #   cisco_interface { 'Bdi100':
+    #     require => Cisco_overlay_global['default'],
+    #     ensure  => present,
+    #     fabric_forwarding_anycast_gateway => 'true',
+    #   }
+    # }
+    #
+    # else {
+    #   cisco_interface { 'vlan97':
+    #     require => Cisco_overlay_global['default'],
+    #     ensure  => present,
+    #     fabric_forwarding_anycast_gateway => 'true',
+    #   }
+    # }
   }
 
-  $source_interface_hold_down_time = platform_get() ? {
-    /n(8|9)k/  => '50',
-    default    => undef,
+  else {
+    warning('SKIP: This platform does not support vxlan feature')
   }
-
-  $ingress_replication = platform_get() ? {
-    /n(8|9)k/  => 'static',
-    default    => undef,
-  }
- 
-  $peer_list = platform_get() ? {
-    /n(8|9)k/  => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
-    default    => undef,
-  }
- 
-  $suppress_uuc = platform_get() ? {
-    /n(5|6)k/  => 'default',
-    default    => undef,
-   }
-
-  cisco_vxlan_vtep { 'nve1':
-    ensure                          => present,
-    description                     => 'Configured by puppet',
-    host_reachability               => 'evpn',
-    shutdown                        => 'false',
-    source_interface                => 'loopback55',
-    source_interface_hold_down_time => $source_interface_hold_down_time,
-  }
-
-  cisco_vxlan_vtep_vni {'nve1 10000':
-    ensure              => present,
-    assoc_vrf           => false,
-    multicast_group     => undef,
-    ingress_replication => $ingress_replication,
-    peer_list           => $peer_list,
-    suppress_uuc        => $suppress_uuc,
-  }
-  
-  cisco_vxlan_vtep_vni {'nve1 20000':
-    ensure              => present,
-    assoc_vrf           => false,
-    multicast_group     => '224.1.1.1',
-    suppress_arp        => 'default',
-  }
-
-  # TBD: Anycast gateway mode
-  # if platform_get() =~ /n7k/ {
-  #   cisco_interface { 'Bdi100':
-  #     require => Cisco_overlay_global['default'],
-  #     ensure  => present,
-  #     fabric_forwarding_anycast_gateway => 'true',
-  #   }
-  # }
-  #
-  # else {
-  #   cisco_interface { 'vlan97':
-  #     require => Cisco_overlay_global['default'],
-  #     ensure  => present,
-  #     fabric_forwarding_anycast_gateway => 'true',
-  #   }
-  # }
 }

--- a/examples/demo_all_cisco.pp
+++ b/examples/demo_all_cisco.pp
@@ -51,8 +51,5 @@ class ciscopuppet::demo_all_cisco {
   include ciscopuppet::cisco::demo_vtp
   include ciscopuppet::cisco::demo_bridge_domain
   include ciscopuppet::cisco::demo_encapsulation
-  # Conditionally include ciscopuppet::demo_vxlan 
-  if platform_get() =~ /n9k/ {
-    include ciscopuppet::cisco::demo_vxlan
-  }
+  include ciscopuppet::cisco::demo_vxlan
 }

--- a/lib/puppet/type/cisco_vxlan_vtep_vni.rb
+++ b/lib/puppet/type/cisco_vxlan_vtep_vni.rb
@@ -171,6 +171,13 @@ Puppet::Type.newtype(:cisco_vxlan_vtep_vni) do
     newvalues(:true, :false, :default)
   end
 
+  newproperty(:suppress_uuc) do
+    desc "Suppress uuc under layer 2 VNI. Valid values are true,
+          false, or 'default'"
+ 
+    newvalues(:true, :false, :default)
+  end
+
   # Multicast-group and ingress-replication are mutually exclusive properties.
   validate do
     fail 'Only one of multicast-group or ingress-replication can be configured, '\
@@ -184,6 +191,7 @@ Puppet::Type.newtype(:cisco_vxlan_vtep_vni) do
     assoc_vrf_incompatible_props = self[:ingress_replication] ||
                                    self[:multicast_group] ||
                                    self[:suppress_arp] ||
+                                   self[:suppress_uuc] ||
                                    self[:peer_list]
 
     fail 'ingress_replication, multicast_group, peer_list & suppress_arp' \

--- a/lib/puppet/type/cisco_vxlan_vtep_vni.rb
+++ b/lib/puppet/type/cisco_vxlan_vtep_vni.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:cisco_vxlan_vtep_vni) do
   newproperty(:suppress_uuc) do
     desc "Suppress uuc under layer 2 VNI. Valid values are true,
           false, or 'default'"
- 
+
     newvalues(:true, :false, :default)
   end
 

--- a/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
+++ b/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
@@ -73,7 +73,7 @@ testheader = 'Resource cisco_overlay_global'
 tests = {
   master:   master,
   agent:    agent,
-  platform: 'n9k',
+  platform: 'n(5|6|7|8|9)k',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -72,7 +72,7 @@ testheader = 'Resource cisco_vxlan_vtep'
 tests = {
   master:        master,
   agent:         agent,
-  platform:      'n(8|9)k',
+  platform:      'n(5|6|7|8|9)k',
   resource_name: 'cisco_vxlan_vtep',
 }
 
@@ -109,7 +109,6 @@ tests['default_properties'] = {
     host_reachability               => 'default',
     shutdown                        => 'default',
     source_interface                => 'default',
-    source_interface_hold_down_time => 'default',
   ",
   resource_props: {
     'host_reachability' => 'flood',
@@ -124,16 +123,21 @@ tests['non_default_properties'] = {
     host_reachability               => 'evpn',
     shutdown                        => 'false',
     source_interface                => 'loopback55',
-    source_interface_hold_down_time => '50',
   ",
   resource_props: {
     'description'                     => 'Configured by Puppet',
     'host_reachability'               => 'evpn',
     'shutdown'                        => 'false',
     'source_interface'                => 'loopback55',
-    'source_interface_hold_down_time' => '50',
   },
 }
+
+# Source Interface Hold-down Time
+if platform[/n(8|9)k/]
+  tests['default_properties'][:manifest_props][:source_interface_hold_down_time] = 'default'
+  tests['non_default_properties'][:manifest_props][:source_interface_hold_down_time] = '100'
+  tests['non_default_properties'][:resource_props][:source_interface_hold_down_time] = '100'
+end
 
 tests['change_parameters'] = {
   title_pattern:  'nve1',
@@ -141,14 +145,12 @@ tests['change_parameters'] = {
     host_reachability               => 'flood',
     shutdown                        => 'true',
     source_interface                => 'loopback1',
-    source_interface_hold_down_time => '100',
   ",
   resource_props: {
     'description'                     => 'Configured by Puppet',
     'host_reachability'               => 'flood',
     'shutdown'                        => 'true',
     'source_interface'                => 'loopback1',
-    'source_interface_hold_down_time' => '100',
   },
 }
 

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -125,10 +125,10 @@ tests['non_default_properties'] = {
     source_interface                => 'loopback55',
   ",
   resource_props: {
-    'description'                     => 'Configured by Puppet',
-    'host_reachability'               => 'evpn',
-    'shutdown'                        => 'false',
-    'source_interface'                => 'loopback55',
+    'description'       => 'Configured by Puppet',
+    'host_reachability' => 'evpn',
+    'shutdown'          => 'false',
+    'source_interface'  => 'loopback55',
   },
 }
 
@@ -147,10 +147,10 @@ tests['change_parameters'] = {
     source_interface                => 'loopback1',
   ",
   resource_props: {
-    'description'                     => 'Configured by Puppet',
-    'host_reachability'               => 'flood',
-    'shutdown'                        => 'true',
-    'source_interface'                => 'loopback1',
+    'description'       => 'Configured by Puppet',
+    'host_reachability' => 'flood',
+    'shutdown'          => 'true',
+    'source_interface'  => 'loopback1',
   },
 }
 

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -72,7 +72,7 @@ testheader = 'Resource cisco_vxlan_vtep_vni'
 tests = {
   master:        master,
   agent:         agent,
-  platform:      'n(8|9)k',
+  platform:      'n(5|6|7|8|9)k',
   resource_name: 'cisco_vxlan_vtep_vni',
 }
 
@@ -104,6 +104,7 @@ tests = {
 #
 tests['default_properties_ingress_replication'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'default',
     suppress_arp        => 'default',
@@ -126,8 +127,15 @@ tests['default_properties_multicast_group'] = {
   },
 }
 
+# Suppress Unknown Unicast
+if platform[/n(5|6)k/]
+  tests['default_properties_multicast_group'][:manifest_props][:suppress_uuc] = 'default'
+  tests['default_properties_multicast_group'][:resource_props][:suppress_uuc] = 'false'
+end
+
 tests['ingress_replication_static_peer_list_empty'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'static',
     peer_list           => [],
@@ -142,6 +150,7 @@ tests['ingress_replication_static_peer_list_empty'] = {
 
 tests['peer_list'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'static',
     peer_list           => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
@@ -156,6 +165,7 @@ tests['peer_list'] = {
 
 tests['peer_list_change_add'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'static',
     peer_list           => ['1.1.1.1', '6.6.6.6', '3.3.3.3', '4.4.4.4'],
@@ -170,6 +180,7 @@ tests['peer_list_change_add'] = {
 
 tests['peer_list_default'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'static',
     peer_list           => 'default',
@@ -184,6 +195,7 @@ tests['peer_list_default'] = {
 
 tests['ingress_replication_bgp'] = {
   title_pattern:  'nve1 10000',
+  platform:       'n(8|9)k',
   manifest_props: "
     ingress_replication => 'bgp',
     suppress_arp        => 'default'
@@ -223,6 +235,28 @@ tests['suppress_arp_false'] = {
   ",
   resource_props: {
     'suppress_arp' => 'false'
+  },
+}
+
+tests['suppress_uuc_true'] = {
+  title_pattern:  'nve1 10000',
+  platform:       'n(5|6)k',
+  manifest_props: "
+    suppress_uuc => 'true'
+  ",
+  resource_props: {
+    'suppress_uuc' => 'true'
+  },
+}
+
+tests['suppress_uuc_false'] = {
+  title_pattern:  'nve1 10000',
+  platform:       'n(5|6)k',
+  manifest_props: "
+    suppress_uuc => 'false'
+  ",
+  resource_props: {
+    'suppress_uuc' => 'false'
   },
 }
 
@@ -351,6 +385,14 @@ test_name "TestCase :: #{testheader}" do
 
   # id = 'suppress_arp_false'
   # tests[id][:desc] = '2.8 Suppress ARP'
+  # test_harness_cisco_vxlan_vtep_vni(tests, id)
+
+  # id = 'suppress_uuc_true'
+  # tests[id][:desc] = '2.9 Suppress Unknown Unicast'
+  # test_harness_cisco_vxlan_vtep_vni(tests, id)
+  #
+  # id = 'suppress_uuc_false'
+  # tests[id][:desc] = '2.10 Suppress Unknown Unicast'
   # test_harness_cisco_vxlan_vtep_vni(tests, id)
 
   resource_absent_cleanup(agent, 'cisco_vxlan_vtep_vni',


### PR DESCRIPTION
- Included support for all nexus platforms (excluding 3k)
- Hold down time, ingress replication, peer list specific to 8,9k.
- added suppress_uuc - specific to 5,6k.
- changes in beaker tests accordingly.
- Manifest - ensure f3 vdc for 7k. Vxlan included in demo_all.
