### PR TITLE
cisco_interface: private_vlan refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Extended `cisco_bgp_af` to include l2vpn/evpn address-family support
 
+- Deprecated `cisco_interface` 'private-vlan' properties and replaced with new methods. The deprecated properties will be removed with release 2.0.0. The old -> new properties are:
+
+| Old Name | New Name(s) |
+|:---|:---:|
+| `private_vlan_mapping`                          | `pvlan_mapping`
+| `switchport_mode_private_vlan_host`             | `switchport_pvlan_host`, `switchport_pvlan_promiscuous`,
+| `switchport_mode_private_vlan_host_association` | `switchport_pvlan_host_association`
+| `switchport_mode_private_vlan_host_promiscous`  | `switchport_pvlan_mapping`
+| `switchport_mode_private_vlan_trunk_promiscuous`| `switchport_pvlan_trunk_promiscuous`
+| `switchport_mode_private_vlan_trunk_secondary`  | `switchport_pvlan_trunk_secondary`
+| `switchport_private_vlan_association_trunk`     | `switchport_pvlan_trunk_association`
+| `switchport_private_vlan_mapping_trunk`         | `switchport_pvlan_mapping_trunk`
+| `switchport_private_vlan_trunk_allowed_vlan`    | `switchport_pvlan_trunk_allowed_vlan`
+| `switchport_private_vlan_trunk_native_vlan`     | `switchport_pvlan_trunk_native_vlan`
+
 ## [1.3.1] - 2016-05-06
 
 ### New feature support

--- a/README.md
+++ b/README.md
@@ -1692,9 +1692,20 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 
 | Property | Caveat Description |
 |:---------|:-------------|
-| `svi_autostate`       | Only supported on N3k,N7k,N9k |
-| `vlan_mapping`        | Only supported on N7k         |
-| `vlan_mapping_enable` | Only supported on N7k         |
+| `pvlan_mapping`                       | Not supported on N8k          |
+| `switchport_pvlan_host`               | Not supported on N8k          |
+| `switchport_pvlan_host_association    | Not supported on N8k          |
+| `switchport_pvlan_mapping`            | Not supported on N8k          |
+| `switchport_pvlan_mapping_trunk`      | Not supported on N3k,N8k      |
+| `switchport_pvlan_promiscuous`        | Not supported on N8k          |
+| `switchport_pvlan_trunk_allowed_vlan` | Not supported on N8k          |
+| `switchport_pvlan_trunk_association`  | Not supported on N3k,N8k      |
+| `switchport_pvlan_trunk_native_vlan`  | Not supported on N8k          |
+| `switchport_pvlan_trunk_promiscuous`  | Not supported on N3k,N8k      |
+| `switchport_pvlan_trunk_secondary`    | Not supported on N3k,N8k      |
+| `svi_autostate`                       | Only supported on N3k,N7k,N9k |
+| `vlan_mapping`                        | Only supported on N7k         |
+| `vlan_mapping_enable`                 | Only supported on N7k         |
 
 #### Parameters
 
@@ -1741,35 +1752,66 @@ interface. Valid value is an integer.
 ##### `switchport_autostate_exclude`
 Exclude this port for the SVI link calculation. Valid values are 'true', 'false', and 'default'.
 
-##### `private_vlan_mapping`
-Private vlan mapping for interface vlan. List of secondary vlans associated to the interface vlan primary.
+##### `pvlan_mapping`
+Maps secondary VLANs to the VLAN interface of a primary VLAN. Valid inputs are a String containing a range of secondary vlans or keyword 'default'.
 
-##### `switchport_mode_private_vlan_host`
-Switchport host mode for private vlan. This a L2 access port. There are two modes: host and promiscous.
+Example: `pvlan_mapping => '3-4,6'`
 
-##### `switchport_mode_private_vlan_host_association`
-This configuration specify which vlans are associated on this port. Host mode only support a pair of vlans: primary and secondary. Valid values are an array of ["primary_vlan", "secondary_vlan"] pairs.
+##### `switchport_pvlan_host`
+Configures a Layer 2 interface as a private VLAN host port. Valid values are 'true', 'false', and 'default'
 
-##### `switchport_mode_private_vlan_host_promisc`
-This configuration specify which vlans are associated on this port. Promiscous mode only support a pair of vlans: primary and secondaries. Valid values are an array of ["primary_vlan", "secondary_vlan"] pairs.
+##### `switchport_pvlan_host_association`
+Associates the Layer 2 host port with the primary and secondary VLANs of a private VLAN. Valid inputs are: An array containing the primary and secondary vlans, or keyword 'default'.
 
-##### `switchport_mode_private_vlan_trunk_promiscuous`
-Switchport trunk promisc mode for private vlan. This a L2 trunk port capable of carrying multiple primary vlans.
+Example: `switchport_pvlan_host_association => ['44', '144']`
 
-##### `switchport_mode_private_vlan_trunk_secondary`
-Switchport trunk secondary mode for private vlan. This a L2 trunk port capable of carrying multiple secondary vlans.
+##### `switchport_pvlan_mapping`
+Associates the specified port with a primary VLAN and a selected list of secondary VLANs. Valid inputs are an array containing both the primary vlan and a range of secondary vlans, or keyword 'default'.
 
-#### `switchport_private_vlan_association_trunk`
-This configuration specify which vlans are associated on this trunk secondary port. Pair of distinguish vlans in the form of primary and secondary are accepted per entry. Valid values are an array of ["primary_vlan", "secondary_vlan"] pairs.
+Example: `switchport_pvlan_mapping => ['44', '3-4,6']`
 
-#### `switchport_private_vlan_mapping_trunk`
-This configuration specify which vlans are associated on this trunk promisc port. Pair of distinguish vlans in the form of primary vlan and secondary vlans (single or range) are accepted per entry. Valid values are an array of ["primary_vlan", "secondary_vlan"] pairs.
+##### `switchport_pvlan_mapping_trunk`
+Maps the promiscuous trunk port with the primary VLAN and a selected list of associated secondary VLANs. Valid inputs are: An array containing both the primary vlan and a range of secondary vlans, a nested array if there are multiple mappings, or keyword 'default'.
 
-#### `switchport_private_vlan_trunk_allowed_vlan`
-This configuration specify which private vlans are associated on this trunk port. Valid values are an array of ["vlan"].
+Examples:
 
-#### `switchport_private_vlan_trunk_native_vlan`
-This configuration specify the native vlan as a private vlan. Valid values are integers.
+```
+ switchport_pvlan_mapping_trunk => [['44', '3-4,6'], ['99', '199']]
+
+   -or-
+
+ switchport_pvlan_mapping_trunk => ['44', '3-4,6']
+```
+
+##### `switchport_pvlan_trunk_allowed_vlan`
+Sets the allowed VLANs for the private VLAN isolated trunk interface. Valid values are a String range of vlans or keyword 'default'.
+
+Example: `switchport_pvlan_trunk_allowed_vlan => '3-4,6'`
+
+##### `switchport_pvlan_trunk_association`
+Associates the Layer 2 isolated trunk port with the primary and secondary VLANs of private VLANs. Valid inputs are: An array containing an association of primary and secondary vlans, a nested array if there are multiple associations, or the keyword 'default'.
+
+Examples:
+
+```
+switchport_pvlan_trunk_association => [['44', '244'], ['45', '245']]
+
+   -or-
+
+switchport_pvlan_trunk_association => ['44', '244']
+```
+
+##### `switchport_pvlan_trunk_native_vlan`
+Sets the native VLAN for the 802.1Q trunk. Valid values are Integer, String, or keyword 'default'.
+
+##### `switchport_pvlan_promiscuous`
+Configures a Layer 2 interface as a private VLAN promiscuous port. Valid values are 'true', 'false', and 'default'.
+
+##### `switchport_pvlan_trunk_promiscuous`
+Configures a Layer 2 interface as a private VLAN promiscuous trunk port. Valid values are 'true', 'false', and 'default'.
+
+##### `switchport_pvlan_trunk_secondary`
+Configures a Layer 2 interface as a private VLAN isolated trunk port. Valid values are 'true', 'false', and 'default'.
 
 ##### `switchport_trunk_allowed_vlan`
 The allowed VLANs for the specified Ethernet interface. Valid values are

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -108,24 +108,39 @@ class ciscopuppet::cisco::demo_interface {
       warning('This platform does not support cisco_bridge_domain')
     }
 
-    # For private vlan
+    # Private-vlan
     if platform_get() =~ /n(3|5|6|7|9)k/ {
       cisco_vlan { '445':
-        ensure     => present,
-        private_vlan_type => 'isolated',
+        ensure                              => present,
+        #pvlan_type                          => 'isolated',
+        private_vlan_type => 'isolated',     # DEPRECATED
       }
       cisco_vlan { '444':
-        ensure     => present,
-        private_vlan_type => 'primary',
-        private_vlan_association => ['445'],
+        ensure                              => present,
+        #pvlan_type                          => 'primary',
+        #pvlan_association                   => ['445'],
+        private_vlan_type  => 'primary',     # DEPRECATED
+        private_vlan_association => ['445'], # DEPRECATED
       }
       cisco_interface { 'Ethernet1/6':
-        description     => 'private_vlan_host_port',
-        switchport_mode_private_vlan_host => 'host',
-        switchport_mode_private_vlan_host_association  => ['444', '445'],
+        description                         => 'Private-vlan Host Port',
+        switchport_pvlan_host               => true,
+        switchport_pvlan_host_association   => [444, 445],
+      }
+      cisco_interface { 'Ethernet1/7':
+        description                         => 'Private-vlan Trunk Port',
+        switchport_pvlan_trunk_secondary    => true,
+        switchport_pvlan_trunk_allowed_vlan => '106,102-103,105',
+        switchport_pvlan_trunk_association  => [[44, 244], [45, 245]],
+        switchport_pvlan_trunk_native_vlan  => 42,
+        switchport_pvlan_mapping_trunk      => [['99', '101,104-105'], ['92', '192']],
+      }
+      cisco_interface { 'vlan29':
+        description                         => 'SVI Private-vlan Mapping',
+        pvlan_mapping                       => '108-109',
       }
     } else {
-      warning('This platform does not support the private vlan feature')
+      warning('This platform does not support the private-vlan feature')
     }
 
     #  Requires F3 or newer linecards

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -31,13 +31,16 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
 
   mk_resource_methods
 
-  # Property symbol arrays for method auto-generation. There are separate arrays
-  # because the boolean-based methods are processed slightly different.
-  # Note: switchport_mode should always process first to evaluate L2 vs L3.
-  # Note: vrf should be the first L3 property to process.  The AutoGen vrf
-  # setter is not used.
+  # Property symbol arrays for getter/setter method auto-generation. Separate
+  # arrays are used to classify different property behaviors and generate
+  # appropriate dynamic methods. Note that some auto-generated methods may be
+  # overridden within this file; e.g. the vrf getter is auto-generated but the
+  # vrf setter is overridden with an explicit method.
+  # Please maintain the properties in alpha order except where noted.
   INTF_NON_BOOL_PROPS = [
+    # Note: :switchport_mode must always process first to evaluate L2 vs L3
     :switchport_mode,
+    # Note: :vrf must be the first L3 property to process
     :vrf,
     :access_vlan,
     :description,
@@ -61,10 +64,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :stp_link_type,
     :stp_port_priority,
     :stp_port_type,
-    :switchport_mode_private_vlan_host,
     :switchport_trunk_allowed_vlan,
     :switchport_trunk_native_vlan,
-    :switchport_private_vlan_trunk_native_vlan,
+    :switchport_pvlan_trunk_native_vlan,
+    :switchport_pvlan_trunk_allowed_vlan,
     :vlan_mapping,
     :vpc_id,
   ]
@@ -77,8 +80,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :negotiate_auto,
     :shutdown,
     :switchport_autostate_exclude,
-    :switchport_mode_private_vlan_trunk_promiscuous,
-    :switchport_mode_private_vlan_trunk_secondary,
+    :switchport_pvlan_host,
+    :switchport_pvlan_promiscuous,
+    :switchport_pvlan_trunk_promiscuous,
+    :switchport_pvlan_trunk_secondary,
     :switchport_vtp,
     :svi_autostate,
     :svi_management,
@@ -86,33 +91,73 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :vpc_peer_link,
   ]
   INTF_ARRAY_FLAT_PROPS = [
-    :private_vlan_mapping,
+    :pvlan_mapping,
     :stp_mst_cost,
     :stp_mst_port_priority,
     :stp_vlan_cost,
     :stp_vlan_port_priority,
-    :switchport_mode_private_vlan_host_association,
-    :switchport_mode_private_vlan_host_promisc,
-    :switchport_private_vlan_association_trunk,
-    :switchport_private_vlan_mapping_trunk,
-    :switchport_private_vlan_trunk_allowed_vlan,
+    :switchport_pvlan_host_association,
+    :switchport_pvlan_mapping,
   ]
-  INTF_ALL_PROPS = INTF_NON_BOOL_PROPS + INTF_BOOL_PROPS + INTF_ARRAY_FLAT_PROPS
 
-  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@interface',
+  INTF_ARRAY_NESTED_PROPS = [
+    :switchport_pvlan_mapping_trunk,
+    :switchport_pvlan_trunk_association,
+  ]
+
+  # TBD: These DEPRECATED arrays will be removed with release 2.0.0
+  DEPRECATED_INTF_FLAT = [
+    :private_vlan_mapping,
+    # Replaced by: pvlan_mapping
+    :switchport_mode_private_vlan_host_association,
+    # Replaced by: switchport_pvlan_host_association
+    :switchport_mode_private_vlan_host_promisc,
+    # Replaced by: switchport_pvlan_mapping,
+    :switchport_private_vlan_trunk_allowed_vlan,
+    # Replaced by: switchport_pvlan_trunk_allowed_vlan,
+    :switchport_private_vlan_association_trunk,
+    # Replaced by: switchport_pvlan_trunk_association
+    :switchport_private_vlan_mapping_trunk,
+    # Replaced by: switchport_pvlan_mapping_trunk
+  ]
+  DEPRECATED_INTF_BOOL = [
+    :switchport_mode_private_vlan_trunk_promiscuous,
+    # Replaced by: switchport_pvlan_trunk_promiscuous,
+    :switchport_mode_private_vlan_trunk_secondary,
+    # Replaced by: switchport_pvlan_trunk_secondary,
+  ]
+  DEPRECATED_INTF_NON_BOOL = [
+    :switchport_mode_private_vlan_host,
+    # Replaced by: switchport_pvlan_host,
+    :switchport_private_vlan_trunk_allowed_vlan,
+    # Replaced by: switchport_pvlan_trunk_allowed_vlan,
+    :switchport_private_vlan_trunk_native_vlan,
+    # Replaced by: switchport_pvlan_trunk_native_vlan,
+  ]
+  INTF_ARRAY_FLAT_PROPS.concat(DEPRECATED_INTF_FLAT)
+  INTF_BOOL_PROPS.concat(DEPRECATED_INTF_BOOL)
+  INTF_NON_BOOL_PROPS.concat(DEPRECATED_INTF_NON_BOOL)
+  # End DEPRECATED
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
                                             INTF_NON_BOOL_PROPS)
-  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@interface',
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@nu',
                                             INTF_BOOL_PROPS)
-  PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_flat, self, '@interface',
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_flat, self, '@nu',
                                             INTF_ARRAY_FLAT_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_nested, self, '@nu',
+                                            INTF_ARRAY_NESTED_PROPS)
+
+  INTF_NON_BOOL_PROPS.concat(INTF_ARRAY_FLAT_PROPS + INTF_ARRAY_NESTED_PROPS)
+  INTF_ALL_PROPS = INTF_NON_BOOL_PROPS + INTF_BOOL_PROPS
 
   def initialize(value={})
     super(value)
-    @interface = Cisco::Interface.interfaces[@property_hash[:name]]
+    @nu = Cisco::Interface.interfaces[@property_hash[:name]]
     @property_flush = {}
   end
 
-  def self.properties_get(interface_name, intf)
+  def self.properties_get(interface_name, nu_obj)
     debug "Checking instance, #{interface_name}."
     current_state = {
       interface: interface_name,
@@ -121,35 +166,26 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     }
     # Call node_utils getter for each property
     INTF_NON_BOOL_PROPS.each do |prop|
-      current_state[prop] = intf.send(prop)
+      current_state[prop] = nu_obj.send(prop)
     end
     INTF_BOOL_PROPS.each do |prop|
-      val = intf.send(prop)
+      val = nu_obj.send(prop)
       if val.nil?
         current_state[prop] = nil
       else
         current_state[prop] = val ? :true : :false
       end
     end
-    INTF_ARRAY_FLAT_PROPS.each do |prop|
-      current_state[prop] = intf.send(prop)
-    end
-    # nested array properties
-    current_state[:vlan_mapping] = intf.vlan_mapping
-    current_state[:stp_mst_cost] = intf.stp_mst_cost
-    current_state[:stp_mst_port_priority] = intf.stp_mst_port_priority
-    current_state[:stp_vlan_cost] = intf.stp_vlan_cost
-    current_state[:stp_vlan_port_priority] = intf.stp_vlan_port_priority
     new(current_state)
   end # self.properties_get
 
   def self.instances
     interfaces = []
-    Cisco::Interface.interfaces.each do |interface_name, intf|
+    Cisco::Interface.interfaces.each do |interface_name, nu_obj|
       begin
         # Not allowed to create an interface for mgmt0 or MgmtEth0/*
         next if interface_name.match(/mgmt/i)
-        interfaces << properties_get(interface_name, intf)
+        interfaces << properties_get(interface_name, nu_obj)
       end
     end
     interfaces
@@ -184,8 +220,8 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
       next unless @resource[prop]
       send("#{prop}=", @resource[prop]) if new_interface
       unless @property_flush[prop].nil?
-        @interface.send("#{prop}=", @property_flush[prop]) if
-          @interface.respond_to?("#{prop}=")
+        @nu.send("#{prop}=", @property_flush[prop]) if
+          @nu.respond_to?("#{prop}=")
       end
     end
     ipv4_addr_mask_set
@@ -206,17 +242,17 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
                   @resource[v4_addr_prop] == :default
 
     if @resource[v4_addr_prop] == :default
-      addr = @interface.default_ipv4_address
+      addr = @nu.default_ipv4_address
     else
       addr = @resource[v4_addr_prop]
     end
 
     if @resource[v4_mask_prop] == :default
-      mask = @interface.default_ipv4_netmask_length
+      mask = @nu.default_ipv4_netmask_length
     else
       mask = @resource[v4_mask_prop]
     end
-    @interface.ipv4_addr_mask_set(addr, mask, secondary)
+    @nu.ipv4_addr_mask_set(addr, mask, secondary)
   end
 
   def ipv4_addr_mask_set
@@ -232,28 +268,28 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
   end
 
   def stp_mst_cost=(should_list)
-    should_list = @interface.default_stp_mst_cost if should_list[0] == :default
+    should_list = @nu.default_stp_mst_cost if should_list[0] == :default
     # check for overlapping arrays in should_list
     PuppetX::Cisco::Utils.fail_array_overlap(should_list)
     @property_flush[:stp_mst_cost] = should_list
   end
 
   def stp_mst_port_priority=(should_list)
-    should_list = @interface.default_stp_mst_port_priority if should_list[0] == :default
+    should_list = @nu.default_stp_mst_port_priority if should_list[0] == :default
     # check for overlapping arrays in should_list
     PuppetX::Cisco::Utils.fail_array_overlap(should_list)
     @property_flush[:stp_mst_port_priority] = should_list
   end
 
   def stp_vlan_cost=(should_list)
-    should_list = @interface.default_stp_vlan_cost if should_list[0] == :default
+    should_list = @nu.default_stp_vlan_cost if should_list[0] == :default
     # check for overlapping arrays in should_list
     PuppetX::Cisco::Utils.fail_array_overlap(should_list)
     @property_flush[:stp_vlan_cost] = should_list
   end
 
   def stp_vlan_port_priority=(should_list)
-    should_list = @interface.default_stp_vlan_port_priority if should_list[0] == :default
+    should_list = @nu.default_stp_vlan_port_priority if should_list[0] == :default
     # check for overlapping arrays in should_list
     PuppetX::Cisco::Utils.fail_array_overlap(should_list)
     @property_flush[:stp_vlan_port_priority] = should_list
@@ -262,7 +298,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
   def vlan_mapping
     return @property_hash[:vlan_mapping] if @resource[:vlan_mapping].nil?
     if @resource[:vlan_mapping][0] == :default &&
-       @property_hash[:vlan_mapping] == @interface.default_vlan_mapping
+       @property_hash[:vlan_mapping] == @nu.default_vlan_mapping
       return [:default]
     else
       @property_hash[:vlan_mapping]
@@ -270,13 +306,13 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
   end
 
   def vlan_mapping=(should_list)
-    should_list = @interface.default_vlan_mapping if should_list[0] == :default
+    should_list = @nu.default_vlan_mapping if should_list[0] == :default
     @property_flush[:vlan_mapping] = should_list
   end
 
   # override vrf setter
   def vrf=(val)
-    val = @interface.default_vrf if val == :default
+    val = @nu.default_vrf if val == :default
     @property_flush[:vrf] = val
 
     # flush other L3 properties because vrf will wipe them out
@@ -294,30 +330,15 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
 
   def flush
     if @property_flush[:ensure] == :absent
-      @interface.destroy
-      @interface = nil
+      @nu.destroy
+      @nu = nil
     else
       # Create/Update
-      if @interface.nil?
+      if @nu.nil?
         new_interface = true
-        @interface = Cisco::Interface.new(@resource[:interface])
+        @nu = Cisco::Interface.new(@resource[:interface])
       end
       properties_set(new_interface)
     end
-    puts_config
   end
-
-  def puts_config
-    if @interface.nil?
-      info "Interface=#{@resource[:interface]} is absent."
-      return
-    end
-
-    # Dump all current properties for this interface
-    current = sprintf("\n%30s: %s", 'interface', @interface.name)
-    INTF_ALL_PROPS.each do |prop|
-      current.concat(sprintf("\n%30s: %s", prop, @interface.send(prop)))
-    end
-    debug current
-  end # puts_config
 end # Puppet::Type

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -1055,9 +1055,11 @@ Puppet::Type.newtype(:cisco_interface) do
     reqs
   end # autorequire vlan
 
-  autorequire(:cisco_vtp) do |rel_catalog|
-    reqs = []
-    reqs << rel_catalog.catalog.resource('Cisco_vtp')
-    reqs # return
-  end # autorequire vtp
+  # TBD: Remove?
+  # autorequire(:cisco_vtp) do |rel_catalog|
+  #   reqs = []
+  #   reqs << rel_catalog.catalog.resource('Cisco_vtp')
+  #   reqs # return
+  #   rel_catalog.catalog.resource('Cisco_vtp', 'default')
+  # end # autorequire vtp
 end # Puppet::Type.newtype

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -59,7 +59,7 @@ module PuppetX
       # Returns a merged and ordered range:
       #   ["2-6", "9"]
       #
-      def self.normalize_range_array(range)
+      def self.normalize_range_array(range, type=:array)
         return range if range.nil? || range.empty?
 
         # This step is puppet only
@@ -78,7 +78,13 @@ module PuppetX
         merged = merge_range(range)
 
         # Convert back to cli dash-syntax
-        ruby_range_to_dash_range(merged)
+        ruby_range_to_dash_range(merged, type)
+      end
+
+      def self.normalize_range_string(range)
+        range = range.to_s
+        return normalize_range_array(range, :string) if range[/[-,]/]
+        range
       end
 
       # Convert a cli-dash-syntax range to ruby-range. This is useful for
@@ -92,6 +98,7 @@ module PuppetX
       #
       def self.dash_range_to_ruby_range(range)
         range = range.split(',') if range.is_a?(String)
+        # [["45", "7-8"], ["46", "9,10"]]
         range.map! do |rng|
           if rng[/-/]
             # '2-5' -> 2..5
@@ -123,7 +130,7 @@ module PuppetX
             r.first.to_s + '-' + r.last.to_s
           end
         end
-        return range.join(', ') if type == :string
+        return range.join(',') if type == :string
         range
       end
 

--- a/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 #
-# 'test_interface_private_vlan' tests private_vlan interface properties.
+# 'test_interface_private_vlan' tests private-vlan interface properties.
 #
 ###############################################################################
 require File.expand_path('../interfacelib.rb', __FILE__)
@@ -51,114 +51,91 @@ tests[:default] = {
   preclean_intf:      true,
   sys_def_switchport: true,
   manifest_props:     {
-    # switchport_mode_private_vlan_host:             no default
-    switchport_mode_private_vlan_host_association:  'default',
-    switchport_mode_private_vlan_trunk_promiscuous: 'default',
-    switchport_mode_private_vlan_trunk_secondary:   'default',
-    # TBD: BROKEN. Should support 'default' but sends literal 'default'
-    # instead of doing default behavior.
-    # switchport_private_vlan_trunk_allowed_vlan:     'default',
-    switchport_private_vlan_association_trunk:      'default',
-    switchport_private_vlan_mapping_trunk:          'default',
-    switchport_private_vlan_trunk_native_vlan:      'default',
+    switchport_pvlan_host:               'default',
+    switchport_pvlan_host_association:   'default',
+    switchport_pvlan_mapping:            'default',
+    switchport_pvlan_mapping_trunk:      'default',
+    switchport_pvlan_promiscuous:        'default',
+    switchport_pvlan_trunk_native_vlan:  'default',
+    switchport_pvlan_trunk_allowed_vlan: 'default',
+    switchport_pvlan_trunk_association:  'default',
+    switchport_pvlan_trunk_promiscuous:  'default',
+    switchport_pvlan_trunk_secondary:    'default',
   },
   resource:           {
-    switchport_mode_private_vlan_host:              'disabled',
-    # switchport_mode_private_vlan_host_association: nil,
-    switchport_mode_private_vlan_trunk_promiscuous: 'false',
-    switchport_mode_private_vlan_trunk_secondary:   'false',
-    # switchport_private_vlan_trunk_allowed_vlan:    nil,
-    # switchport_private_vlan_association_trunk:     nil,
-    # switchport_private_vlan_mapping_trunk:         nil,
-    switchport_private_vlan_trunk_native_vlan:      '1',
+    switchport_pvlan_host:               'false',
+    # switchport_pvlan_host_association:  nil,
+    # switchport_pvlan_mapping:           nil,
+    # switchport_pvlan_mapping_trunk:     nil,
+    switchport_pvlan_promiscuous:        'false',
+    switchport_pvlan_trunk_native_vlan:  '1',
+    switchport_pvlan_trunk_allowed_vlan: 'none',
+    # switchport_pvlan_trunk_association: nil,
+    switchport_pvlan_trunk_promiscuous:  'false',
+    switchport_pvlan_trunk_secondary:    'false',
   },
 }
 
-# allowed = ['100', '102-103', '105']
-assoc = %w(106 107)
-tests[:port_mode_host] = {
-  desc:               '2.1 Port Mode Host',
-  title_pattern:      intf,
-  preclean_intf:      true,
-  sys_def_switchport: true,
-  manifest_props:     {
-    switchport_mode_private_vlan_host:             :host,
-    switchport_mode_private_vlan_host_association: assoc,
-    switchport_private_vlan_trunk_native_vlan:     100,
-    # switchport_private_vlan_trunk_allowed_vlan:    allowed,
+tests[:host] = {
+  desc:           '2.1 Host',
+  title_pattern:  intf,
+  preclean_intf:  true,
+  manifest_props: {
+    switchport_pvlan_host:               true,
+    switchport_pvlan_host_association:   %w(98 99),
+    switchport_pvlan_trunk_allowed_vlan: '106, 105, 102,103',
+    switchport_pvlan_trunk_native_vlan:  42,
   },
-  resource:           {
-    switchport_mode_private_vlan_host:             'host',
-    switchport_mode_private_vlan_host_association: "#{assoc}",
-    switchport_private_vlan_trunk_native_vlan:     '100',
-    # TBD: BROKEN: Idempotence issues. This implementation is broken:
-    #   ['100', '102-103', '105'] vs '100 102-103 105'
-    # Why does it transform from multi-member list to string???
-    # switchport_private_vlan_trunk_allowed_vlan:    "#{allowed}",
+  resource:       {
+    switchport_pvlan_host:               'true',
+    switchport_pvlan_host_association:   %w(98 99),
+    switchport_pvlan_trunk_allowed_vlan: '102-103,105-106',
+    switchport_pvlan_trunk_native_vlan:  '42',
   },
 }
 
-# Clone the test hash above to retest using 'promiscuous' mode
-t = tests[:port_mode_promiscuous] = tests[:port_mode_host].clone
-t[:desc] = '2.2 Port Mode Promiscuous'
-t[:manifest_props][:switchport_mode_private_vlan_host] = :promiscuous
-t[:resource][:switchport_mode_private_vlan_host] = :promiscuous
+tests[:promiscuous] = {
+  desc:           '2.2 Promiscuous',
+  title_pattern:  intf,
+  manifest_props: {
+    switchport_pvlan_promiscuous: true
+  },
+}
 
 tests[:trunk_secondary] = {
-  desc:               '3.1 Trunk Secondary',
-  platform:           'n(5|6|7|9)k',
-  title_pattern:      intf,
-  preclean_intf:      true,
-  sys_def_switchport: true,
-  manifest_props:     {
-    switchport_mode_private_vlan_trunk_secondary: true,
-    switchport_private_vlan_association_trunk:    %w(100 102),
-    switchport_private_vlan_mapping_trunk:        ['100', '101,104-105'],
+  desc:           '3.1 Trunk Secondary',
+  platform:       'n(5|6|7|9)k',
+  title_pattern:  intf,
+  preclean_intf:  true,
+  manifest_props: {
+    switchport_pvlan_trunk_association: [%w(45 245), %w(44 244)],
+    switchport_pvlan_trunk_secondary:   true,
+    switchport_pvlan_mapping_trunk:     [%w(99 101,105,104), %w(92 192)],
   },
-  resource:           {
-    switchport_mode_private_vlan_trunk_secondary: 'true',
-    # TBD: BROKEN. It inputs a multi-member list but normalizes to a
-    # single index? ['100 102'] is wrong but we will keep this temporarily to
-    # show the broken behavior.
-    switchport_private_vlan_association_trunk:    "['100 102']",
-    # TBD: BROKEN. Same as above.
-    switchport_private_vlan_mapping_trunk:        "['100 101,104-105']",
+  resource:       {
+    switchport_pvlan_trunk_association: [%w(44 244), %w(45 245)],
+    switchport_pvlan_trunk_secondary:   'true',
+    switchport_pvlan_mapping_trunk:     [%w(99  101,104-105), %w(92 192)],
   },
 }
+
 tests[:trunk_promiscuous] = {
-  desc:               '3.2 Trunk Promiscuous',
-  platform:           'n(5|6|7|9)k',
-  title_pattern:      intf,
-  preclean_intf:      true,
-  sys_def_switchport: true,
-  manifest_props:     {
-    switchport_mode_private_vlan_trunk_promiscuous: true,
-    switchport_private_vlan_association_trunk:      %w(100 102),
-    switchport_private_vlan_mapping_trunk:          ['100', '101,104-105'],
-  },
-  resource:           {
-    switchport_mode_private_vlan_trunk_promiscuous: 'true',
-    # TBD: BROKEN. It inputs a multi-member list but normalizes to a
-    # single index? ['100 102'] is wrong but we will keep this temporarily to
-    # show the broken behavior.
-    switchport_private_vlan_association_trunk:      "['100 102']",
-    # TBD: BROKEN. Same as above.
-    switchport_private_vlan_mapping_trunk:          "['100 101,104-105']",
+  desc:           '3.2 Trunk Promiscuous',
+  platform:       'n(5|6|7|9)k',
+  title_pattern:  intf,
+  manifest_props: {
+    switchport_pvlan_trunk_promiscuous: true
   },
 }
 
 svi = 'vlan13'
-mapping = %w(108-109)
 tests[:svi_mapping] = {
   desc:           '4.1 SVI Private-Vlan Mapping',
   platform:       'n(5|6|7|9)k',
   title_pattern:  svi,
   preclean_intf:  true,
   manifest_props: {
-    private_vlan_mapping: mapping
-  },
-  resource:       {
-    private_vlan_mapping: "#{mapping}"
+    private_vlan_mapping: %w(108-109)
   },
 }
 
@@ -185,8 +162,8 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Port Mode")
-  test_harness_run(tests, :port_mode_host)
-  test_harness_run(tests, :port_mode_promiscuous)
+  test_harness_run(tests, :host)
+  test_harness_run(tests, :promiscuous)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Trunk Mode")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -273,6 +273,7 @@ def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
       when /cisco_snmp_user/
         next if title[/devops/i]
       when /cisco_vlan/
+        # TBD: Per-vlan cleanup is too slow. Consider 'no vlan 1-4095'
         next if title == '1'
       when /cisco_vrf/
         next if title[/management/]
@@ -810,8 +811,13 @@ end
 # Helper to set properties using the puppet resource command.
 def resource_set(agent, resource, msg='')
   logger.info("\n#{msg}")
-  cmd = "resource #{resource[:name]} '#{resource[:title]}' " \
-                  "#{resource[:property]}='#{resource[:value]}'"
+  if resource.is_a?(Array)
+    cmd =
+      "resource %s '%s' %s='%s'" % resource # rubocop:disable Style/FormatString
+  else
+    cmd = "resource #{resource[:name]} '#{resource[:title]}' "\
+          "#{resource[:property]}='#{resource[:value]}'"
+  end
   cmd = PUPPET_BINPATH + cmd
   on(agent, cmd, acceptable_exit_codes: [0, 2])
 end


### PR DESCRIPTION
* Deprecated the private_vlan properties that were released with 1.3.0 and created new pvlan properties in their place.

* This is the companion to NU PR: cisco/cisco-network-node-utils#406

* Updated Type, Provider, Beaker, Demo, README, and CHANGELOG.

* Currently only tested on N7, N9-i3. Additional testing in prog.
