### PR TITLE
Hotfix 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.2] - TBD
+### Fixed:
+- Remove `autorequire` references in cisco types.
+  - Fixes incompatibility between cisco resources and latest puppet agent rpm.
+- Fix `undefined method 'previous'` bug in `cisco_command_config` provider. 
+
 ## [1.3.1] - 2016-05-06
 
 ### New feature support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@ This version was never released.
 - Initial release of puppetlabs-ciscopuppet module, supporting Cisco NX-OS software release 7.0(3)I2(1) on Cisco Nexus switch platforms: N95xx, N93xx, N30xx and N31xx.
 - Please note: 0.9.0 is an EFT pre-release for a limited audience with access to NX-OS 7.0(3)I2(1). Additional code changes may occur in 0.9.x prior to the final 1.0.0 release.
 
+[1.3.2]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.3...v1.3.1
 [1.2.3]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/cisco/cisco-network-puppet-module/compare/v1.2.0...v1.2.2

--- a/lib/puppet/provider/cisco_command_config/cisco.rb
+++ b/lib/puppet/provider/cisco_command_config/cisco.rb
@@ -74,7 +74,9 @@ Puppet::Type.type(:cisco_command_config).provide(:cisco) do
 
   rescue Cisco::CliError => e
     # Tell the user what succeeded, then fail with the actual failure.
-    info "Successfully updated:\n#{e.previous.join("\n")}" unless e.previous.empty?
+    unless e.successful_input.empty?
+      info "Successfully updated:\n#{e.successful_input.join("\n")}"
+    end
     raise
   end # command=
 end # Puppet::Type

--- a/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
@@ -95,25 +95,4 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_cfg_svc) do
 
     newvalues(:local, :unselected, :default)
   end
-
-  ################
-  # Autorequires #
-  ################
-
-  # At a minimum, tacacs_server must be enabled to use these features
-  autorequire(:cisco_tacacs_server) do |rel_catalog|
-    rel_catalog.catalog.resource('Cisco_tacacs_server', 'default')
-  end
-
-  # Autorequire all cisco_aaa_group_tacacs associated with this service
-  autorequire(:cisco_aaa_group_tacacs) do |rel_catalog|
-    groups = []
-    if self[:groups]
-      self[:groups].flatten.each do |group|
-        groups << rel_catalog.catalog.resource('Cisco_aaa_group_tacacs',
-                                               "#{group}")
-      end
-    end
-    groups
-  end
 end

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -95,25 +95,4 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
 
     newvalues(:local, :unselected, :default)
   end
-
-  ################
-  # Autorequires #
-  ################
-
-  # At a minimum, tacacs_server must be enabled to use these features
-  autorequire(:cisco_tacacs_server) do |rel_catalog|
-    rel_catalog.catalog.resource('Cisco_tacacs_server', 'default')
-  end
-
-  # Autorequire all cisco_aaa_group_tacacs associated with this service
-  autorequire(:cisco_aaa_group_tacacs) do |rel_catalog|
-    groups = []
-    if self[:groups]
-      self[:groups].flatten.each do |group|
-        groups << rel_catalog.catalog.resource('Cisco_aaa_group_tacacs',
-                                               "#{group}")
-      end
-    end
-    groups
-  end
 end

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -925,22 +925,4 @@ Puppet::Type.newtype(:cisco_interface) do
       (is.size == should.flatten.size && is.sort == should.flatten.sort)
     end
   end # private_vlan_mapping
-
-  ################
-  # Autorequires #
-  ################
-
-  autorequire(:cisco_vlan) do |rel_catalog|
-    reqs = []
-    unless self[:access_vlan].nil? || self[:access_vlan] == :default
-      reqs << rel_catalog.catalog.resource('Cisco_vlan', "#{self[:access_vlan]}")
-    end # if
-    reqs
-  end # autorequire vlan
-
-  autorequire(:cisco_vtp) do |rel_catalog|
-    reqs = []
-    reqs << rel_catalog.catalog.resource('Cisco_vtp')
-    reqs # return
-  end # autorequire vtp
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_interface_ospf.rb
+++ b/lib/puppet/type/cisco_interface_ospf.rb
@@ -20,7 +20,6 @@ require 'ipaddr'
 
 Puppet::Type.newtype(:cisco_interface_ospf) do
   @doc = "Manages configuration of an OSPF interface instance
-  **Autorequires:** cisco_interface, cisco_ospf
 
   cisco_interface_ospf {\"<interface> <ospf>\":
     ..attributes..
@@ -273,37 +272,5 @@ Puppet::Type.newtype(:cisco_interface_ospf) do
        !/^lo\S+$/.match(self[:interface].downcase).nil?
       fail 'passive_interface value cannot be set on loopback interfaces'
     end
-  end
-
-  ################
-  # Autorequires #
-  ################
-
-  # Autorequire cisco_interface; do not fail if it is not present in the manifest
-  autorequire(:cisco_interface) do |rel_catalog|
-    reqs = []
-
-    interface_title = self[:interface]
-
-    dep = rel_catalog.catalog.resource('cisco_interface', interface_title)
-
-    info "Cisco_interface[#{interface_title}] was not found in catalog. " \
-         'Will obtain from device.' if dep.nil?
-    reqs << dep
-    reqs
-  end
-
-  # Autorequire cisco_ospf; do not fail if it is not present in the manifest
-  autorequire(:cisco_ospf) do |rel_catalog|
-    reqs = []
-
-    ospf_title = self[:ospf]
-
-    dep = rel_catalog.catalog.resource('cisco_ospf', ospf_title)
-
-    info "Cisco_ospf[#{ospf_title}] was not found in catalog. " \
-         'Will obtain from device.' if dep.nil?
-    reqs << dep
-    reqs
   end
 end

--- a/lib/puppet/type/cisco_snmp_community.rb
+++ b/lib/puppet/type/cisco_snmp_community.rb
@@ -93,16 +93,4 @@ Puppet::Type.newtype(:cisco_snmp_community) do
       value
     end
   end
-
-  ################
-  # Autorequires #
-  ################
-
-  # Autorequire all cisco_snmp_groups associated with this community
-  autorequire(:cisco_snmp_group) do |rel_catalog|
-    groups = []
-    groups << rel_catalog.catalog.resource('Cisco_snmp_group',
-                                           "#{self[:group]}")
-    groups
-  end
 end

--- a/lib/puppet/type/cisco_snmp_user.rb
+++ b/lib/puppet/type/cisco_snmp_user.rb
@@ -18,7 +18,6 @@
 
 Puppet::Type.newtype(:cisco_snmp_user) do
   @doc = "Manages an SNMP user on an cisco SNMP server.
-  **Autorequires:** cisco_snmp_group
 
   cisco_snmp_user {\"<user> <engine_id>\":
     ..attributes..
@@ -163,23 +162,5 @@ Puppet::Type.newtype(:cisco_snmp_user) do
           false)."
     defaultto(:false)
     newvalues(:true, :false)
-  end
-
-  ################
-  # Autorequires #
-  ################
-
-  # Autorequire all cisco_snmp_groups associated with this user
-  autorequire(:cisco_snmp_group) do |rel_catalog|
-    groups = []
-
-    unless self[:groups].nil?
-      (self[:groups]).select do |group|
-        group_name = "#{group}"
-        groups << rel_catalog.catalog.resource('cisco_snmp_group', group_name)
-      end
-    end
-
-    groups
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ciscopuppet",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "cisco",
   "summary": "Cisco Puppet providers and types for NX-OS devices",
   "license": "Apache-2.0",


### PR DESCRIPTION
This update fixes the following issues:

- Remove autorequire references in cisco types.
  - Fixes incompatibility between cisco resources and latest puppet agent rpm.
- Fix undefined method 'previous' bug in cisco_command_config provider.

Full beaker results using FCS dublin image:
```
Overall Stats
    Passed     : 104
    Passx      : 0
    Failed     : 0
    Aborted    : 0
    Blocked    : 0
    Skipped    : 15
    Errored    : 3

    TOTAL      : 122

Success Rate   : 97.54 %
```
The errored test cases are the following:
- DNS test case that is intentionally commented out.
- `test_private_vlan` passed on re-test.
- ./cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb bug in dublin image.