### PR TITLE
Test get set

### DIFF
--- a/lib/puppet/provider/cisco_command_config/cisco.rb
+++ b/lib/puppet/provider/cisco_command_config/cisco.rb
@@ -85,4 +85,35 @@ Puppet::Type.type(:cisco_command_config).provide(:cisco) do
     info "Successfully updated:\n#{e.previous.join("\n")}" unless e.previous.empty?
     raise
   end # command=
+
+  def test_get
+    # This method is for beaker use only. It allows beaker to retrieve any
+    # configuration it needs from the device using puppet resource. Callers
+    # must pass a filter string to test_get.
+    # Example usage:
+    #  puppet resource cisco_command_config 'cc' test_get='incl feature'
+    cmd = 'show running-config all'
+    cmd << " | #{@resource[:test_get]}" if @resource[:test_get]
+
+    result = @node.get(command: cmd)
+    "\n" + result unless result.nil?
+  end
+
+  def test_get=(noop)
+    # This is a dummy setter to keep Puppet from raising an error.
+  end
+
+  def test_set
+    # This is a dummy getter to keep Puppet from raising an error.
+  end
+
+  def test_set=(cmds)
+    # This method is for beaker use only. It allows beaker to set simple raw
+    # configuration using puppet resource.
+    # Example usage:
+    #  puppet resource cisco_command_config 'cc' test_set='no feature foo'
+    return if cmds.empty?
+    output = @node.set(values: cmds)
+    debug "Output from node:\n#{output}" unless output.nil?
+  end
 end # Puppet::Type

--- a/lib/puppet/type/cisco_command_config.rb
+++ b/lib/puppet/type/cisco_command_config.rb
@@ -106,4 +106,37 @@ Puppet::Type.newtype(:cisco_command_config) do
       value.gsub!(/^(#{indent_level})/, '') # remove extra indentation
     end # validate
   end # property command
+
+  newproperty(:test_get) do
+    desc %(
+      This is a test-only property for beaker use. It allows beaker to retrieve
+      any configuration it needs from the device using puppet resource. Callers
+      must pass a filter string to test_get.
+      Example usage:
+        puppet resource cisco_command_config 'cc' test_get='incl feature'
+    )
+
+    def insync?(*)
+      # This is a "get-only" property so insync? is overridden to prevent
+      # puppet from displaying the following notice:
+      #   Notice: /Cisco_command_config[c]/test_get: test_get changed '' to ''
+      true
+    end
+  end
+
+  newproperty(:test_set) do
+    desc %(
+      This is a test-only property for beaker use. It allows beaker to set
+      simple raw configuration using puppet resource.
+      Example usage:
+       puppet resource cisco_command_config 'cc' test_set='no feature foo'
+    )
+
+    munge do |value|
+      value << "\n"
+      value.gsub!(/^\s*$\n/, '')
+      indent_level = value.match(/\A\s*/)
+      value.gsub!(/^(#{indent_level})/, '') # remove extra indentation
+    end
+  end
 end # Puppet::Type.newtype

--- a/tests/beaker_tests/cisco_command_config/test_command_config.rb
+++ b/tests/beaker_tests/cisco_command_config/test_command_config.rb
@@ -222,6 +222,27 @@ tests['configure_loopback_interface'] = {
 # HELPER FUNCTIONS
 #################################################################
 
+def test_set_get
+  stepinfo = 'Test test_get/test_set properties'
+  logger.info("\n#{'-' * 60}\n#{stepinfo}")
+  cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
+
+  logger.info('* cleanup testbed')
+  on(agent, cmd_prefix + "test_set='no interface loopback42'")
+
+  logger.info('* create config')
+  on(agent, cmd_prefix + "test_set='interface loopback42'")
+
+  logger.info('* check config')
+  on(agent, cmd_prefix + "test_get='incl loopback42'")
+  fail_test("TestStep :: set/get :: FAIL\nstdout:\n#{stdout}") unless
+    stdout[/^interface loopback42/]
+
+  logger.info('* cleanup testbed')
+  on(agent, cmd_prefix + "test_set='no interface loopback42'")
+  logger.info("#{stepinfo} :: PASS\n#{'-' * 60}\n")
+end
+
 # Full command string for puppet resource command used to verify
 # the configuration applied by the cisco_command_config resource.
 def puppet_resource_cmd(tests, id)
@@ -290,6 +311,8 @@ test_name "TestCase :: #{testheader}" do
   id = 'configure_loopback_interface'
   tests[id][:desc] = '1.5 Apply INTERFACE Config'
   test_harness_cisco_command_config(tests, id)
+
+  test_set_get
 end
 
 logger.info('TestCase :: # {testheader} :: End')

--- a/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
@@ -64,7 +64,7 @@ testheader = 'SERVICE Resource :: All Attributes NonDefaults'
 # @test_name [TestCase] Executes nondefaults testcase for SERVICE Resource.
 test_name "TestCase :: #{testheader}" do
   raise_skip_exception('Not supported for OAC platforms', self) if
-    platform[/'n5|6|7|k'/]
+    platform[/n(5|6|7)k/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -810,7 +810,7 @@ end
 
 # Helper to set properties using the puppet resource command.
 def resource_set(agent, resource, msg='')
-  logger.info("\n#{msg}")
+  logger.info("\nresource_set: #{msg}")
   if resource.is_a?(Array)
     cmd =
       "resource %s '%s' %s='%s'" % resource # rubocop:disable Style/FormatString


### PR DESCRIPTION
Add test_get / test_set to command_config
* Needed a way for beaker to query / set config that didn't have explicit resource support (e.g. disabling a feature)

* test_get is a simple get-only property that does a show running; callers set a filter to parse what they need:
    puppet resource cisco_command_config 'cc' test_get='incl feature'

* test_set is a simple set-only property:
    puppet resource cisco_command_config 'cc' test_set='no feature foo'

* Also fixed a bad regex in file_service_package

* Tested on n3,n5,n7,n9