### PR TITLE
command_config: undefined method 'previous'

### DIFF
--- a/lib/puppet/provider/cisco_command_config/cisco.rb
+++ b/lib/puppet/provider/cisco_command_config/cisco.rb
@@ -82,7 +82,9 @@ Puppet::Type.type(:cisco_command_config).provide(:cisco) do
 
   rescue Cisco::CliError => e
     # Tell the user what succeeded, then fail with the actual failure.
-    info "Successfully updated:\n#{e.previous.join("\n")}" unless e.previous.empty?
+    unless e.successful_input.empty?
+      info "Successfully updated:\n#{e.successful_input.join("\n")}"
+    end
     raise
   end # command=
 


### PR DESCRIPTION
* Symptom: Simple cc manifest with a faulty line of config:

cisco_command_config { 'interface':
   command  => '
     interface loopback42
     ipv6 pim foo
   '
}

When puppet agent runs the cc provider drops into a rescue which should first print out the parts of the config that were successfully processed and then do a raise, but instead we see:

```
  Error: undefined method 'previous' for #<Cisco::CliError:0x0000000460ac08>
```

* Analysis: `client.rb` was refactored a few months ago, wherein the `previous` hash key was renamed to `successful_input`. The cc providers (both puppet & chef) never got updated with the new key name.
  * Ref: https://github.com/cisco/cisco-network-node-utils/blob/develop/lib/cisco_node_utils/client/nxapi/client.rb#L285

* Testing:

```
Linux# puppet agent -t --debug
 ...
Info: Cisco_command_config[interface](provider=cisco): Successfully updated:
interface loopback42
Error: The command 'ipv6 pim foo' was rejected with error:
% Invalid command

Error: /Stage[main]/Main/Node[default]/Cisco_command_config[interface]/command: change from  to interface loopback42
ipv6 pim foo
 failed: The command 'ipv6 pim foo' was rejected with error:
% Invalid command

```