### PR TITLE
Misc test_interface fixes

### DIFF
--- a/tests/beaker_tests/cisco_interface/interfacelib.rb
+++ b/tests/beaker_tests/cisco_interface/interfacelib.rb
@@ -51,7 +51,7 @@ def config_anycast_gateway_mac?(tests, id)
   # TBD: Consider creating a resource_get to avoid vsh calls
   on(agent, get_vshell_cmd('show runn fabric forwarding'), pty: true)
 
-  return unless stdout[/anycast-gateway-mac/]
+  return if stdout[/anycast-gateway-mac/]
   cmd = ['cisco_overlay_global', 'default', 'anycast_gateway_mac', '1.1.1']
   resource_set(agent, cmd, 'fabric forwarding anycast-gateway-mac 1.1.1')
 end

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -133,6 +133,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   interface_cleanup(agent, intf)
+  system_default_switchport(agent, false)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface/test_interface_svi.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_svi.rb
@@ -95,13 +95,6 @@ tests[:anycast] = {
   },
 }
 
-resource_cisco_overlay_global = {
-  name:     'cisco_overlay_global',
-  title:    'default',
-  property: 'anycast_gateway_mac',
-  value:    '1.1.1',
-}
-
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
@@ -114,9 +107,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :default_autostate)
   test_harness_run(tests, :non_default_autostate)
 
-  # :anycast test requires anycast_gateway_mac to be set.
-  resource_set(agent, resource_cisco_overlay_global,
-               'Overlay Global mac setup')
   test_harness_run(tests, :anycast)
 
   # -------------------------------------------------------------------


### PR DESCRIPTION
* test_interface_L2 should reset sys_def_switchport
  * This test sets the system default switchport state to true but it should reset it to false when it's finished.

* Remove explicit anycast config
  * anycast-gateway-mac is a required dependency; a recent commit added an explicit call to the test file to set this up; BUT we already had existing code for doing this that was part of interfacelib.rb

  * The interfacelib code was returning early because of /unless/if/

* Tested on n9-i4
