### PR TITLE
cisco_bfd_global provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### New feature support
+#### Cisco Resources
+- `cisco_bfd_global` type and provider.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ BFD fabricpath control vlan.  Valid values are integer, and 'default'.
 ##### `interval`
 BFD interval.  Valid values are an array of [interval, min_rx, multiplier] or 'default'.
 
-Example: `fabricpath_interval => [100, 120, 4]`
+Example: `interval => [100, 120, 4]`
 
 ##### `ipv4_echo_rx_interval`
 IPv4 session echo receive interval in milliseconds.  Valid values are integer, and 'default'.
@@ -951,7 +951,7 @@ IPv4 session echo receive interval in milliseconds.  Valid values are integer, a
 ##### `ipv4_interval`
 BFD IPv4 session interval.  Valid values are an array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier] or 'default'.
 
-Example: `fabricpath_interval => [100, 120, 4]`
+Example: `ipv4_interval => [100, 120, 4]`
 
 ##### `ipv4_slow_timer`
 BFD IPv4 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.
@@ -962,7 +962,7 @@ IPv6 session echo receive interval in milliseconds.  Valid values are integer, a
 ##### `ipv6_interval`
 BFD IPv6 session interval.  Valid values are an array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier] or 'default'.
 
-Example: `fabricpath_interval => [100, 120, 4]`
+Example: `ipv6_interval => [100, 120, 4]`
 
 ##### `ipv6_slow_timer`
 BFD IPv6 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.

--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ Manages configuration of a BFD (Bidirectional Forwarding Detection) instance.
 | N5k      | 7.3(0)N1(1)        | 1.4.0                  |
 | N6k      | 7.3(0)N1(1)        | 1.4.0                  |
 | N7k      | 7.3(0)D1(1)        | 1.4.0                  |
+| N8k      | 7.3(0)F1(1)        | 1.4.0                  |
 
 #### <a name="cisco_bfd_global-caveats">Caveats</a>
 
@@ -930,6 +931,9 @@ Echo receive interval in milliseconds.  Valid values are integer, and 'default'.
 
 ##### `fabricpath_interval`
 BFD fabricpath interval.  Valid values are an array of [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier] or 'default'.
+Example
+:--
+`fabricpath_interval => [100, 120, 4]`
 
 ##### `fabricpath_slow_timer`
 BFD fabricpath slow rate timer in milliseconds.  Valid values are integer, and 'default'.
@@ -939,12 +943,18 @@ BFD fabricpath control vlan.  Valid values are integer, and 'default'.
 
 ##### `interval`
 BFD interval.  Valid values are an array of [interval, min_rx, multiplier] or 'default'.
+Example
+:--
+`interval => [100, 120, 4]`
 
 ##### `ipv4_echo_rx_interval`
 IPv4 session echo receive interval in milliseconds.  Valid values are integer, and 'default'.
 
 ##### `ipv4_interval`
 BFD IPv4 session interval.  Valid values are an array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier] or 'default'.
+Example
+:--
+`ipv4_interval => [100, 120, 4]`
 
 ##### `ipv4_slow_timer`
 BFD IPv4 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.
@@ -954,6 +964,9 @@ IPv6 session echo receive interval in milliseconds.  Valid values are integer, a
 
 ##### `ipv6_interval`
 BFD IPv6 session interval.  Valid values are an array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier] or 'default'.
+Example
+:--
+`ipv6_interval => [100, 120, 4]`
 
 ##### `ipv6_slow_timer`
 BFD IPv6 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.

--- a/README.md
+++ b/README.md
@@ -931,9 +931,8 @@ Echo receive interval in milliseconds.  Valid values are integer, and 'default'.
 
 ##### `fabricpath_interval`
 BFD fabricpath interval.  Valid values are an array of [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier] or 'default'.
-Example
-:--
-`fabricpath_interval => [100, 120, 4]`
+
+Example: `fabricpath_interval => [100, 120, 4]`
 
 ##### `fabricpath_slow_timer`
 BFD fabricpath slow rate timer in milliseconds.  Valid values are integer, and 'default'.
@@ -943,18 +942,16 @@ BFD fabricpath control vlan.  Valid values are integer, and 'default'.
 
 ##### `interval`
 BFD interval.  Valid values are an array of [interval, min_rx, multiplier] or 'default'.
-Example
-:--
-`interval => [100, 120, 4]`
+
+Example: `fabricpath_interval => [100, 120, 4]`
 
 ##### `ipv4_echo_rx_interval`
 IPv4 session echo receive interval in milliseconds.  Valid values are integer, and 'default'.
 
 ##### `ipv4_interval`
 BFD IPv4 session interval.  Valid values are an array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier] or 'default'.
-Example
-:--
-`ipv4_interval => [100, 120, 4]`
+
+Example: `fabricpath_interval => [100, 120, 4]`
 
 ##### `ipv4_slow_timer`
 BFD IPv4 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.
@@ -964,9 +961,8 @@ IPv6 session echo receive interval in milliseconds.  Valid values are integer, a
 
 ##### `ipv6_interval`
 BFD IPv6 session interval.  Valid values are an array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier] or 'default'.
-Example
-:--
-`ipv6_interval => [100, 120, 4]`
+
+Example: `fabricpath_interval => [100, 120, 4]`
 
 ##### `ipv6_slow_timer`
 BFD IPv6 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A note about support for specific platform models:
 | [cisco_acl](#type-cisco_acl)                               | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [cisco_ace](#type-cisco_ace)                               | ✅  | ✅  | ✅* | ✅* | ✅* | \*[caveats](#cisco_ace-caveats) |
 | [cisco_command_config](#type-cisco_command_config)         | ✅  | ✅  | ✅  | ✅  | ✅  |
+| [cisco_bfd_global](#type-cisco_bfd_global)                 | ✅* | ✅* | ✅* | ✅* | ✅* | \*[caveats](#cisco_bfd_global-caveats) |
 | [cisco_bgp](#type-cisco_bgp)                               | ✅  | ✅  | ✅* | ✅* | ✅* | \*[caveats](#cisco_bgp-caveats) |
 | [cisco_bgp_af](#type-cisco_bgp_af)                         | ✅* | ✅* | ✅  | ✅* | ✅  | \*[caveats](#cisco_bgp_af-caveats) |
 | [cisco_bgp_neighbor](#type-cisco_bgp_neighbor)             | ✅  | ✅  | ✅  | ✅  | ✅  |
@@ -231,6 +232,9 @@ The following resources include cisco types and providers along with cisco provi
 * ACL Types
   * [`cisco_ace`](#type-cisco_ace)
   * [`cisco_acl`](#type-cisco_acl)
+
+* BFD Types
+  * [`cisco_bfd_global`](#type-cisco_bfd_global)
 
 * BGP Types
   * [`cisco_vrf`](#type-cisco_vrf)
@@ -354,6 +358,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`cisco_aaa_group_tacacs`](#type-cisco_aaa_group_tacacs)
 * [`cisco_acl`](#type-cisco_acl)
 * [`cisco_ace`](#type-cisco_ace)
+* [`cisco_bfd_global`](#type-cisco_bfd_global)
 * [`cisco_bgp`](#type-cisco_bgp)
 * [`cisco_bgp_af`](#type-cisco_bgp_af)
 * [`cisco_bgp_neighbor`](#type-cisco_bgp_neighbor)
@@ -881,6 +886,83 @@ Allows matching based on Time-To-Live (TTL) value. Valid values are type Integer
 | Example
 |:--
 | `ttl => '128'`
+
+--
+### Type: cisco_bfd_global
+
+Manages configuration of a BFD (Bidirectional Forwarding Detection) instance.
+
+| Platform | OS Minimum Version | Module Minimum Version |
+|----------|:------------------:|:----------------------:|
+| N9k      | 7.0(3)I3(1)        | 1.4.0                  |
+| N3k      | 7.0(3)I3(1)        | 1.4.0                  |
+| N5k      | 7.3(0)N1(1)        | 1.4.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.4.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.4.0                  |
+
+#### <a name="cisco_bfd_global-caveats">Caveats</a>
+
+| Property | Caveat Description |
+|:--------|:-------------|
+| `echo_rx_interval`      | Not supported on N5k, N6k      |
+| `fabricpath_interval`   | Not supported on N3k, N8k, N9k |
+| `fabricpath_slow_timer` | Not supported on N3k, N8k, N9k |
+| `fabricpath_vlan`       | Not supported on N3k, N8k, N9k |
+| `interval`              | Not supported on N8k, N9k      |
+| `ipv4_echo_rx_interval` | Not supported on N5k, N6k      |
+| `ipv4_interval`         | Not supported on N5k, N6k      |
+| `ipv4_slow_timer`       | Not supported on N5k, N6k      |
+| `ipv6_echo_rx_interval` | Not supported on N5k, N6k      |
+| `ipv6_interval`         | Not supported on N5k, N6k      |
+| `ipv6_slow_timer`       | Not supported on N5k, N6k      |
+| `startup_timer`         | Not supported on N5k, N6k, N7k |
+
+#### Parameters
+
+##### `ensure`
+Determines whether the config should be present or not on the device. Valid values are 'present' and 'absent'.
+
+##### `echo_interface`
+Loopback interface used for echo frames.  Valid values are String, and 'default'.
+
+##### `echo_rx_interval`
+Echo receive interval in milliseconds.  Valid values are integer, and 'default'.
+
+##### `fabricpath_interval`
+BFD fabricpath interval.  Valid values are an array of [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier] or 'default'.
+
+##### `fabricpath_slow_timer`
+BFD fabricpath slow rate timer in milliseconds.  Valid values are integer, and 'default'.
+
+##### `fabricpath_vlan`
+BFD fabricpath control vlan.  Valid values are integer, and 'default'.
+
+##### `interval`
+BFD interval.  Valid values are an array of [interval, min_rx, multiplier] or 'default'.
+
+##### `ipv4_echo_rx_interval`
+IPv4 session echo receive interval in milliseconds.  Valid values are integer, and 'default'.
+
+##### `ipv4_interval`
+BFD IPv4 session interval.  Valid values are an array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier] or 'default'.
+
+##### `ipv4_slow_timer`
+BFD IPv4 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.
+
+##### `ipv6_echo_rx_interval`
+IPv6 session echo receive interval in milliseconds.  Valid values are integer, and 'default'.
+
+##### `ipv6_interval`
+BFD IPv6 session interval.  Valid values are an array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier] or 'default'.
+
+##### `ipv6_slow_timer`
+BFD IPv6 session slow rate timer in milliseconds.  Valid values are integer, and 'default'.
+
+##### `slow_timer`
+BFD slow rate timer in milliseconds.  Valid values are integer, and 'default'.
+
+##### `startup_timer`
+BFD delayed startup timer in seconds.  Valid values are integer, and 'default'.
 
 --
 ### Type: cisco_bgp

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -1,0 +1,146 @@
+# Manifest to demo cisco_interface provider
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ciscopuppet::cisco::demo_bfd {
+
+  $echo_rx_interval = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 300,
+    default => undef
+  }
+
+  $fabricpath_interval = platform_get() ? {
+    /(n5k|n6k|n7k)/ => 750,
+    default => undef
+  }
+
+  $fabricpath_min_rx = platform_get() ? {
+    /(n5k|n6k|n7k)/ => 350,
+    default => undef
+  }
+
+  $fabricpath_multiplier = platform_get() ? {
+    /(n5k|n6k|n7k)/ => 45,
+    default => undef
+  }
+
+  $fabricpath_slow_timer = platform_get() ? {
+    /(n5k|n6k|n7k)/ => 15000,
+    default => undef
+  }
+
+  $fabricpath_vlan = platform_get() ? {
+    /(n5k|n6k|n7k)/ => 100,
+    default => undef
+  }
+
+  # To be removed later
+  $interval = platform_get() ? {
+    /(n3k|n5k|n6k|n7k)/ => 100,
+    default => undef
+  }
+
+  $ipv4_echo_rx_interval = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 100,
+    default => undef
+  }
+
+  $ipv4_interval = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 200,
+    default => undef
+  }
+
+  $ipv4_min_rx = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 200,
+    default => undef
+  }
+
+  $ipv4_multiplier = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 50,
+    default => undef
+  }
+
+  $ipv4_slow_timer = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 10000,
+    default => undef
+  }
+
+  $ipv6_echo_rx_interval = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 200,
+    default => undef
+  }
+
+  $ipv6_interval = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 500,
+    default => undef
+  }
+
+  $ipv6_min_rx = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 500,
+    default => undef
+  }
+
+  $ipv6_multiplier = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 30,
+    default => undef
+  }
+
+  $ipv6_slow_timer = platform_get() ? {
+    /(n3k|n7k|n8k|n9k)/ => 25000,
+    default => undef
+  }
+
+  # To be removed later
+  $min_rx = platform_get() ? {
+    /(n3k|n5k|n6k|n7k)/ => 100,
+    default => undef
+  }
+
+  # To be removed later
+  $multiplier = platform_get() ? {
+    /(n3k|n5k|n6k|n7k)/ => 25,
+    default => undef
+  }
+
+  $startup_timer = platform_get() ? {
+    /(n3k|n8k|n9k)/ => 25,
+    default => undef
+  }
+
+  cisco_bfd_global { 'default':
+    echo_interface        => 10,
+    echo_rx_interval      => $echo_rx_interval,
+    fabricpath_interval   => $fabricpath_interval,
+    fabricpath_min_rx     => $fabricpath_min_rx,
+    fabricpath_multiplier => $fabricpath_multiplier,
+    fabricpath_slow_timer => $fabricpath_slow_timer,
+    fabricpath_vlan       => $fabricpath_vlan,
+    interval              => $interval,
+    ipv4_echo_rx_interval => $ipv4_echo_rx_interval,
+    ipv4_interval         => $ipv4_interval,
+    ipv4_min_rx           => $ipv4_min_rx,
+    ipv4_multiplier       => $ipv4_multiplier,
+    ipv4_slow_timer       => $ipv4_slow_timer,
+    ipv6_echo_rx_interval => $ipv6_echo_rx_interval,
+    ipv6_interval         => $ipv6_interval,
+    ipv6_min_rx           => $ipv6_min_rx,
+    ipv6_multiplier       => $ipv6_multiplier,
+    ipv6_slow_timer       => $ipv6_slow_timer,
+    min_rx                => $min_rx,
+    multiplier            => $multiplier,
+    slow_timer            => 5000,
+    startup_timer         => $startup_timer,
+  }
+}

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -71,6 +71,10 @@ class ciscopuppet::cisco::demo_bfd {
     default => undef
   }
 
+  cisco_interface { 'loopback10':
+      ensure => present,
+    }
+
   cisco_bfd_global { 'default':
     ensure                => 'present',
     echo_interface        => 10,

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -36,6 +36,11 @@ class ciscopuppet::cisco::demo_bfd {
     default => undef
   }
 
+  $interval = platform_get() ? {
+    /(n3k|n5k|n6k|n7k)/ => ['100', '100', '25'],
+    default => undef
+  }
+
   $ipv4_echo_rx_interval = platform_get() ? {
     /(n3k|n7k|n8k|n9k)/ => 100,
     default => undef
@@ -73,16 +78,16 @@ class ciscopuppet::cisco::demo_bfd {
 
   cisco_interface { 'loopback10':
       ensure => present,
-    }
+  }
 
   cisco_bfd_global { 'default':
     ensure                => 'present',
-    echo_interface        => 10,
+    echo_interface        => 'loopback10',
     echo_rx_interval      => $echo_rx_interval,
     fabricpath_interval   => $fabricpath_interval,
     fabricpath_slow_timer => $fabricpath_slow_timer,
     fabricpath_vlan       => $fabricpath_vlan,
-    interval              => ['100', '100', '25'],
+    interval              => $interval,
     ipv4_echo_rx_interval => $ipv4_echo_rx_interval,
     ipv4_interval         => $ipv4_interval,
     ipv4_slow_timer       => $ipv4_slow_timer,

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -36,6 +36,7 @@ class ciscopuppet::cisco::demo_bfd {
     default => undef
   }
 
+  # TBD: this is due to a bug on n8k and n9k
   $interval = platform_get() ? {
     /(n3k|n5k|n6k|n7k)/ => ['100', '100', '25'],
     default => undef

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -22,17 +22,7 @@ class ciscopuppet::cisco::demo_bfd {
   }
 
   $fabricpath_interval = platform_get() ? {
-    /(n5k|n6k|n7k)/ => 750,
-    default => undef
-  }
-
-  $fabricpath_min_rx = platform_get() ? {
-    /(n5k|n6k|n7k)/ => 350,
-    default => undef
-  }
-
-  $fabricpath_multiplier = platform_get() ? {
-    /(n5k|n6k|n7k)/ => 45,
+    /(n5k|n6k|n7k)/ => ['750', '350', '35'],
     default => undef
   }
 
@@ -46,29 +36,13 @@ class ciscopuppet::cisco::demo_bfd {
     default => undef
   }
 
-  # To be removed later
-  $interval = platform_get() ? {
-    /(n3k|n5k|n6k|n7k)/ => 100,
-    default => undef
-  }
-
   $ipv4_echo_rx_interval = platform_get() ? {
     /(n3k|n7k|n8k|n9k)/ => 100,
     default => undef
   }
 
   $ipv4_interval = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 200,
-    default => undef
-  }
-
-  $ipv4_min_rx = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 200,
-    default => undef
-  }
-
-  $ipv4_multiplier = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 50,
+    /(n3k|n7k|n8k|n9k)/ => ['200', '200', '50'],
     default => undef
   }
 
@@ -83,34 +57,12 @@ class ciscopuppet::cisco::demo_bfd {
   }
 
   $ipv6_interval = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 500,
-    default => undef
-  }
-
-  $ipv6_min_rx = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 500,
-    default => undef
-  }
-
-  $ipv6_multiplier = platform_get() ? {
-    /(n3k|n7k|n8k|n9k)/ => 30,
+    /(n3k|n7k|n8k|n9k)/ => ['500', '500', '30'],
     default => undef
   }
 
   $ipv6_slow_timer = platform_get() ? {
     /(n3k|n7k|n8k|n9k)/ => 25000,
-    default => undef
-  }
-
-  # To be removed later
-  $min_rx = platform_get() ? {
-    /(n3k|n5k|n6k|n7k)/ => 100,
-    default => undef
-  }
-
-  # To be removed later
-  $multiplier = platform_get() ? {
-    /(n3k|n5k|n6k|n7k)/ => 25,
     default => undef
   }
 
@@ -123,23 +75,15 @@ class ciscopuppet::cisco::demo_bfd {
     echo_interface        => 10,
     echo_rx_interval      => $echo_rx_interval,
     fabricpath_interval   => $fabricpath_interval,
-    fabricpath_min_rx     => $fabricpath_min_rx,
-    fabricpath_multiplier => $fabricpath_multiplier,
     fabricpath_slow_timer => $fabricpath_slow_timer,
     fabricpath_vlan       => $fabricpath_vlan,
-    interval              => $interval,
+    interval              => ['100', '100', '25'],
     ipv4_echo_rx_interval => $ipv4_echo_rx_interval,
     ipv4_interval         => $ipv4_interval,
-    ipv4_min_rx           => $ipv4_min_rx,
-    ipv4_multiplier       => $ipv4_multiplier,
     ipv4_slow_timer       => $ipv4_slow_timer,
     ipv6_echo_rx_interval => $ipv6_echo_rx_interval,
     ipv6_interval         => $ipv6_interval,
-    ipv6_min_rx           => $ipv6_min_rx,
-    ipv6_multiplier       => $ipv6_multiplier,
     ipv6_slow_timer       => $ipv6_slow_timer,
-    min_rx                => $min_rx,
-    multiplier            => $multiplier,
     slow_timer            => 5000,
     startup_timer         => $startup_timer,
   }

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -72,6 +72,7 @@ class ciscopuppet::cisco::demo_bfd {
   }
 
   cisco_bfd_global { 'default':
+    ensure                => 'present',
     echo_interface        => 10,
     echo_rx_interval      => $echo_rx_interval,
     fabricpath_interval   => $fabricpath_interval,

--- a/examples/cisco/demo_bfd.pp
+++ b/examples/cisco/demo_bfd.pp
@@ -76,8 +76,8 @@ class ciscopuppet::cisco::demo_bfd {
     default => undef
   }
 
-  cisco_interface { 'loopback10':
-      ensure => present,
+  cisco_command_config { 'loopback':
+    command => 'interface loopback10',
   }
 
   cisco_bfd_global { 'default':

--- a/examples/demo_all_cisco.pp
+++ b/examples/demo_all_cisco.pp
@@ -28,6 +28,7 @@ class ciscopuppet::demo_all_cisco {
 
   include ciscopuppet::cisco::demo_aaa
   include ciscopuppet::cisco::demo_acl
+  include ciscopuppet::cisco::demo_bfd
   include ciscopuppet::cisco::demo_bgp
   include ciscopuppet::cisco::demo_command_config
   include ciscopuppet::cisco::demo_evpn

--- a/lib/puppet/provider/cisco_bfd_global/cisco.rb
+++ b/lib/puppet/provider/cisco_bfd_global/cisco.rb
@@ -1,0 +1,234 @@
+# The Cisco provider for cisco_bfd_global
+#
+# May, 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_bfd_global).provide(:cisco) do
+  desc 'The Cisco bfd_global provider.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  BFD_GLOBAL_NON_BOOL_PROPS = [
+    :echo_interface,
+    :echo_rx_interval,
+    :fabricpath_interval,
+    :fabricpath_min_rx,
+    :fabricpath_multiplier,
+    :fabricpath_slow_timer,
+    :fabricpath_vlan,
+    :interval,
+    :ipv4_echo_rx_interval,
+    :ipv4_interval,
+    :ipv4_min_rx,
+    :ipv4_multiplier,
+    :ipv4_slow_timer,
+    :ipv6_echo_rx_interval,
+    :ipv6_interval,
+    :ipv6_min_rx,
+    :ipv6_multiplier,
+    :ipv6_slow_timer,
+    :min_rx,
+    :multiplier,
+    :slow_timer,
+    :startup_timer,
+  ]
+
+  BFD_GLOBAL_ALL_PROPS = BFD_GLOBAL_NON_BOOL_PROPS
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
+                                            BFD_GLOBAL_NON_BOOL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    @nu = Cisco::BfdGlobal.globals[@property_hash[:name]]
+    @property_flush = {}
+    debug 'Created provider instance of cisco_bfd_global'
+  end
+
+  def self.properties_get(global_id, nu_obj)
+    debug "Checking instance, global #{global_id}"
+    current_state = {
+      name:   global_id,
+      ensure: :present,
+    }
+
+    # Call node_utils getter for each property
+    BFD_GLOBAL_NON_BOOL_PROPS.each do |prop|
+      current_state[prop] = nu_obj.send(prop)
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    globals = []
+    Cisco::BfdGlobal.globals.each do |global_id, v|
+      globals << properties_get(global_id, v)
+    end
+    globals
+  end
+
+  def self.prefetch(resources)
+    globals = instances
+
+    resources.keys.each do |id|
+      provider = globals.find { |nu_obj| nu_obj.instance_name == id }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    (@property_hash[:ensure] == :present)
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def instance_name
+    name
+  end
+
+  def properties_set(new_global=false)
+    BFD_GLOBAL_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_global
+      unless @property_flush[prop].nil?
+        @nu.send("#{prop}=", @property_flush[prop]) if
+          @nu.respond_to?("#{prop}=")
+      end
+    end
+    # custom setters which require one-shot multi-param setters
+    interval_set
+    ipv4_interval_set
+    ipv6_interval_set
+    fabricpath_interval_set
+  end
+
+  def interval_set
+    attrs = {}
+    vars = [
+      :interval,
+      :min_rx,
+      :multiplier,
+    ]
+    if vars.any? { |p| @property_flush.key?(p) }
+      # At least one var has changed, get all vals from manifest
+      vars.each do |p|
+        if @resource[p] == :default
+          attrs[p] = @nu.send("default_#{p}")
+        else
+          attrs[p] = @resource[p]
+        end
+      end
+    end
+    return if attrs.empty?
+    @nu.interval_set(attrs)
+  end
+
+  def ipv4_interval_set
+    attrs = {}
+    vars = [
+      :ipv4_interval,
+      :ipv4_min_rx,
+      :ipv4_multiplier,
+    ]
+    if vars.any? { |p| @property_flush.key?(p) }
+      # At least one var has changed, get all vals from manifest
+      vars.each do |p|
+        if @resource[p] == :default
+          attrs[p] = @nu.send("default_#{p}")
+        else
+          attrs[p] = @resource[p]
+        end
+      end
+    end
+    return if attrs.empty?
+    @nu.ipv4_interval_set(attrs)
+  end
+
+  def ipv6_interval_set
+    attrs = {}
+    vars = [
+      :ipv6_interval,
+      :ipv6_min_rx,
+      :ipv6_multiplier,
+    ]
+    if vars.any? { |p| @property_flush.key?(p) }
+      # At least one var has changed, get all vals from manifest
+      vars.each do |p|
+        if @resource[p] == :default
+          attrs[p] = @nu.send("default_#{p}")
+        else
+          attrs[p] = @resource[p]
+        end
+      end
+    end
+    return if attrs.empty?
+    @nu.ipv6_interval_set(attrs)
+  end
+
+  def fabricpath_interval_set
+    attrs = {}
+    vars = [
+      :fabricpath_interval,
+      :fabricpath_min_rx,
+      :fabricpath_multiplier,
+    ]
+    if vars.any? { |p| @property_flush.key?(p) }
+      # At least one var has changed, get all vals from manifest
+      vars.each do |p|
+        if @resource[p] == :default
+          attrs[p] = @nu.send("default_#{p}")
+        else
+          attrs[p] = @resource[p]
+        end
+      end
+    end
+    return if attrs.empty?
+    @nu.fabricpath_interval_set(attrs)
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @nu.destroy
+      @nu = nil
+    else
+      # Create/Update
+      new_global = false
+      if @nu.nil?
+        new_global = true
+        @nu = Cisco::BfdGlobal.new(@resource[:name])
+      end
+      properties_set(new_global)
+    end
+  end
+end # Puppet::Type

--- a/lib/puppet/provider/cisco_bfd_global/cisco.rb
+++ b/lib/puppet/provider/cisco_bfd_global/cisco.rb
@@ -126,26 +126,6 @@ Puppet::Type.type(:cisco_bfd_global).provide(:cisco) do
     end
   end
 
-  def fabricpath_interval=(should_list)
-    should_list = @nu.default_fabricpath_interval if should_list[0] == :default
-    @property_flush[:fabricpath_interval] = should_list
-  end
-
-  def interval=(should_list)
-    should_list = @nu.default_interval if should_list[0] == :default
-    @property_flush[:interval] = should_list
-  end
-
-  def ipv4_interval=(should_list)
-    should_list = @nu.default_ipv4_interval if should_list[0] == :default
-    @property_flush[:ipv4_interval] = should_list
-  end
-
-  def ipv6_interval=(should_list)
-    should_list = @nu.default_ipv6_interval if should_list[0] == :default
-    @property_flush[:ipv6_interval] = should_list
-  end
-
   def flush
     if @property_flush[:ensure] == :absent
       @nu.destroy

--- a/lib/puppet/provider/cisco_bfd_global/cisco.rb
+++ b/lib/puppet/provider/cisco_bfd_global/cisco.rb
@@ -36,32 +36,29 @@ Puppet::Type.type(:cisco_bfd_global).provide(:cisco) do
   BFD_GLOBAL_NON_BOOL_PROPS = [
     :echo_interface,
     :echo_rx_interval,
-    :fabricpath_interval,
-    :fabricpath_min_rx,
-    :fabricpath_multiplier,
     :fabricpath_slow_timer,
     :fabricpath_vlan,
-    :interval,
     :ipv4_echo_rx_interval,
-    :ipv4_interval,
-    :ipv4_min_rx,
-    :ipv4_multiplier,
     :ipv4_slow_timer,
     :ipv6_echo_rx_interval,
-    :ipv6_interval,
-    :ipv6_min_rx,
-    :ipv6_multiplier,
     :ipv6_slow_timer,
-    :min_rx,
-    :multiplier,
     :slow_timer,
     :startup_timer,
   ]
 
-  BFD_GLOBAL_ALL_PROPS = BFD_GLOBAL_NON_BOOL_PROPS
+  BFD_GLOBAL_ARRAY_FLAT_PROPS = [
+    :fabricpath_interval,
+    :interval,
+    :ipv4_interval,
+    :ipv6_interval,
+  ]
+
+  BFD_GLOBAL_ALL_PROPS = BFD_GLOBAL_ARRAY_FLAT_PROPS + BFD_GLOBAL_NON_BOOL_PROPS
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
                                             BFD_GLOBAL_NON_BOOL_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_flat, self, '@nu',
+                                            BFD_GLOBAL_ARRAY_FLAT_PROPS)
 
   def initialize(value={})
     super(value)
@@ -81,6 +78,14 @@ Puppet::Type.type(:cisco_bfd_global).provide(:cisco) do
     BFD_GLOBAL_NON_BOOL_PROPS.each do |prop|
       current_state[prop] = nu_obj.send(prop)
     end
+    BFD_GLOBAL_ARRAY_FLAT_PROPS.each do |prop|
+      current_state[prop] = nu_obj.send(prop)
+    end
+    # nested array properties
+    current_state[:fabricpath_interval] = nu_obj.fabricpath_interval
+    current_state[:interval] = nu_obj.interval
+    current_state[:ipv4_interval] = nu_obj.ipv4_interval
+    current_state[:ipv6_interval] = nu_obj.ipv6_interval
     new(current_state)
   end # self.properties_get
 
@@ -126,95 +131,26 @@ Puppet::Type.type(:cisco_bfd_global).provide(:cisco) do
           @nu.respond_to?("#{prop}=")
       end
     end
-    # custom setters which require one-shot multi-param setters
-    interval_set
-    ipv4_interval_set
-    ipv6_interval_set
-    fabricpath_interval_set
   end
 
-  def interval_set
-    attrs = {}
-    vars = [
-      :interval,
-      :min_rx,
-      :multiplier,
-    ]
-    if vars.any? { |p| @property_flush.key?(p) }
-      # At least one var has changed, get all vals from manifest
-      vars.each do |p|
-        if @resource[p] == :default
-          attrs[p] = @nu.send("default_#{p}")
-        else
-          attrs[p] = @resource[p]
-        end
-      end
-    end
-    return if attrs.empty?
-    @nu.interval_set(attrs)
+  def fabricpath_interval=(should_list)
+    should_list = @nu.default_fabricpath_interval if should_list[0] == :default
+    @property_flush[:fabricpath_interval] = should_list
   end
 
-  def ipv4_interval_set
-    attrs = {}
-    vars = [
-      :ipv4_interval,
-      :ipv4_min_rx,
-      :ipv4_multiplier,
-    ]
-    if vars.any? { |p| @property_flush.key?(p) }
-      # At least one var has changed, get all vals from manifest
-      vars.each do |p|
-        if @resource[p] == :default
-          attrs[p] = @nu.send("default_#{p}")
-        else
-          attrs[p] = @resource[p]
-        end
-      end
-    end
-    return if attrs.empty?
-    @nu.ipv4_interval_set(attrs)
+  def interval=(should_list)
+    should_list = @nu.default_interval if should_list[0] == :default
+    @property_flush[:interval] = should_list
   end
 
-  def ipv6_interval_set
-    attrs = {}
-    vars = [
-      :ipv6_interval,
-      :ipv6_min_rx,
-      :ipv6_multiplier,
-    ]
-    if vars.any? { |p| @property_flush.key?(p) }
-      # At least one var has changed, get all vals from manifest
-      vars.each do |p|
-        if @resource[p] == :default
-          attrs[p] = @nu.send("default_#{p}")
-        else
-          attrs[p] = @resource[p]
-        end
-      end
-    end
-    return if attrs.empty?
-    @nu.ipv6_interval_set(attrs)
+  def ipv4_interval=(should_list)
+    should_list = @nu.default_ipv4_interval if should_list[0] == :default
+    @property_flush[:ipv4_interval] = should_list
   end
 
-  def fabricpath_interval_set
-    attrs = {}
-    vars = [
-      :fabricpath_interval,
-      :fabricpath_min_rx,
-      :fabricpath_multiplier,
-    ]
-    if vars.any? { |p| @property_flush.key?(p) }
-      # At least one var has changed, get all vals from manifest
-      vars.each do |p|
-        if @resource[p] == :default
-          attrs[p] = @nu.send("default_#{p}")
-        else
-          attrs[p] = @resource[p]
-        end
-      end
-    end
-    return if attrs.empty?
-    @nu.fabricpath_interval_set(attrs)
+  def ipv6_interval=(should_list)
+    should_list = @nu.default_ipv6_interval if should_list[0] == :default
+    @property_flush[:ipv6_interval] = should_list
   end
 
   def flush

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     Example:
     cisco_bfd_global { 'default':
       ensure                => 'present',
-      echo_interface        => 10,
+      echo_interface        => 'loopback10',
       echo_rx_interval      => 300,
       fabricpath_interval   => ['750', '350', '45'],
       fabricpath_slow_timer => 15000,
@@ -50,10 +50,12 @@ Puppet::Type.newtype(:cisco_bfd_global) do
   ###################
 
   newparam(:name, namevar: :true) do
-    desc 'ID of the bfd global config. Valid values are default.'
+    desc "Instance of bfd global, only allow the value 'default'"
 
-    validate do |inst_name|
-      fail "only acceptable name is 'default'" if inst_name != 'default'
+    validate do |name|
+      if name != 'default'
+        error "only 'default' is accepted as a valid bfd_global name"
+      end
     end
   end # param id
 
@@ -63,15 +65,10 @@ Puppet::Type.newtype(:cisco_bfd_global) do
 
   newproperty(:echo_interface) do
     desc "Loopback interface used for echo frames. Valid values are
-          integer, keyword 'default'."
+          string, keyword 'default'."
 
     munge do |value|
       value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'echo_interface must be a valid integer, or default.'
-      end
       value
     end
   end # property echo_interface

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -1,0 +1,397 @@
+# Manages the Cisco Bfd Global configuration resource.
+#
+# May 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_bfd_global) do
+  @doc = "
+    Manages the Cisco Bfd Global configuration resource.
+    cisco_bfd_global {'default':
+      ..attributes..
+    }
+    'default' is only acceptable name for this global config object.
+    Example:
+    cisco_bfd_global { 'default':
+      echo_interface        => 10,
+      echo_rx_interval      => 300,
+      fabricpath_interval   => 750,
+      fabricpath_min_rx     => 350,
+      fabricpath_multiplier => 45,
+      fabricpath_slow_timer => 15000,
+      fabricpath_vlan       => 100,
+      interval              => 100,
+      ipv4_echo_rx_interval => 100,
+      ipv4_interval         => 200,
+      ipv4_min_rx           => 200,
+      ipv4_multiplier       => 50,
+      ipv4_slow_timer       => 10000,
+      ipv6_echo_rx_interval => 200,
+      ipv6_interval         => 500,
+      ipv6_min_rx           => 500,
+      ipv6_multiplier       => 30,
+      ipv6_slow_timer       => 25000,
+      min_rx                => 100,
+      multiplier            => 25,
+      slow_timer            => 5000,
+      startup_timer         => 25,
+    }
+  "
+  ###################
+  # Resource Naming #
+  ###################
+
+  newparam(:name, namevar: :true) do
+    desc 'ID of the bfd global config. Valid values are default.'
+
+    validate do |inst_name|
+      fail "only acceptable name is 'default'" if inst_name != 'default'
+    end
+  end # param id
+
+  ##############
+  # Attributes #
+  ##############
+
+  newproperty(:echo_interface) do
+    desc "Loopback interface used for echo frames. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'echo_interface must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property echo_interface
+
+  newproperty(:echo_rx_interval) do
+    desc "Echo receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'echo_rx_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property echo_rx_interval
+
+  newproperty(:fabricpath_interval) do
+    desc "Fabricpath transmit interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'fabricpath_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property fabricpath_interval
+
+  newproperty(:fabricpath_min_rx) do
+    desc "Fabricpath minimum receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'fabricpath_min_rx must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property fabricpath_min_rx
+
+  newproperty(:fabricpath_multiplier) do
+    desc "Fabricpath detect multiplier. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'fabricpath_multiplier must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property fabricpath_multiplier
+
+  newproperty(:fabricpath_slow_timer) do
+    desc "Fabricpath slow rate timer in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'fabricpath_slow_timer must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property fabricpath_slow_timer
+
+  newproperty(:fabricpath_vlan) do
+    desc "Fabricpath control vlan. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'fabricpath_vlan must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property fabricpath_vlan
+
+  newproperty(:interval) do
+    desc "Transmit interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property interval
+
+  newproperty(:ipv4_echo_rx_interval) do
+    desc "Ipv4 session echo receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv4_echo_rx_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv4_echo_rx_interval
+
+  newproperty(:ipv4_interval) do
+    desc "Ipv4 session transmit interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv4_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv4_interval
+
+  newproperty(:ipv4_min_rx) do
+    desc "Ipv4 session minimum receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv4_min_rx must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv4_min_rx
+
+  newproperty(:ipv4_multiplier) do
+    desc "Ipv4 session detect multiplier. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv4_multiplier must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv4_multiplier
+
+  newproperty(:ipv4_slow_timer) do
+    desc "Ipv4 session slow rate timer in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv4_slow_timer must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv4_slow_timer
+
+  newproperty(:ipv6_echo_rx_interval) do
+    desc "Ipv6 session echo receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv6_echo_rx_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv6_echo_rx_interval
+
+  newproperty(:ipv6_interval) do
+    desc "Ipv6 session transmit interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv6_interval must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv6_interval
+
+  newproperty(:ipv6_min_rx) do
+    desc "Ipv6 session minimum receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv6_min_rx must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv6_min_rx
+
+  newproperty(:ipv6_multiplier) do
+    desc "Ipv6 session detect multiplier. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv6_multiplier must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv6_multiplier
+
+  newproperty(:ipv6_slow_timer) do
+    desc "Ipv6 session slow rate timer in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'ipv6_slow_timer must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property ipv6_slow_timer
+
+  newproperty(:min_rx) do
+    desc "Minimum receive interval in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'min_rx must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property min_rx
+
+  newproperty(:multiplier) do
+    desc "Detect multiplier. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'multiplier must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property multiplier
+
+  newproperty(:slow_timer) do
+    desc "Slow rate timer in msec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'slow_timer must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property slow_timer
+
+  newproperty(:startup_timer) do
+    desc "Delayed startup timer in sec. Valid values are
+          integer, keyword 'default'."
+
+    munge do |value|
+      value = :default if value == 'default'
+      begin
+        value = Integer(value) unless value == :default
+      rescue
+        raise 'startup_timer must be a valid integer, or default.'
+      end
+      value
+    end
+  end # property startup_timer
+end

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -50,13 +50,10 @@ Puppet::Type.newtype(:cisco_bfd_global) do
   ###################
 
   newparam(:name, namevar: :true) do
-    desc "Instance of bfd global, only allow the value 'default'"
+    inputs = "The name of the bfd_global instance. Valid values are 'default' only"
+    desc inputs
 
-    validate do |name|
-      if name != 'default'
-        error "only 'default' is accepted as a valid bfd_global name"
-      end
-    end
+    validate { |name| error inputs unless name == 'default' }
   end # param id
 
   ##############
@@ -65,7 +62,7 @@ Puppet::Type.newtype(:cisco_bfd_global) do
 
   newproperty(:echo_interface) do
     desc "Loopback interface used for echo frames. Valid values are
-          string, keyword 'default'."
+          string (e.g. 'loopback42'), or keyword 'default'."
 
     munge do |value|
       value = :default if value == 'default'
@@ -77,21 +74,12 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     desc "Echo receive interval in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'echo_rx_interval must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property echo_rx_interval
 
   newproperty(:fabricpath_interval, array_matching: :all) do
-    format = '[fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier]'
-    desc 'An array of [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier]'\
-         "Valid values match format #{format}."
+    desc "Valid values are an array of  [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier]
+      or keyword 'default'"
 
     def should_to_s(value)
       value.inspect
@@ -101,48 +89,26 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       value.inspect
     end
 
-    munge do |value|
-      begin
-        return value = :default if value == 'default'
-        value
-      end
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property fabricpath_interval
 
   newproperty(:fabricpath_slow_timer) do
     desc "Fabricpath slow rate timer in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'fabricpath_slow_timer must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property fabricpath_slow_timer
 
   newproperty(:fabricpath_vlan) do
     desc "Fabricpath control vlan. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'fabricpath_vlan must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property fabricpath_vlan
 
   newproperty(:interval, array_matching: :all) do
-    format = '[interval, min_rx, multiplier]'
-    desc 'An array of [interval, min_rx, multiplier]'\
-         "Valid values match format #{format}."
+    desc "Valid values are an array of  [interval, min_rx, multiplier]
+      or keyword 'default'"
 
     def should_to_s(value)
       value.inspect
@@ -152,33 +118,19 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       value.inspect
     end
 
-    munge do |value|
-      begin
-        return value = :default if value == 'default'
-        value
-      end
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property interval
 
   newproperty(:ipv4_echo_rx_interval) do
     desc "Ipv4 session echo receive interval in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv4_echo_rx_interval must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property ipv4_echo_rx_interval
 
   newproperty(:ipv4_interval, array_matching: :all) do
-    format = '[ipv4_interval, ipv4_min_rx, ipv4_multiplier]'
-    desc 'An array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier]'\
-         "Valid values match format #{format}."
+    desc "Valid values are an array of  [ipv4_interval, ipv4_min_rx, ipv4_multiplier]
+      or keyword 'default'"
 
     def should_to_s(value)
       value.inspect
@@ -188,48 +140,26 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       value.inspect
     end
 
-    munge do |value|
-      begin
-        return value = :default if value == 'default'
-        value
-      end
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property ipv4_interval
 
   newproperty(:ipv4_slow_timer) do
     desc "Ipv4 session slow rate timer in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv4_slow_timer must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property ipv4_slow_timer
 
   newproperty(:ipv6_echo_rx_interval) do
     desc "Ipv6 session echo receive interval in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv6_echo_rx_interval must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property ipv6_echo_rx_interval
 
   newproperty(:ipv6_interval, array_matching: :all) do
-    format = '[ipv6_interval, ipv6_min_rx, ipv6_multiplier]'
-    desc 'An array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier]'\
-         "Valid values match format #{format}."
+    desc "Valid values are an array of  [ipv6_interval, ipv6_min_rx, ipv6_multiplier]
+      or keyword 'default'"
 
     def should_to_s(value)
       value.inspect
@@ -239,56 +169,27 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       value.inspect
     end
 
-    munge do |value|
-      begin
-        return value = :default if value == 'default'
-        value
-      end
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property ipv6_interval
 
   newproperty(:ipv6_slow_timer) do
     desc "Ipv6 session slow rate timer in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv6_slow_timer must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property ipv6_slow_timer
 
   newproperty(:slow_timer) do
     desc "Slow rate timer in msec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'slow_timer must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property slow_timer
 
   newproperty(:startup_timer) do
     desc "Delayed startup timer in sec. Valid values are
           integer, keyword 'default'."
 
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'startup_timer must be a valid integer, or default.'
-      end
-      value
-    end
+    munge { |value| value == 'default' ? :default : Integer(value) }
   end # property startup_timer
 end

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -25,6 +25,7 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     'default' is only acceptable name for this global config object.
     Example:
     cisco_bfd_global { 'default':
+      ensure                => 'present',
       echo_interface        => 10,
       echo_rx_interval      => 300,
       fabricpath_interval   => ['750', '350', '45'],
@@ -41,6 +42,9 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       startup_timer         => 25,
     }
   "
+
+  ensurable
+
   ###################
   # Resource Naming #
   ###################

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -27,24 +27,16 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     cisco_bfd_global { 'default':
       echo_interface        => 10,
       echo_rx_interval      => 300,
-      fabricpath_interval   => 750,
-      fabricpath_min_rx     => 350,
-      fabricpath_multiplier => 45,
+      fabricpath_interval   => ['750', '350', '45'],
       fabricpath_slow_timer => 15000,
       fabricpath_vlan       => 100,
-      interval              => 100,
+      interval              => ['100', '100', '25'],
       ipv4_echo_rx_interval => 100,
-      ipv4_interval         => 200,
-      ipv4_min_rx           => 200,
-      ipv4_multiplier       => 50,
+      ipv4_interval         => ['200', '200', '50'],
       ipv4_slow_timer       => 10000,
       ipv6_echo_rx_interval => 200,
-      ipv6_interval         => 500,
-      ipv6_min_rx           => 500,
-      ipv6_multiplier       => 30,
+      ipv6_interval         => ['500', '500', '30'],
       ipv6_slow_timer       => 25000,
-      min_rx                => 100,
-      multiplier            => 25,
       slow_timer            => 5000,
       startup_timer         => 25,
     }
@@ -95,50 +87,26 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     end
   end # property echo_rx_interval
 
-  newproperty(:fabricpath_interval) do
-    desc "Fabricpath transmit interval in msec. Valid values are
-          integer, keyword 'default'."
+  newproperty(:fabricpath_interval, array_matching: :all) do
+    format = '[fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier]'
+    desc 'An array of [fabricpath_interval, fabricpath_min_rx, fabricpath_multiplier]'\
+         "Valid values match format #{format}."
+
+    def should_to_s(value)
+      value.inspect
+    end
+
+    def is_to_s(value)
+      value.inspect
+    end
 
     munge do |value|
-      value = :default if value == 'default'
       begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'fabricpath_interval must be a valid integer, or default.'
+        return value = :default if value == 'default'
+        value
       end
-      value
     end
   end # property fabricpath_interval
-
-  newproperty(:fabricpath_min_rx) do
-    desc "Fabricpath minimum receive interval in msec. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'fabricpath_min_rx must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property fabricpath_min_rx
-
-  newproperty(:fabricpath_multiplier) do
-    desc "Fabricpath detect multiplier. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'fabricpath_multiplier must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property fabricpath_multiplier
 
   newproperty(:fabricpath_slow_timer) do
     desc "Fabricpath slow rate timer in msec. Valid values are
@@ -170,18 +138,24 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     end
   end # property fabricpath_vlan
 
-  newproperty(:interval) do
-    desc "Transmit interval in msec. Valid values are
-          integer, keyword 'default'."
+  newproperty(:interval, array_matching: :all) do
+    format = '[interval, min_rx, multiplier]'
+    desc 'An array of [interval, min_rx, multiplier]'\
+         "Valid values match format #{format}."
+
+    def should_to_s(value)
+      value.inspect
+    end
+
+    def is_to_s(value)
+      value.inspect
+    end
 
     munge do |value|
-      value = :default if value == 'default'
       begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'interval must be a valid integer, or default.'
+        return value = :default if value == 'default'
+        value
       end
-      value
     end
   end # property interval
 
@@ -200,50 +174,26 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     end
   end # property ipv4_echo_rx_interval
 
-  newproperty(:ipv4_interval) do
-    desc "Ipv4 session transmit interval in msec. Valid values are
-          integer, keyword 'default'."
+  newproperty(:ipv4_interval, array_matching: :all) do
+    format = '[ipv4_interval, ipv4_min_rx, ipv4_multiplier]'
+    desc 'An array of [ipv4_interval, ipv4_min_rx, ipv4_multiplier]'\
+         "Valid values match format #{format}."
+
+    def should_to_s(value)
+      value.inspect
+    end
+
+    def is_to_s(value)
+      value.inspect
+    end
 
     munge do |value|
-      value = :default if value == 'default'
       begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv4_interval must be a valid integer, or default.'
+        return value = :default if value == 'default'
+        value
       end
-      value
     end
   end # property ipv4_interval
-
-  newproperty(:ipv4_min_rx) do
-    desc "Ipv4 session minimum receive interval in msec. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv4_min_rx must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property ipv4_min_rx
-
-  newproperty(:ipv4_multiplier) do
-    desc "Ipv4 session detect multiplier. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv4_multiplier must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property ipv4_multiplier
 
   newproperty(:ipv4_slow_timer) do
     desc "Ipv4 session slow rate timer in msec. Valid values are
@@ -275,50 +225,26 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     end
   end # property ipv6_echo_rx_interval
 
-  newproperty(:ipv6_interval) do
-    desc "Ipv6 session transmit interval in msec. Valid values are
-          integer, keyword 'default'."
+  newproperty(:ipv6_interval, array_matching: :all) do
+    format = '[ipv6_interval, ipv6_min_rx, ipv6_multiplier]'
+    desc 'An array of [ipv6_interval, ipv6_min_rx, ipv6_multiplier]'\
+         "Valid values match format #{format}."
+
+    def should_to_s(value)
+      value.inspect
+    end
+
+    def is_to_s(value)
+      value.inspect
+    end
 
     munge do |value|
-      value = :default if value == 'default'
       begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv6_interval must be a valid integer, or default.'
+        return value = :default if value == 'default'
+        value
       end
-      value
     end
   end # property ipv6_interval
-
-  newproperty(:ipv6_min_rx) do
-    desc "Ipv6 session minimum receive interval in msec. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv6_min_rx must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property ipv6_min_rx
-
-  newproperty(:ipv6_multiplier) do
-    desc "Ipv6 session detect multiplier. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'ipv6_multiplier must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property ipv6_multiplier
 
   newproperty(:ipv6_slow_timer) do
     desc "Ipv6 session slow rate timer in msec. Valid values are
@@ -334,36 +260,6 @@ Puppet::Type.newtype(:cisco_bfd_global) do
       value
     end
   end # property ipv6_slow_timer
-
-  newproperty(:min_rx) do
-    desc "Minimum receive interval in msec. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'min_rx must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property min_rx
-
-  newproperty(:multiplier) do
-    desc "Detect multiplier. Valid values are
-          integer, keyword 'default'."
-
-    munge do |value|
-      value = :default if value == 'default'
-      begin
-        value = Integer(value) unless value == :default
-      rescue
-        raise 'multiplier must be a valid integer, or default.'
-      end
-      value
-    end
-  end # property multiplier
 
   newproperty(:slow_timer) do
     desc "Slow rate timer in msec. Valid values are

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -1,0 +1,263 @@
+###############################################################################
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
+#
+###############################################################################
+
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Test hash top-level keys
+tests = {
+  master:           master,
+  agent:            agent,
+  operating_system: 'nexus',
+  platform:         'n(7|9)k',
+  resource_name:    'cisco_bfd_global',
+}
+
+default_interval_plat_1 = %w(250 250 3)
+default_interval_plat_2 = %w(50 50 3)
+non_default_interval = %w(100 100 25)
+non_default_ipv4_interval = %w(200 200 50)
+non_default_ipv6_interval = %w(500 500 30)
+non_default_fabricpath_interval = %w(750 350 35)
+
+# Test hash test cases
+tests[:default_plat_1] = {
+  desc:           '1.1 Defaults for n3k',
+  platform:       'n3k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        'default',
+    echo_rx_interval:      'default',
+    interval:              'default',
+    ipv4_echo_rx_interval: 'default',
+    ipv4_interval:         'default',
+    ipv4_slow_timer:       'default',
+    ipv6_echo_rx_interval: 'default',
+    ipv6_interval:         'default',
+    ipv6_slow_timer:       'default',
+    slow_timer:            'default',
+    startup_timer:         'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    echo_interface:        'false',
+    echo_rx_interval:      250,
+    interval:              default_interval_plat_1,
+    ipv4_echo_rx_interval: 250,
+    ipv4_interval:         default_interval_plat_1,
+    ipv4_slow_timer:       2000,
+    ipv6_echo_rx_interval: 250,
+    ipv6_interval:         default_interval_plat_1,
+    ipv6_slow_timer:       2000,
+    slow_timer:            2000,
+    startup_timer:         5,
+  },
+}
+
+tests[:default_plat_2] = {
+  desc:           '1.2 Defaults for n8k, n9k',
+  platform:       'n(8|9)k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        'default',
+    echo_rx_interval:      'default',
+    interval:              'default',
+    ipv4_echo_rx_interval: 'default',
+    ipv4_interval:         'default',
+    ipv4_slow_timer:       'default',
+    ipv6_echo_rx_interval: 'default',
+    ipv6_interval:         'default',
+    ipv6_slow_timer:       'default',
+    slow_timer:            'default',
+    startup_timer:         'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    echo_interface:        'false',
+    echo_rx_interval:      50,
+    interval:              default_interval_plat_2,
+    ipv4_echo_rx_interval: 50,
+    ipv4_interval:         default_interval_plat_2,
+    ipv4_slow_timer:       2000,
+    ipv6_echo_rx_interval: 50,
+    ipv6_interval:         default_interval_plat_2,
+    ipv6_slow_timer:       2000,
+    slow_timer:            2000,
+    startup_timer:         5,
+  },
+}
+
+tests[:default_plat_3] = {
+  desc:           '1.3 Defaults for n5k, n6k',
+  platform:       'n(5|6)k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        'default',
+    fabricpath_interval:   'default',
+    fabricpath_slow_timer: 'default',
+    fabricpath_vlan:       'default',
+    interval:              'default',
+    slow_timer:            'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    echo_interface:        'false',
+    fabricpath_interval:   default_interval_plat_2,
+    fabricpath_slow_timer: 2000,
+    fabricpath_vlan:       1,
+    interval:              default_interval_plat_2,
+    slow_timer:            2000,
+  },
+}
+
+tests[:default_plat_4] = {
+  desc:           '1.4 Defaults for n7k',
+  platform:       'n7k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        'default',
+    echo_rx_interval:      'default',
+    fabricpath_interval:   'default',
+    fabricpath_slow_timer: 'default',
+    fabricpath_vlan:       'default',
+    interval:              'default',
+    ipv4_echo_rx_interval: 'default',
+    ipv4_interval:         'default',
+    ipv4_slow_timer:       'default',
+    ipv6_echo_rx_interval: 'default',
+    ipv6_interval:         'default',
+    ipv6_slow_timer:       'default',
+    slow_timer:            'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    echo_interface:        'false',
+    echo_rx_interval:      50,
+    fabricpath_interval:   default_interval_plat_2,
+    fabricpath_slow_timer: 2000,
+    fabricpath_vlan:       1,
+    interval:              default_interval_plat_2,
+    ipv4_echo_rx_interval: 50,
+    ipv4_interval:         default_interval_plat_2,
+    ipv4_slow_timer:       2000,
+    ipv6_echo_rx_interval: 50,
+    ipv6_interval:         default_interval_plat_2,
+    ipv6_slow_timer:       2000,
+    slow_timer:            2000,
+  },
+}
+
+# Non-default Tests. NOTE: [:resource] = [:manifest_props] for all non-default
+
+tests[:non_default_plat_1] = {
+  desc:           '2.1 Non Defaults for n3k, n8k, n9k',
+  platform:       'n(3|8|9)k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        10,
+    echo_rx_interval:      300,
+    interval:              non_default_interval,
+    ipv4_echo_rx_interval: 100,
+    ipv4_interval:         non_default_ipv4_interval,
+    ipv4_slow_timer:       10_000,
+    ipv6_echo_rx_interval: 200,
+    ipv6_interval:         non_default_ipv6_interval,
+    ipv6_slow_timer:       25_000,
+    slow_timer:            5000,
+    startup_timer:         25,
+  },
+}
+
+tests[:non_default_plat_2] = {
+  desc:           '2.2 Non Defaults for n5k, n6k',
+  platform:       'n(5|6)k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        10,
+    fabricpath_interval:   non_default_fabricpath_interval,
+    fabricpath_slow_timer: 15_000,
+    fabricpath_vlan:       100,
+    interval:              non_default_interval,
+    slow_timer:            5000,
+  },
+}
+
+tests[:non_default_plat_3] = {
+  desc:           '2.3 Non Defaults for n7k',
+  platform:       'n7k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        10,
+    echo_rx_interval:      300,
+    fabricpath_interval:   non_default_fabricpath_interval,
+    fabricpath_slow_timer: 15_000,
+    fabricpath_vlan:       100,
+    interval:              non_default_interval,
+    ipv4_echo_rx_interval: 100,
+    ipv4_interval:         non_default_ipv4_interval,
+    ipv4_slow_timer:       10_000,
+    ipv6_echo_rx_interval: 200,
+    ipv6_interval:         non_default_ipv6_interval,
+    ipv6_slow_timer:       25_000,
+    slow_timer:            5000,
+  },
+}
+
+# Overridden to properly handle dependencies for this test file.
+def test_harness_dependencies(_tests, id)
+  return unless id[/non_default_/]
+  cmd = 'interface loopback 10'
+  command_config(agent, cmd, cmd)
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{tests[:resource_name]}" do
+  # -------------------------------------------------------------------
+  device = platform
+  logger.info("#### This device is of type: #{device} #####")
+  logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+
+  test_harness_run(tests, :default_plat_1)
+  test_harness_run(tests, :default_plat_2)
+  test_harness_run(tests, :default_plat_3)
+  test_harness_run(tests, :default_plat_4)
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
+
+  test_harness_run(tests, :non_default_plat_1)
+  test_harness_run(tests, :non_default_plat_2)
+  test_harness_run(tests, :non_default_plat_3)
+  resource_absent_cleanup(agent, 'cisco_bfd_global')
+  skipped_tests_summary(tests)
+end
+
+logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -29,26 +29,27 @@ tests = {
   master:           master,
   agent:            agent,
   operating_system: 'nexus',
-  platform:         'n(7|9)k',
   resource_name:    'cisco_bfd_global',
 }
 
-default_interval_plat_1 = %w(250 250 3)
-default_interval_plat_2 = %w(50 50 3)
+default_interval_plat_1 = %w(50 50 3)
+default_interval_plat_2 = %w(250 250 3)
 non_default_interval = %w(100 100 25)
 non_default_ipv4_interval = %w(200 200 50)
 non_default_ipv6_interval = %w(500 500 30)
 non_default_fabricpath_interval = %w(750 350 35)
 
 # Test hash test cases
-tests[:default_plat_1] = {
-  desc:           '1.1 Defaults for n3k',
-  platform:       'n3k',
+tests[:default] = {
+  desc:           '1.1 Defaults',
   title_pattern:  'default',
   preclean:       'cisco_bfd_global',
   manifest_props: {
     echo_interface:        'default',
     echo_rx_interval:      'default',
+    fabricpath_interval:   'default',
+    fabricpath_slow_timer: 'default',
+    fabricpath_vlan:       'default',
     interval:              'default',
     ipv4_echo_rx_interval: 'default',
     ipv4_interval:         'default',
@@ -62,12 +63,15 @@ tests[:default_plat_1] = {
   code:           [0, 2],
   resource:       {
     echo_interface:        'false',
-    echo_rx_interval:      250,
+    echo_rx_interval:      50,
+    fabricpath_interval:   default_interval_plat_1,
+    fabricpath_slow_timer: 2000,
+    fabricpath_vlan:       1,
     interval:              default_interval_plat_1,
-    ipv4_echo_rx_interval: 250,
+    ipv4_echo_rx_interval: 50,
     ipv4_interval:         default_interval_plat_1,
     ipv4_slow_timer:       2000,
-    ipv6_echo_rx_interval: 250,
+    ipv6_echo_rx_interval: 50,
     ipv6_interval:         default_interval_plat_1,
     ipv6_slow_timer:       2000,
     slow_timer:            2000,
@@ -75,159 +79,24 @@ tests[:default_plat_1] = {
   },
 }
 
-tests[:default_plat_2] = {
-  desc:           '1.2 Defaults for n8k, n9k',
-  platform:       'n(8|9)k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'default',
-    echo_rx_interval:      'default',
-    ipv4_echo_rx_interval: 'default',
-    ipv4_interval:         'default',
-    ipv4_slow_timer:       'default',
-    ipv6_echo_rx_interval: 'default',
-    ipv6_interval:         'default',
-    ipv6_slow_timer:       'default',
-    slow_timer:            'default',
-    startup_timer:         'default',
-  },
-  code:           [0, 2],
-  resource:       {
-    echo_interface:        'false',
-    echo_rx_interval:      50,
-    ipv4_echo_rx_interval: 50,
+# Per platform default values
+resource = {
+  n3k: {
+    echo_rx_interval:      250,
+    interval:              default_interval_plat_2,
+    ipv4_echo_rx_interval: 250,
     ipv4_interval:         default_interval_plat_2,
-    ipv4_slow_timer:       2000,
-    ipv6_echo_rx_interval: 50,
+    ipv6_echo_rx_interval: 250,
     ipv6_interval:         default_interval_plat_2,
-    ipv6_slow_timer:       2000,
-    slow_timer:            2000,
-    startup_timer:         5,
-  },
+  }
 }
 
-tests[:default_plat_3] = {
-  desc:           '1.3 Defaults for n5k, n6k',
-  platform:       'n(5|6)k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'default',
-    fabricpath_interval:   'default',
-    fabricpath_slow_timer: 'default',
-    fabricpath_vlan:       'default',
-    interval:              'default',
-    slow_timer:            'default',
-  },
-  code:           [0, 2],
-  resource:       {
-    echo_interface:        'false',
-    fabricpath_interval:   default_interval_plat_2,
-    fabricpath_slow_timer: 2000,
-    fabricpath_vlan:       1,
-    interval:              default_interval_plat_2,
-    slow_timer:            2000,
-  },
-}
-
-tests[:default_plat_4] = {
-  desc:           '1.4 Defaults for n7k',
-  platform:       'n7k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'default',
-    echo_rx_interval:      'default',
-    fabricpath_interval:   'default',
-    fabricpath_slow_timer: 'default',
-    fabricpath_vlan:       'default',
-    interval:              'default',
-    ipv4_echo_rx_interval: 'default',
-    ipv4_interval:         'default',
-    ipv4_slow_timer:       'default',
-    ipv6_echo_rx_interval: 'default',
-    ipv6_interval:         'default',
-    ipv6_slow_timer:       'default',
-    slow_timer:            'default',
-  },
-  code:           [0, 2],
-  resource:       {
-    echo_interface:        'false',
-    echo_rx_interval:      50,
-    fabricpath_interval:   default_interval_plat_2,
-    fabricpath_slow_timer: 2000,
-    fabricpath_vlan:       1,
-    interval:              default_interval_plat_2,
-    ipv4_echo_rx_interval: 50,
-    ipv4_interval:         default_interval_plat_2,
-    ipv4_slow_timer:       2000,
-    ipv6_echo_rx_interval: 50,
-    ipv6_interval:         default_interval_plat_2,
-    ipv6_slow_timer:       2000,
-    slow_timer:            2000,
-  },
-}
+tests[:default][:resource].merge!(resource[:n3k]) if platform[/n3k/]
 
 # Non-default Tests. NOTE: [:resource] = [:manifest_props] for all non-default
 
-tests[:non_default_plat_1] = {
-  desc:           '2.1 Non Defaults for n3k',
-  platform:       'n3k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'loopback10',
-    echo_rx_interval:      300,
-    interval:              non_default_interval,
-    ipv4_echo_rx_interval: 100,
-    ipv4_interval:         non_default_ipv4_interval,
-    ipv4_slow_timer:       10_000,
-    ipv6_echo_rx_interval: 200,
-    ipv6_interval:         non_default_ipv6_interval,
-    ipv6_slow_timer:       25_000,
-    slow_timer:            5000,
-    startup_timer:         25,
-  },
-}
-
-tests[:non_default_plat_2] = {
-  desc:           '2.2 Non Defaults for n8k, n9k',
-  platform:       'n(8|9)k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'loopback10',
-    echo_rx_interval:      300,
-    ipv4_echo_rx_interval: 100,
-    ipv4_interval:         non_default_ipv4_interval,
-    ipv4_slow_timer:       10_000,
-    ipv6_echo_rx_interval: 200,
-    ipv6_interval:         non_default_ipv6_interval,
-    ipv6_slow_timer:       25_000,
-    slow_timer:            5000,
-    startup_timer:         25,
-  },
-}
-
-tests[:non_default_plat_3] = {
-  desc:           '2.3 Non Defaults for n5k, n6k',
-  platform:       'n(5|6)k',
-  title_pattern:  'default',
-  preclean:       'cisco_bfd_global',
-  manifest_props: {
-    echo_interface:        'loopback10',
-    fabricpath_interval:   non_default_fabricpath_interval,
-    fabricpath_slow_timer: 15_000,
-    fabricpath_vlan:       100,
-    interval:              non_default_interval,
-    slow_timer:            5000,
-  },
-}
-
-tests[:non_default_plat_4] = {
-  desc:           '2.4 Non Defaults for n7k',
-  platform:       'n7k',
+tests[:non_default] = {
+  desc:           '2.1 Non Defaults',
   title_pattern:  'default',
   preclean:       'cisco_bfd_global',
   manifest_props: {
@@ -244,12 +113,43 @@ tests[:non_default_plat_4] = {
     ipv6_interval:         non_default_ipv6_interval,
     ipv6_slow_timer:       25_000,
     slow_timer:            5000,
+    startup_timer:         25,
   },
 }
+
+def unsupported_properties(_tests, _id)
+  unprops = []
+  if platform[/n(3|8|9)k/]
+    unprops <<
+      :fabricpath_interval <<
+      :fabricpath_slow_timer <<
+      :fabricpath_vlan
+
+  elsif platform[/n(5|6)k/]
+    unprops <<
+      :echo_rx_interval <<
+      :ipv4_echo_rx_interval <<
+      :ipv4_interval <<
+      :ipv4_slow_timer <<
+      :ipv6_echo_rx_interval <<
+      :ipv6_interval <<
+      :ipv6_slow_timer <<
+      :startup_timer
+
+  elsif platform[/n7k/]
+    unprops <<
+      :startup_timer
+  end
+
+  # TBD: this is due to nxos bug on n8k and n9k
+  unprops << :interval if platform[/n(8|9)k/]
+
+  unprops
+end
 
 # Overridden to properly handle dependencies for this test file.
 def test_harness_dependencies(_tests, id)
-  return unless id[/non_default_/]
+  return unless id[/non_default/]
   cmd = 'interface loopback 10'
   command_config(agent, cmd, cmd)
 end
@@ -263,19 +163,12 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("#### This device is of type: #{device} #####")
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default_plat_1)
-  test_harness_run(tests, :default_plat_2)
-  test_harness_run(tests, :default_plat_3)
-  test_harness_run(tests, :default_plat_4)
+  test_harness_run(tests, :default)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default_plat_1)
-  test_harness_run(tests, :non_default_plat_2)
-  test_harness_run(tests, :non_default_plat_3)
-  test_harness_run(tests, :non_default_plat_4)
+  test_harness_run(tests, :non_default)
   resource_absent_cleanup(agent, 'cisco_bfd_global')
-  skipped_tests_summary(tests)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -83,7 +83,6 @@ tests[:default_plat_2] = {
   manifest_props: {
     echo_interface:        'default',
     echo_rx_interval:      'default',
-    interval:              'default',
     ipv4_echo_rx_interval: 'default',
     ipv4_interval:         'default',
     ipv4_slow_timer:       'default',
@@ -97,7 +96,6 @@ tests[:default_plat_2] = {
   resource:       {
     echo_interface:        'false',
     echo_rx_interval:      50,
-    interval:              default_interval_plat_2,
     ipv4_echo_rx_interval: 50,
     ipv4_interval:         default_interval_plat_2,
     ipv4_slow_timer:       2000,
@@ -174,12 +172,12 @@ tests[:default_plat_4] = {
 # Non-default Tests. NOTE: [:resource] = [:manifest_props] for all non-default
 
 tests[:non_default_plat_1] = {
-  desc:           '2.1 Non Defaults for n3k, n8k, n9k',
-  platform:       'n(3|8|9)k',
+  desc:           '2.1 Non Defaults for n3k',
+  platform:       'n3k',
   title_pattern:  'default',
   preclean:       'cisco_bfd_global',
   manifest_props: {
-    echo_interface:        10,
+    echo_interface:        'loopback10',
     echo_rx_interval:      300,
     interval:              non_default_interval,
     ipv4_echo_rx_interval: 100,
@@ -194,12 +192,31 @@ tests[:non_default_plat_1] = {
 }
 
 tests[:non_default_plat_2] = {
-  desc:           '2.2 Non Defaults for n5k, n6k',
+  desc:           '2.2 Non Defaults for n8k, n9k',
+  platform:       'n(8|9)k',
+  title_pattern:  'default',
+  preclean:       'cisco_bfd_global',
+  manifest_props: {
+    echo_interface:        'loopback10',
+    echo_rx_interval:      300,
+    ipv4_echo_rx_interval: 100,
+    ipv4_interval:         non_default_ipv4_interval,
+    ipv4_slow_timer:       10_000,
+    ipv6_echo_rx_interval: 200,
+    ipv6_interval:         non_default_ipv6_interval,
+    ipv6_slow_timer:       25_000,
+    slow_timer:            5000,
+    startup_timer:         25,
+  },
+}
+
+tests[:non_default_plat_3] = {
+  desc:           '2.3 Non Defaults for n5k, n6k',
   platform:       'n(5|6)k',
   title_pattern:  'default',
   preclean:       'cisco_bfd_global',
   manifest_props: {
-    echo_interface:        10,
+    echo_interface:        'loopback10',
     fabricpath_interval:   non_default_fabricpath_interval,
     fabricpath_slow_timer: 15_000,
     fabricpath_vlan:       100,
@@ -208,13 +225,13 @@ tests[:non_default_plat_2] = {
   },
 }
 
-tests[:non_default_plat_3] = {
-  desc:           '2.3 Non Defaults for n7k',
+tests[:non_default_plat_4] = {
+  desc:           '2.4 Non Defaults for n7k',
   platform:       'n7k',
   title_pattern:  'default',
   preclean:       'cisco_bfd_global',
   manifest_props: {
-    echo_interface:        10,
+    echo_interface:        'loopback10',
     echo_rx_interval:      300,
     fabricpath_interval:   non_default_fabricpath_interval,
     fabricpath_slow_timer: 15_000,
@@ -256,6 +273,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :non_default_plat_1)
   test_harness_run(tests, :non_default_plat_2)
   test_harness_run(tests, :non_default_plat_3)
+  test_harness_run(tests, :non_default_plat_4)
   resource_absent_cleanup(agent, 'cisco_bfd_global')
   skipped_tests_summary(tests)
 end


### PR DESCRIPTION
This PR is for the cisco_bfd_global provider. 
All tests for demo_manifests and beaker pass across all platforms.
one property (interval) is not supported on n8k and n9k due to platform code issue. 
The changelog and README are updated except for n8k (which is missing globally).