### PR TITLE
Added IOS XR support for snmp_user

### DIFF
--- a/examples/netdev/demo_snmp.pp
+++ b/examples/netdev/demo_snmp.pp
@@ -29,14 +29,29 @@ class ciscopuppet::netdev::demo_snmp {
     acl    => 'testcomacl',
   }
 
+  $password = $operatingsystem ? {
+    'nexus' => '0x7e5030ffd26d7e1b366a9041e9c63c94',
+    default => '0307530A080824414B'
+  }
+
+  $private_key = $operatingsystem ? {
+    'nexus' => '0xcc012f26b3384d4b3da979bff48b4ffe',
+    default => '12491D42475E5A'
+  }
+
+  $localized_key = $operatingsystem ? {
+    'ios_xr' => undef,
+    default  => true
+  }
+
   snmp_user { 'test_snmp_user':
     ensure          => present,
     roles           => ['network-operator'],
     auth            => 'md5',
-    password        => '0x7e5030ffd26d7e1b366a9041e9c63c94',
+    password        => $password,
     privacy         => 'aes128',
-    private_key     => '0xcc012f26b3384d4b3da979bff48b4ffe',
-    localized_key   => true,
+    private_key     => $private_key,
+    localized_key   => $localized_key,
   }
 
   snmp_notification { 'vtp vlandelete':

--- a/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
+++ b/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
@@ -68,7 +68,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpUserLib.create_snmp_user_manifest_present)
+    on(master, SnmpUserLib.create_snmp_user_manifest_present(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -89,12 +89,25 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
       search_pattern_in_output(stdout, { 'auth' => 'md5' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
-                               false, self, logger)
+
+      if operating_system == 'ios_xr'
+        search_pattern_in_output(stdout, { 'password' => '0307530A080824414B' },
+                                 false, self, logger)
+      else
+        search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
+                                 false, self, logger)
+      end
+
       search_pattern_in_output(stdout, { 'privacy' => 'aes128' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
-                               false, self, logger)
+
+      if operating_system == 'ios_xr'
+        search_pattern_in_output(stdout, { 'private_key' => '12491D42475E59' },
+                                 false, self, logger)
+      else
+        search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
+                                 false, self, logger)
+      end
     end
 
     logger.info("Check snmp_user resource presence on agent :: #{result}")
@@ -103,7 +116,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present (with changes)manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpUserLib.create_snmp_user_manifest_present_change)
+    on(master, SnmpUserLib.create_snmp_user_manifest_present_change(operating_system))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -121,15 +134,27 @@ test_name "TestCase :: #{testheader}" do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'engine_id' => '128:0:0:9:3:8:0:39:34:152:217' },
-                               false, self, logger)
+                               false, self, logger) unless operating_system == 'ios_xr'
       search_pattern_in_output(stdout, { 'auth' => 'sha' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
-                               false, self, logger)
+
+      if operating_system == 'ios_xr'
+        search_pattern_in_output(stdout, { 'password' => '0307530A080824414B' },
+                                 false, self, logger)
+      else
+        search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
+                                 false, self, logger)
+      end
+
       search_pattern_in_output(stdout, { 'privacy' => 'des' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
-                               false, self, logger)
+      if operating_system == 'ios_xr'
+        search_pattern_in_output(stdout, { 'private_key' => '12491D42475E59' },
+                                 false, self, logger)
+      else
+        search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
+                                 false, self, logger)
+      end
     end
 
     logger.info("Check snmp_user resource presence on agent :: #{result}")

--- a/tests/beaker_tests/snmp_user/snmp_userlib.rb
+++ b/tests/beaker_tests/snmp_user/snmp_userlib.rb
@@ -44,8 +44,8 @@ module SnmpUserLib
   # where 'ensure' is set to present.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_snmp_user_manifest_present
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_snmp_user_manifest_present(type)
+    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_user { 'test_snmp_user':
     ensure          => present,
@@ -58,20 +58,34 @@ node default {
   }
 }
 EOF"
-    manifest_str
+
+    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_user { 'test_snmp_user':
+    ensure          => present,
+    roles           => ['network-operator'],
+    version         => 'v3',
+    auth            => 'md5',
+    password        => '0307530A080824414B',
+    privacy         => 'aes128',
+    private_key     => '12491D42475E59',
+  }
+}
+EOF"
+    type == 'ios_xr' ? ios_xr_str : nxos_str
   end
 
   # Method to create a manifest for snmp_user resource attribute 'ensure'
   # where 'ensure' is set to present, and a few changes made from above.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_snmp_user_manifest_present_change
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_snmp_user_manifest_present_change(type)
+    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_user { 'test_snmp_user':
     ensure          => present,
     auth            => 'sha',
-    password        => '0x7e5030ffd26d7e1b366a9041e9c63c94',
+    password        => '0307530A080824414B',
     privacy         => 'des',
     private_key     => '0xcc012f26b3384d4b3da979bff48b4ffe',
     localized_key   => true,
@@ -79,7 +93,21 @@ node default {
   }
 }
 EOF"
-    manifest_str
+
+    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  snmp_user { 'test_snmp_user':
+    ensure          => present,
+    roles           => ['network-operator'],
+    version         => 'v3',
+    auth            => 'sha',
+    password        => '0307530A080824414B',
+    privacy         => 'des',
+    private_key     => '12491D42475E59',
+  }
+}
+EOF"
+    type == 'ios_xr' ? ios_xr_str : nxos_str
   end
 
   # Method to create a manifest for snmp_user resource attribute 'ensure'


### PR DESCRIPTION
This is to bring IOS XR support to snmp_user
This provider does not supported unencrypted passwords, thus all password specified must be already encrypted.

```
tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb passed in 234.26 seconds
      Test Suite: tests @ 2016-06-14 18:04:38 +0100

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 234.28 seconds
      Average Test Time: 234.28 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -
```