### PR TITLE
test_interface_private_vlan: fix trunk assoc cleanup

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1033,7 +1033,7 @@ def skip_unless_supported(tests)
   pattern = tests[:platform]
   return false if pattern.nil? || platform.match(tests[:platform])
   msg = "Skipping all tests; '#{tests[:resource_name]}' "\
-        'is unsupported on this node'
+        '(or test file) is not supported on this node'
   banner = '#' * msg.length
   raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
 end


### PR DESCRIPTION
* Found a bug on n9k where 'private-vlan association trunk' does not get cleaned up by 'default interface', which breaks this beaker test

* Created a workaround cleanup method that does 'no switchport'

* No support for private-vlan on 8k

* Tested on N9k-I3