### PR TITLE
cisco_vlan: pvlan refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Extended `cisco_bgp_af` to include l2vpn/evpn address-family support
 
+- Deprecated `cisco_vlan` 'private-vlan' properties and replaced with new methods. The deprecated properties will be removed with release 2.0.0. The old -> new properties are:
+
+| Old Name | New Name(s) |
+|:---|:---:|
+| `private_vlan_association` | `pvlan_association`
+| `private_vlan_type`        | `pvlan_type`
+
 ## [1.3.1] - 2016-05-06
 
 ### New feature support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Deprecated `cisco_vlan` 'private-vlan' properties and replaced with new methods. The deprecated properties will be removed with release 2.0.0. The old -> new properties are:
 
-| Old Name | New Name(s) |
+| Old Name | New Name |
 |:---|:---:|
 | `private_vlan_association` | `pvlan_association`
 | `private_vlan_type`        | `pvlan_type`

--- a/README.md
+++ b/README.md
@@ -2878,8 +2878,10 @@ Manages a Cisco VLAN.
 
 | Property | Caveat Description |
 |:--------|:-------------|
-| `fabric_control` | Only supported on N7k (support added in ciscopuppet 1.3.0) |
-| `mode`           | Only supported on N5k,N6k,N7k |
+| `fabric_control`    | Only supported on N7k (support added in ciscopuppet 1.3.0) |
+| `mode`              | Only supported on N5k,N6k,N7k |
+| `pvlan_type`        | Not supported on N8k |
+| `pvlan_association` | Not supported on N8k |
 
 #### Parameters
 
@@ -2906,11 +2908,11 @@ State of the VLAN. Valid values are 'active', 'suspend', and keyword 'default'.
 Whether or not the vlan is shutdown. Valid values are 'true', 'false' and
 keyword 'default'.
 
-##### `private_vlan_type`
+##### `pvlan_type`
 The private vlan type. Valid values are 'primary', 'isolated' and 'community'.
 
-##### `private_vlan_association`
-Associate the secondary vlanis to the primary vlan. Valid values are integer like 5,10-12.
+##### `pvlan_association`
+Associate the secondary vlan to the primary vlan. Valid values are integer like 5,10-12.
 
 ##### `fabric_control`
 Specifies this vlan as the fabric control vlan. Only one bridge-domain or VLAN can be configured as fabric-control. Valid values are true, false.

--- a/examples/cisco/demo_vlan.pp
+++ b/examples/cisco/demo_vlan.pp
@@ -24,19 +24,19 @@ class ciscopuppet::cisco::demo_vlan {
     default => undef
   }
   cisco_vlan { '220':
-    ensure          => present,
-    mapped_vni      => $mapped_vni,
-    vlan_name       => 'newtest',
-    shutdown        => true,
-    state           => 'active',
-    fabric_control  => $fabric_control
+    ensure         => present,
+    mapped_vni     => $mapped_vni,
+    vlan_name      => 'newtest',
+    shutdown       => true,
+    state          => 'active',
+    fabric_control => $fabric_control
   }
   # For private vlan
   if platform_get() =~ /n(3|5|6|7|9)k/ {
     cisco_vlan { '333':
-      ensure     => present,
-      private_vlan_type => 'primary',
-      private_vlan_association => ['334,336-339'],
+      ensure            => present,
+      pvlan_type        => 'primary',
+      pvlan_association => ['334,336-339'],
     }
   
   } else {

--- a/lib/puppet/provider/cisco_vlan/cisco.rb
+++ b/lib/puppet/provider/cisco_vlan/cisco.rb
@@ -31,10 +31,24 @@ Puppet::Type.type(:cisco_vlan).provide(:cisco) do
 
   mk_resource_methods
 
-  VLAN_ARRAY_FLAT_PROPS = [:private_vlan_association]
+  VLAN_ARRAY_FLAT_PROPS = [:pvlan_association]
   VLAN_NON_BOOL_PROPS = [:mapped_vni, :mode, :state,
-                         :private_vlan_type, :vlan_name]
+                         :pvlan_type, :vlan_name]
   VLAN_BOOL_PROPS = [:fabric_control, :shutdown]
+
+  # TBD: These DEPRECATED arrays will be removed with release 2.0.0
+  DEPRECATED_VLAN_ARRAY_FLAT = [
+    :private_vlan_association
+    # Replaced by: pvlan_association
+  ]
+  DEPRECATED_VLAN_NON_BOOL = [
+    :private_vlan_type
+    # Replaced by: pvlan_type
+  ]
+  VLAN_ARRAY_FLAT_PROPS.concat(DEPRECATED_VLAN_ARRAY_FLAT)
+  VLAN_NON_BOOL_PROPS.concat(DEPRECATED_VLAN_NON_BOOL)
+  # End DEPRECATED
+
   VLAN_ALL_PROPS = VLAN_ARRAY_FLAT_PROPS + VLAN_NON_BOOL_PROPS + VLAN_BOOL_PROPS
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@vlan',

--- a/lib/puppet/type/cisco_vlan.rb
+++ b/lib/puppet/type/cisco_vlan.rb
@@ -40,8 +40,8 @@ Puppet::Type.newtype(:cisco_vlan) do
       mapped_vni => 20000,
       state      => 'active',
       shutdown   => 'true',
-      private_vlan_type => 'primary',
-      private_vlan_association => ['101-104']
+      pvlan_type => 'primary',
+      pvlan_association => ['101-104']
       fabric_control   => 'true',
     }"
 
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:cisco_vlan) do
       :default)
   end # property shutdown
 
-  newproperty(:private_vlan_type) do
+  newproperty(:pvlan_type) do
     desc 'The private vlan type for VLAN. Valid values are string
           primary, isolated, community'
 
@@ -169,9 +169,9 @@ Puppet::Type.newtype(:cisco_vlan) do
       end # rescue
       value
     end
-  end # property private_vlan_type
+  end # property pvlan_type
 
-  newproperty(:private_vlan_association, array_matching: :all) do
+  newproperty(:pvlan_association, array_matching: :all) do
     valid = %(
       Valid values are an Array or String of vlan ranges, or keyword 'default'.
       Examples: ['2-5, 9'] or '2-5, 9'
@@ -193,7 +193,7 @@ Puppet::Type.newtype(:cisco_vlan) do
       normal = PuppetX::Cisco::Utils.normalize_range_array(should)
       (is.size == normal.size && is.sort == normal.sort)
     end
-  end # property private_vlan_association
+  end # property pvlan_association
 
   newproperty(:fabric_control) do
     desc %(Specifies this VLAN as the fabric control VLAN. Only one bridge-domain or VLAN can be configured as fabric-control.
@@ -204,4 +204,61 @@ Puppet::Type.newtype(:cisco_vlan) do
       :false,
       :default)
   end # property fabric_control
+
+  #############################################################################
+  #                                                                           #
+  #                         DEPRECATED PROPERTIES Start                       #
+  #                                                                           #
+  #############################################################################
+
+  newproperty(:private_vlan_type) do
+    dep = %(## -DEPRECATED- ## Property. Replace with: 'pvlan_type')
+    desc dep
+    valid_input = %w(primary isolated community)
+
+    validate do |value|
+      fail dep unless value.kind_of? String
+
+      unless valid_input.include?(value) ||
+             value == 'default' || value == :default
+        fail dep
+      end
+    end
+
+    munge do |value|
+      begin
+        value = :default if value == 'default'
+        value = String(value) unless value == :default
+      rescue
+        raise 'Type is not a valid string.'
+      end # rescue
+      value
+    end
+  end # property private_vlan_type
+
+  newproperty(:private_vlan_association, array_matching: :all) do
+    dep = %(## -DEPRECATED- ## Property. Replace with: 'pvlan_association')
+    desc dep
+    validate do |value|
+      fail dep unless
+        value == 'default' ||
+        /^(\s*\d+\s*[-,\d\s]*\d+\s*)$/.match(value).to_s == value
+    end
+
+    munge do |value|
+      value == 'default' ? :default : value.to_s.gsub(/\s+/, '')
+    end
+
+    def insync?(is)
+      # Summarize the manifest ranges before comparing.
+      normal = PuppetX::Cisco::Utils.normalize_range_array(should)
+      (is.size == normal.size && is.sort == normal.sort)
+    end
+  end # property private_vlan_association
+
+  #############################################################################
+  #                                                                           #
+  #                         DEPRECATED PROPERTIES End                         #
+  #                                                                           #
+  #############################################################################
 end # Puppet::Type.newtype

--- a/tests/beaker_tests/cisco_vlan/test_private_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_private_vlan.rb
@@ -45,12 +45,12 @@ tests[:primary] = {
   desc:           '1.1 Primary',
   title_pattern:  '100',
   manifest_props: {
-    private_vlan_type:        'primary',
-    private_vlan_association: '101, 102, 98-99, 105',
+    pvlan_type:        'primary',
+    pvlan_association: '101, 102, 98-99, 105',
   },
   resource:       {
-    private_vlan_type:        'primary',
-    private_vlan_association: "['98-99', '101-102', '105']",
+    pvlan_type:        'primary',
+    pvlan_association: "['98-99', '101-102', '105']",
   },
 }
 
@@ -58,7 +58,7 @@ tests[:community] = {
   desc:           '1.2 Community',
   title_pattern:  '100',
   manifest_props: {
-    private_vlan_type: 'community'
+    pvlan_type: 'community'
   },
 }
 
@@ -66,7 +66,7 @@ tests[:isolated] = {
   desc:           '1.3 Isolated',
   title_pattern:  '100',
   manifest_props: {
-    private_vlan_type: 'isolated'
+    pvlan_type: 'isolated'
   },
 }
 


### PR DESCRIPTION
This PR is for refactoring private-vlan types in cisco_vlan provider. Only private_vlan_type and private_vlan_association are changed to pvlan_tupe and pvlan_association.

Tested on n3k, n6k, n7k, n8k and n9k. All demo_manifests and beaker tests passed.