### PR TITLE
test_vrf: skip rd test when i2 img

### DIFF
--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -74,6 +74,7 @@ def unsupported_properties(_tests, _id)
       :vpn_id
 
     unprops << :vni unless platform[/n9k/]
+    unprops << :route_distinguisher if nexus_i2_image
 
   else
     unprops <<


### PR DESCRIPTION
* Tested on n3k-i2, n9k-i3