### PR TITLE
test_vdc: fix for non-F3 testbeds

### DIFF
--- a/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
+++ b/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
@@ -29,6 +29,9 @@ tests = {
   platform:      'n7k',
 }
 
+# Skip -ALL- tests if a top-level platform/os key exludes this platform
+skip_unless_supported(tests)
+
 tests[:non_default] = {
   desc:           "1.1 Non Default Properties 'change name, state and fabric_control",
   title_pattern:  '100',

--- a/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain_vni.rb
+++ b/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain_vni.rb
@@ -23,12 +23,15 @@ testheader = 'Resource cisco_bridge_domain_vni'
 
 # Top-level keys set by caller:
 tests = {
-  master:           master,
   agent:            agent,
-  resource_name:    'cisco_bridge_domain_vni',
-  platform:         'n7k',
+  master:           master,
   operating_system: 'nexus',
+  platform:         'n7k',
+  resource_name:    'cisco_bridge_domain_vni',
 }
+
+# Skip -ALL- tests if a top-level platform/os key exludes this platform
+skip_unless_supported(tests)
 
 tests[:default] = {
   title_pattern:  '100-110',
@@ -37,36 +40,43 @@ tests[:default] = {
   },
 }
 
-tests[:non_default_properties_change_member_vni] = {
-  desc:           '2.1 Non Default Properties for ordered member vni',
+tests[:non_default] = {
+  desc:           '2.1 Non Default',
   title_pattern:  '100-110',
   manifest_props: {
     member_vni: '5100-5105,6050,7000-7001,5050,8000'
   },
 }
 
-tests[:non_default_properties_random_member_vni] = {
-  desc:           '3.1 Non Default Properties for random member vni',
+tests[:non_default_random] = {
+  desc:           '2.2 Non Default Properties for random member vni',
   title_pattern:  '100-105,150,200-203',
   manifest_props: {
     member_vni: '5100-5105,6050,7000-7001,5050,8000'
   },
 }
 
+def test_harness_dependencies(_tests, id)
+  return unless id == :non_default
+
+  # feature vni requires F3 linecards
+  limit_resource_module_type_set(default_vdc_name, 'f3')
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{testheader}" do
   # -------------------------------------------------------------------
-  logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  id = :non_default_properties_change_member_vni
-  test_harness_run(tests, id)
-  resource_absent_cleanup(agent, 'cisco_bridge_domain_vni', 'bridge-domain CLEANUP :: ')
+  test_harness_run(tests, :non_default)
+  resource_absent_cleanup(agent, 'cisco_bridge_domain_vni')
 
-  id = :non_default_properties_random_member_vni
-  test_harness_run(tests, id)
-  resource_absent_cleanup(agent, 'cisco_bridge_domain_vni', 'bridge-domain CLEANUP :: ')
+  test_harness_run(tests, :non_default_random)
+  resource_absent_cleanup(agent, 'cisco_bridge_domain_vni')
+
+  teardown_vdc
 end
 
 logger.info('TestCase :: # {testheader} :: End')

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -32,6 +32,9 @@ tests = {
   resource_name:    'cisco_vdc',
 }
 
+# Skip -ALL- tests if a top-level platform/os key exludes this platform
+skip_unless_supported(tests)
+
 # Test hash test cases
 tests[:non_default] = {
   desc:           '1.1 non default properties',
@@ -50,22 +53,10 @@ def test_harness_dependencies(_tests, id)
   limit_resource_module_type_set(default_vdc_name, nil)
 end
 
-def teardown_vdc
-  logger.info("\n* Teardown VDC")
-
-  # Testbeds without F3 cards should be set back to their default state;
-  # failure to do so will leave the testbed without usable interfaces.
-  # Assume that F3 testbeds should be left with module-type set to F3.
-  limit_resource_module_type_set(default_vdc_name, nil) unless
-    mt_full_interface
-end
-
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
-  skip_unless_supported(tests)
-
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
   test_harness_run(tests, :non_default)

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -921,6 +921,17 @@ def vdc_allocate_interface_set(vdc, intf)
   on(agent, cmd, pty: true)
 end
 
+# VDC post-test cleanup
+def teardown_vdc
+  logger.info("\n* Teardown VDC")
+
+  # Testbeds without F3 cards should be set back to their default state;
+  # failure to do so will leave the testbed without usable interfaces.
+  # Assume that F3 testbeds should be left with module-type set to F3.
+  limit_resource_module_type_set(default_vdc_name, nil) unless
+    mt_full_interface
+end
+
 # Facter command builder helper method
 def facter_cmd(cmd)
   FACTER_BINPATH + cmd


### PR DESCRIPTION
* Updated this test to work with non-F3 N7k testbeds.
  * Initially set the VDC module-type to default state
  * Then set module-type to F3 and test
  * There's no great way to know which way to leave the module-type when this test completes, so:
    * Reset module-type to default for non-F3 testbeds since leaving it as F3 means the device won't have any usable interfaces
    * Noop for F3 testbeds so that it leaves their F3 still usable

* Tested on n6, n7-non-F3

Edit: Added some add'l fixes for bridge-domain tests