### PR TITLE
Platform check and fix misconfig

### DIFF
--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -44,7 +44,7 @@ class ciscopuppet::cisco::demo_interface {
       ipv4_netmask_length           => 24,
       ipv4_address_secondary        => '192.168.88.1',
       ipv4_netmask_length_secondary => 24,
-      ipv4_forwarding               => true,
+      ipv4_forwarding               => false,
       ipv4_pim_sparse_mode          => false,
       mtu                           => 1600,
       # Removed because of too many differences between platforms and linecards
@@ -88,20 +88,24 @@ class ciscopuppet::cisco::demo_interface {
       svi_management   => true,
       ipv4_arp_timeout => 300,
     }
-    
-    cisco_bridge_domain { "100":
-      ensure    => 'present',
-      shutdown  => false,
-      bd_name   => 'test1'
-    }   
 
-    cisco_interface { 'Bdi100':
-      require               => Cisco_bridge_domain['100'],
-      ensure                => 'present',
-      shutdown              => false,
-      ipv4_address          => "10.10.10.1",
-      ipv4_netmask_length   => 24, 
-      vrf                   => 'test1'
+    if platform_get() =~ /n7k/ {
+      cisco_bridge_domain { "100":
+        ensure    => 'present',
+        shutdown  => false,
+        bd_name   => 'test1'
+      }
+
+      cisco_interface { 'Bdi100':
+        require               => Cisco_bridge_domain['100'],
+        ensure                => 'present',
+        shutdown              => false,
+        ipv4_address          => "10.10.10.1",
+        ipv4_netmask_length   => 24,
+        vrf                   => 'test1'
+      }
+    } else {
+      warning('This platform does not support the bdi feature')
     }
 
     # For private vlan

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -105,7 +105,7 @@ class ciscopuppet::cisco::demo_interface {
         vrf                   => 'test1'
       }
     } else {
-      warning('This platform does not support the bdi feature')
+      warning('This platform does not support cisco_bridge_domain')
     }
 
     # For private vlan


### PR DESCRIPTION
#### Fix the following errors

```bash
Error: /Stage[main]/Ciscopuppet::Cisco::Demo_interface/Cisco_interface[Ethernet1/1]: Could not evaluate: [interface ethernet1/1] The command ' ip address 192.168.55.5/24 ' was rejected with error:
IP configuration not permitted on forwarding-enabled interfaces
```

```bash
Error: /Stage[main]/Ciscopuppet::Cisco::Demo_interface/Cisco_bridge_domain[100]: Could not evaluate: undefined method `split' for nil:NilClass
```