### PR TITLE
Add bridge-domain cleanup to remove_all_vlans

### DIFF
--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -263,9 +263,7 @@ end
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
-  device = platform
-  logger.info("#### This device is of type: #{device} #####")
-  resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge-domain CLEANUP :: ')
+  remove_all_vlans(agent)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)
@@ -280,6 +278,8 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :non_default_bd)
   test_harness_run(tests, :non_default_plat_1)
   test_harness_run(tests, :non_default_plat_2)
+
+  remove_all_vlans(agent)
   skipped_tests_summary(tests)
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1199,9 +1199,11 @@ def debug_probe(probe, msg)
   logger.info("\n      #{msg}: #{dbg}")
 end
 
-def remove_all_vlans(agent, stepinfo='Remove all vlans')
+def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
   step "\n--------\n * TestStep :: #{stepinfo}" do
     resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge domains')
+    cmd = 'system bridge-domain none'
+    command_config(agent, cmd, cmd)
     resource_absent_cleanup(agent, 'cisco_vlan', 'vlans')
   end
 end


### PR DESCRIPTION
* test_stp_global cleanup was lacking
* Tested on n7,n9

```
  --------
   * TestStep :: Remove all vlans & bridge-domains

    *
    --------
     * TestStep :: bridge domains
        * bridge domains Removing cisco_bridge_domain '22'
        * bridge domains Removing cisco_bridge_domain '24'

    system bridge-domain none

    *
    --------
     * TestStep :: vlans
        * vlans Removing cisco_vlan '20'
        * vlans Removing cisco_vlan '28'

```