### PR TITLE
modifications for snmp_notification on IOS_XR

### DIFF
--- a/lib/puppet/provider/snmp_notification/cisco.rb
+++ b/lib/puppet/provider/snmp_notification/cisco.rb
@@ -55,6 +55,9 @@ Puppet::Type.type(:snmp_notification).provide(:cisco) do
   end
 
   def flush
+    if @snmpnotification.nil?
+      @snmpnotification = Cisco::SnmpNotification.new(@resource[:name])
+    end
     enable = @resource[:enable] == :true ? true : false
     @snmpnotification.enable = enable if @resource[:enable]
   end

--- a/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb
@@ -66,7 +66,7 @@ test_name "TestCase :: #{testheader}" do
     logger.info('Setup switch for provider')
 
     # Make sure radius server is not configured before test starts.
-    on(master, SnmpNotificationLib.create_absent)
+    on(master, SnmpNotificationLib.create_absent(operating_system))
 
     # Expected exit_code is 0,2 since server may or may not be configured.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -75,7 +75,7 @@ test_name "TestCase :: #{testheader}" do
 
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpNotificationLib.create_defaults)
+    on(master, SnmpNotificationLib.create_defaults(operating_system))
 
     # Expected exit_code is 0 since this is a puppet agent cmd with no change.
     # Or expected exit_code is 2 since this is a puppet agent cmd with change.
@@ -86,23 +86,24 @@ test_name "TestCase :: #{testheader}" do
   end
 
   # @step [Step] Checks snmp_notification resource on agent using resource cmd.
-  step 'TestStep :: Check snmp_notification resource absent on agent' do
-    # Expected exit_code is 0 since this is a puppet resource cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = PUPPET_BINPATH + "resource snmp_notification 'aaa server-state-change'"
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'enable' => 'false' },
-                               false, self, logger)
+  unless operating_system == 'ios_xr'
+    step 'TestStep :: Check snmp_notification resource absent on agent' do
+      # Expected exit_code is 0 since this is a puppet resource cmd.
+      # Flag is set to false to check for presence of RegExp pattern in stdout.
+      cmd_str = PUPPET_BINPATH + "resource snmp_notification 'aaa server-state-change'"
+      on(agent, cmd_str) do
+        search_pattern_in_output(stdout,
+                                 { 'enable' => 'false' },
+                                 false, self, logger)
+      end
+
+      logger.info("Check snmp_notification resource absent on agent :: #{result}")
     end
-
-    logger.info("Check snmp_notification resource absent on agent :: #{result}")
   end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpNotificationLib.create_non_defaults)
+    on(master, SnmpNotificationLib.create_non_defaults(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -115,7 +116,11 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check snmp_notification resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = PUPPET_BINPATH + "resource snmp_notification 'aaa server-state-change'"
+    if operating_system == 'ios_xr'
+      cmd_str = PUPPET_BINPATH + "resource snmp_notification 'ntp'"
+    else
+      cmd_str = PUPPET_BINPATH + "resource snmp_notification 'aaa server-state-change'"
+    end
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'enable' => 'true' },

--- a/tests/beaker_tests/netdev_stdlib/snmp_notificationlib.rb
+++ b/tests/beaker_tests/netdev_stdlib/snmp_notificationlib.rb
@@ -37,36 +37,60 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 module SnmpNotificationLib
   # A. Methods to create manifests for snmp_notification Puppet provider test cases.
 
-  def self.create_absent
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_absent(type)
+    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_notification { 'aaa server-state-change':
     enable => false,
   }
 }
 EOF"
-    manifest_str
+
+    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'ntp':
+    enable => false,
+  }
+}
+EOF"
+    type == 'ios_xr' ? ios_xr_str : nxos_str
   end
 
-  def self.create_defaults
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_defaults(type)
+    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_notification { 'aaa server-state-change':
     enable => false,
   }
 }
 EOF"
-    manifest_str
+
+    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'ntp':
+    enable => false,
+  }
+}
+EOF"
+    type == 'ios_xr' ? ios_xr_str : nxos_str
   end
 
-  def self.create_non_defaults
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_non_defaults(type)
+    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_notification { 'aaa server-state-change':
     enable => true,
   }
 }
 EOF"
-    manifest_str
+
+    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_notification { 'ntp':
+    enable => true,
+  }
+}
+EOF"
+    type == 'ios_xr' ? ios_xr_str : nxos_str
   end
 end


### PR DESCRIPTION
tests/beaker_tests/netdev_stdlib/snmp_notification_provider_defaults.rb passed in 64.67 seconds
      Test Suite: tests @ 2016-05-31 15:24:59 +0100

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 64.67 seconds
      Average Test Time: 64.67 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
Pending Tests Cases:

No tests to run for suite 'post_suite'
No tests to run for suite 'pre_cleanup'
Cleanup: cleaning up after successful run
Warning: ssh connection to master has been terminated
Warning: ssh connection to exr has been terminated
