### PR TITLE
skip file_service test for OAC

### DIFF
--- a/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
@@ -63,6 +63,8 @@ testheader = 'SERVICE Resource :: All Attributes NonDefaults'
 
 # @test_name [TestCase] Executes nondefaults testcase for SERVICE Resource.
 test_name "TestCase :: #{testheader}" do
+  raise_skip_exception('Not supported for OAC platforms', self) if
+  platform[/'n5|6|7|k'/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.


### PR DESCRIPTION
The file_service_package/service_provider_nondefaults.rb is not apllicable to OAC platforms n5/6/7k. This PR is to skip the test on these platforms.
Tested on n6k, n7k (it skips) and n9k (it runs normally). Have not tested on n5k because of resource unavailability but the added code should skip on n5k also as it is just a string comparison.