### PR TITLE
normalize_range_array for puppet

### DIFF
--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -19,6 +19,7 @@
 module PuppetX
   module Cisco
     # PuppetX::Cisco::Utils: - Common helper methods shared by any Type/Provider
+    # rubocop:disable Metrics/ClassLength
     class Utils
       require 'ipaddr'
       # Helper utility method for ip/prefix format networks.
@@ -44,6 +45,112 @@ module PuppetX
       def self.flush_boolean?(prop)
         prop.is_a?(TrueClass) || prop.is_a?(FalseClass)
       end
+
+      # normalize_range_array
+      #
+      # Given a list of ranges, merge any overlapping ranges and normalize the
+      # them as a string that can be used directly on the switch.
+      #
+      # Note: The ranges are converted to ruby ranges for easy merging,
+      # then converted back to a cli-syntax ranges.
+      #
+      # Accepts an array or string:
+      #   ["2-5", "9", "4-6"]  -or-  '2-5, 9, 4-6'  -or-  ["2-5, 9, 4-6"]
+      # Returns a merged and ordered range:
+      #   ["2-6", "9"]
+      #
+      def self.normalize_range_array(range)
+        return range if range.nil? || range.empty?
+
+        # This step is puppet only
+        return range if range[0] == :default
+
+        # Handle string within an array: ["2-5, 9, 4-6"] to '2-5, 9, 4-6'
+        range = range.shift if range.is_a?(Array) && range.length == 1
+
+        # Handle string only: '2-5, 9, 4-6' to ["2-5", "9", "4-6"]
+        range = range.split(',') if range.is_a?(String)
+
+        # Convert to ruby-syntax ranges
+        range = dash_range_to_ruby_range(range)
+
+        # Sort & Merge
+        merged = merge_range(range)
+
+        # Convert back to cli dash-syntax
+        ruby_range_to_dash_range(merged)
+      end
+
+      # Convert a cli-dash-syntax range to ruby-range. This is useful for
+      # preparing inputs to merge_range().
+      #
+      # Inputs an array or string of dash-syntax ranges -> returns an array
+      # of ruby ranges.
+      #
+      # Accepts an array or string: ["2-5", "9", "4-6"] or '2-5, 9, 4-6'
+      # Returns an array of ranges: [2..5, 9..9, 4..6]
+      #
+      def self.dash_range_to_ruby_range(range)
+        range = range.split(',') if range.is_a?(String)
+        range.map! do |rng|
+          if rng[/-/]
+            # '2-5' -> 2..5
+            rng.split('-').inject { |a, e| a.to_i..e.to_i }
+          else
+            # '9' -> 9..9
+            rng.to_i..rng.to_i
+          end
+        end
+        range
+      end
+
+      # Convert a ruby-range to cli-dash-syntax.
+      #
+      # Inputs an array of ruby ranges -> returns an array or string of
+      # dash-syntax ranges.
+      #
+      # when (:array)  [2..6, 9..9]  ->  ['2-6', '9']
+      #
+      # when (:string)  [2..6, 9..9]  ->  '2-6, 9'
+      #
+      def self.ruby_range_to_dash_range(range, type=:array)
+        range.map! do |r|
+          if r.first == r.last
+            # 9..9 -> '9'
+            r.first.to_s
+          else
+            # 2..6 -> '2-6'
+            r.first.to_s + '-' + r.last.to_s
+          end
+        end
+        return range.join(', ') if type == :string
+        range
+      end
+
+      # Merge overlapping ranges.
+      #
+      # Inputs an array of ruby ranges:         [2..5, 9..9, 4..6]
+      # Returns an array of merged ruby ranges: [2..6, 9..9]
+      #
+      def self.merge_range(range)
+        # sort to lowest range 'first' values:
+        #    [2..5, 9..9, 4..6]  ->  [2..5, 4..6, 9..9]
+        range = range.sort_by(&:first)
+
+        *merged = range.shift
+        range.each do |r|
+          lastr = merged[-1]
+          if lastr.last >= r.first - 1
+            merged[-1] = lastr.first..[r.last, lastr.last].max
+          else
+            merged.push(r)
+          end
+        end
+        merged
+      end # merge_range
+
+      # TBD: Investigate replacing fail_array_overlap() and range_summarize()
+      # with above methods.
 
       # Helper utility for checking if arrays are overlapping in a
       # give list.
@@ -124,38 +231,7 @@ module PuppetX
         ranges.join(',').gsub('..', '-')
       end
     end # class Utils
-
-    # PuppetX::Cisco::PvlanUtils - Common BGP methods used by BGP Types/Providers
-    class PvlanUtils
-      # This api is used by private vlan to prepare the massage the input.
-      # The input can be in the following formats for vlans:
-      # 10-12,14. Prepare_list api is transforming this input into a flat array.
-      # In the example above the returned array will be 10, 11, 12, 13. Prepare
-      # list is first splitting the input on ',' and the than expanding the vlan
-      # range element like 10-12 into a flat array. The final result will
-      # be a  flat array.
-
-      def self.prepare_list(input)
-        return [] if input.nil? || input.empty?
-        result = []
-        input.gsub!('-', '..')
-        input.gsub!(/\s+/, '')
-        new_list = input.split(',')
-        new_list.each do |member|
-          if member.include?('..')
-            elema = member.split('..').map { |d| Integer(d) }
-            elema.sort!
-            tr = elema[0]..elema[1]
-            tr.to_a.each do |item|
-              result.push(item.to_s)
-            end
-          else
-            result.push(member)
-          end
-        end
-        result
-      end
-    end
+    # rubocop:enable Metrics/ClassLength
 
     # PuppetX::Cisco::BgpUtil - Common BGP methods used by BGP Types/Providers
     class BgpUtils

--- a/tests/beaker_tests/cisco_vlan/test_private_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_private_vlan.rb
@@ -41,20 +41,16 @@ tests = {
 # Skip -ALL- tests if a top-level platform/os key exludes this platform
 skip_unless_supported(tests)
 
-# assoc = %w(99 101 102 105)
 tests[:primary] = {
   desc:           '1.1 Primary',
   title_pattern:  '100',
   manifest_props: {
-    private_vlan_type: 'primary',
-    # private_vlan_association: assoc,
+    private_vlan_type:        'primary',
+    private_vlan_association: '101, 102, 98-99, 105',
   },
   resource:       {
-    private_vlan_type: 'primary',
-    # TBD: BROKEN (idempotence). It inputs a multi-member list but normalizes to a
-    # single index: ['99 100 102 105']. This is wrong but we will keep this
-    # temporarily to show the broken behavior.
-    # private_vlan_association: "#{assoc}",
+    private_vlan_type:        'primary',
+    private_vlan_association: "['98-99', '101-102', '105']",
   },
 }
 
@@ -74,11 +70,17 @@ tests[:isolated] = {
   },
 }
 
+# This method overrides the method in utilitylib.rb to set up dependencies
+# for interface tests.
+def test_harness_dependencies(*)
+  logger.info('  * Process test_harness_dependencies (test_private_vlan)')
+  remove_all_vlans(agent)
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
-  remove_all_vlans(agent)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Property Testing")
   test_harness_run(tests, :primary)


### PR DESCRIPTION
This is the puppet counter-part to NU. The notes below are copied from: https://github.com/cisco/cisco-network-node-utils/pull/400
The main difference between these is a default check in Utils.normalize_range_array and that there's no Utils.dash_range_to_elements since that's not needed in puppet.

* The motivation for this change was finding yet another array normalizer in the private vlan code so these changes are initially meant to address fixes there. IMO our range summarize methods were getting a bit long and difficult to maintain; these new methods will hopefully simplify things somewhat.

  * The main problem these methods are trying to solve is reconciling manifest inputs with getter results when there are overlapping ranges; e.g.:
  * '2-5, 9, 4-6'     needs to be ['2-6', '9']
  * ['2', '3', '4-6'] needs to be ['2-6']
  * ['2', '3', '4']   needs to be ['2-4']

* It's fairly easy to merge the ranges if they are actual ruby ranges instead of the dash-syntax ranges, so the new methods just convert to ruby ranges, merge, and convert back.

* Tested on n9k. Additional testing coming on the other platforms, as well well as demo, Readme, etc.