### PR TITLE
N7k testbed cleanup fixes

### DIFF
--- a/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
+++ b/tests/beaker_tests/cisco_fabricpath_global/test_fabricpath_global.rb
@@ -238,14 +238,16 @@ def test_harness_fabricpath_global(tests, id)
   tests[id][:ensure] = nil
 end
 
+def testbed_cleanup(agent)
+  remove_all_vlans(agent)
+  resource_absent_cleanup(agent, 'cisco_fabricpath_global')
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{testheader}" do
-  resource_absent_cleanup(agent, 'cisco_fabricpath_global',
-                          'Setup for cisco_fabricpath_global provider test')
-  device = platform
-  logger.info("#### This device is of type: #{device} #####")
+  testbed_cleanup(agent)
 
   logger.info("\n#{'-' * 60}\nSection 0. Testbed Initialization")
   setup_fabricpath_env(tests, self)
@@ -289,6 +291,8 @@ test_name "TestCase :: #{testheader}" do
   tests[id][:desc] = '4.2 Non Default Properties exclusive to Platform (abs)'
   tests[id][:ensure] = :absent
   test_harness_fabricpath_global(tests, id)
+
+  testbed_cleanup(agent)
 end
 
 logger.info('TestCase :: # {testheader} :: End')

--- a/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
+++ b/tests/beaker_tests/cisco_fabricpath_topology/test_fabricpath_topology.rb
@@ -158,14 +158,16 @@ def test_harness_fabricpath_topology(tests, id)
   tests[id][:ensure] = nil
 end
 
+def testbed_cleanup(agent)
+  remove_all_vlans(agent)
+  resource_absent_cleanup(agent, 'cisco_fabricpath_topology')
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{testheader}" do
-  resource_absent_cleanup(agent, 'cisco_fabricpath_topology',
-                          'Setup for cisco_fabricpath_topology provider test')
-  device = platform
-  logger.info("#### This device is of type: #{device} #####")
+  testbed_cleanup(agent)
 
   logger.info("\n#{'-' * 60}\nSection 0. Testbed Initialization")
   setup_fabricpath_env(tests, self)
@@ -179,6 +181,8 @@ test_name "TestCase :: #{testheader}" do
   tests[id][:desc] = '1.2 Non Default Properties (absent)'
   tests[id][:ensure] = :absent
   test_harness_fabricpath_topology(tests, id)
+
+  testbed_cleanup(agent)
 end
 
 logger.info('TestCase :: # {testheader} :: End')

--- a/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
+++ b/tests/beaker_tests/cisco_interface/test_vlan_mapping.rb
@@ -93,6 +93,8 @@ tests = {
   resource_name:    'cisco_interface',
   bridge_domain:    '199',
   switchport_mode:  'trunk',
+  # On N7k, feature vni requires solely F3 cards in the vdc
+  vdc_limit_module: 'f3',
 }
 
 # tests[id] keys set by caller and used by test_harness_common:
@@ -182,6 +184,7 @@ test_name "TestCase :: #{testheader}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_vlan_mapping(tests, 'non_default_properties')
-end
 
+  interface_cleanup(agent, tests[:intf], 'Post-test cleanup: ')
+end
 logger.info("TestCase :: #{testheader} :: End")

--- a/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
+++ b/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
@@ -82,6 +82,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # Clean up any stale pre-req configs that might conflict with our test
   resource_absent_cleanup(agent, 'cisco_encapsulation')
+  interface_cleanup(agent, intf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
@@ -97,5 +98,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -----------------------------------
   resource_absent_cleanup(agent, 'cisco_interface_service_vni')
   resource_absent_cleanup(agent, 'cisco_encapsulation')
+
+  interface_cleanup(agent, intf, 'Post-test cleanup: ')
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -297,6 +297,7 @@ def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
   step "\n--------\n * TestStep :: #{stepinfo}" do
     # set each resource to ensure=absent
     get_current_resource_instances(agent, res_name).each do |title|
+      # Some resources have exceptions
       case res_name
       when /cisco_bgp$/
         # cleaning default cleans them all
@@ -687,12 +688,15 @@ end
 # test interface name to use for testing.
 # tests[:vdc] The default vdc name
 # tests[:intf] A compatible interface to use for MT-full testing.
+# rubocop:disable Metrics/AbcSize
 def setup_mt_full_env(tests, testcase)
   # MT-full tests require a specific linecard. Search for a compatible
   # module and enable it.
 
   testheader = tests[:resource_name]
-  mod = 'f3'
+  mod = tests[:vdc_limit_module]
+  mod = 'f3' if mod.nil?
+
   step 'Check for Compatible Line Module' do
     tests[:intf] = mt_full_interface
     break if tests[:intf]
@@ -710,9 +714,7 @@ def setup_mt_full_env(tests, testcase)
   vdc = tests[:vdc]
 
   step "Check for 'limit-resource module-type #{mod}'" do
-    break if limit_resource_module_type_get(vdc, mod)
-    logger.info("limit-resource module-type does not include '#{mod}', "\
-                'update it now...')
+    break if limit_resource_module_type_get(vdc, mod, :exact)
     limit_resource_module_type_set(vdc, mod)
     break if limit_resource_module_type_get(vdc, mod)
     prereq_skip(testheader, testcase,
@@ -739,6 +741,7 @@ def setup_mt_full_env(tests, testcase)
   config_encap_profile_vni_global(agent, tests[:encap_prof_global]) if
     tests[:encap_prof_global]
 end
+# rubocop:enable Metrics/AbcSize
 
 # setup_fabricpath_env
 # Check and set up prerequisites for fabricpath testing.
@@ -754,7 +757,9 @@ def setup_fabricpath_env(tests, testcase)
   return unless platform == 'n7k'
 
   testheader = tests[:resource_name]
-  mod = 'f2e f3'
+  mod = tests[:vdc_limit_module]
+  mod = 'f2e f3' if mod.nil?
+
   step 'Check for Compatible Line Module' do
     tests[:intf_type] = 'ethernet'
     tests[:intf] = fabricpath_interface
@@ -833,9 +838,18 @@ def default_vdc_name
 end
 
 # Check for presence of limit-resource module-type
-def limit_resource_module_type_get(vdc, mod)
+# The lookup is a loose match by default but some features like 'vni' are
+# required to use a specific set of modules only, in which case specify
+# ':exact' for a strict match of the current modules.
+def limit_resource_module_type_get(vdc, mod, match=nil)
   cmd = get_vshell_cmd("sh vdc #{vdc} detail")
-  pat = Regexp.new("vdc supported linecards:.*(#{mod})")
+  if match == :exact
+    # Must be this list of modules only
+    pat = Regexp.new("vdc supported linecards: (#{mod})")
+  else
+    # Just make sure module type is in list
+    pat = Regexp.new("vdc supported linecards:.*(#{mod})")
+  end
   out = on(agent, cmd, pty: true).stdout.match(pat)
   out.nil? ? nil : Regexp.last_match[1]
 end
@@ -1183,4 +1197,11 @@ def debug_probe(probe, msg)
   dbg = ''
   probe[:probe_props].each { |p| dbg += "'#{p}' => #{probe[:caps][p]}, " }
   logger.info("\n      #{msg}: #{dbg}")
+end
+
+def remove_all_vlans(agent, stepinfo='Remove all vlans')
+  step "\n--------\n * TestStep :: #{stepinfo}" do
+    resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge domains')
+    resource_absent_cleanup(agent, 'cisco_vlan', 'vlans')
+  end
 end


### PR DESCRIPTION
* Mostly F3 & vlan related
* The F3 issue still needs work but we will address post-release.
* feature vni can only work if limit-resource module-type is set exclusively to 'f3'
* Tested (on N7k w/F3 module) all of the tests that use the methods I changed