### PR TITLE
Fix vxlan_vtep_vni suppress_uuc prop

### DIFF
--- a/lib/puppet/provider/cisco_vxlan_vtep_vni/cisco.rb
+++ b/lib/puppet/provider/cisco_vxlan_vtep_vni/cisco.rb
@@ -42,7 +42,8 @@ Puppet::Type.type(:cisco_vxlan_vtep_vni).provide(:cisco) do
   ]
 
   VXLAN_VTEP_VNI_BOOL_PROPS = [
-    :suppress_arp
+    :suppress_arp,
+    :suppress_uuc,
   ]
 
   VXLAN_VTEP_VNI_ALL_PROPS =

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -398,7 +398,7 @@ test_name "TestCase :: #{testheader}" do
   tests[id][:desc] = '2.6 Multicast Group'
   test_harness_cisco_vxlan_vtep_vni(tests, id)
 
-  # TBD - The following tests will generate the following error.
+  # TBD - The suppress_arp tests will generate the following error.
   #  ERROR: Please configure TCAM region... Configuring the TCAM region
   # requires a switch reboot.  These tests will remain commented out
   # until we can design a solution.
@@ -411,13 +411,13 @@ test_name "TestCase :: #{testheader}" do
   # tests[id][:desc] = '2.8 Suppress ARP'
   # test_harness_cisco_vxlan_vtep_vni(tests, id)
 
-  # id = 'suppress_uuc_true'
-  # tests[id][:desc] = '2.9 Suppress Unknown Unicast'
-  # test_harness_cisco_vxlan_vtep_vni(tests, id)
-  #
-  # id = 'suppress_uuc_false'
-  # tests[id][:desc] = '2.10 Suppress Unknown Unicast'
-  # test_harness_cisco_vxlan_vtep_vni(tests, id)
+  id = 'suppress_uuc_true'
+  tests[id][:desc] = '2.9 Suppress Unknown Unicast'
+  test_harness_cisco_vxlan_vtep_vni(tests, id)
+
+  id = 'suppress_uuc_false'
+  tests[id][:desc] = '2.10 Suppress Unknown Unicast'
+  test_harness_cisco_vxlan_vtep_vni(tests, id)
 
   resource_absent_cleanup(agent, 'cisco_vxlan_vtep_vni',
                           'Setup switch for cisco_vxlan_vtep_vni provider test')


### PR DESCRIPTION
The suppress_uuc property was never really added to puppet.  This adds the property and un-comments the associated test cases.

Tested on: n5k, n6k(skips), n8k, n9k(I2 and I3)