### PR TITLE
Fix cisco_aaa* 'TACACS+ group delete denied, group is in use' issue

### DIFF
--- a/lib/puppet/provider/cisco_tacacs_server/cisco.rb
+++ b/lib/puppet/provider/cisco_tacacs_server/cisco.rb
@@ -142,7 +142,6 @@ Puppet::Type.type(:cisco_tacacs_server).provide(:cisco) do
   def deadtime
     if @resource[:deadtime] == :default &&
        @property_hash[:deadtime] == Cisco::TacacsServer.default_deadtime
-      debug "Default value is #{deadtime_value}."
       deadtime = :default
     else
       deadtime = @property_hash[:deadtime]

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -95,4 +95,25 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
 
     newvalues(:local, :unselected, :default)
   end
+
+  ################
+  # Autorequires #
+  ################
+
+  # At a minimum, tacacs_server must be enabled to use these features
+  autorequire(:cisco_tacacs_server) do |rel_catalog|
+    rel_catalog.catalog.resource('Cisco_tacacs_server', 'default')
+  end
+
+  # Autorequire all cisco_aaa_group_tacacs associated with this service
+  autorequire(:cisco_aaa_group_tacacs) do |rel_catalog|
+    groups = []
+    if self[:groups]
+      self[:groups].flatten.each do |group|
+        groups << rel_catalog.catalog.resource('Cisco_aaa_group_tacacs',
+                                               "#{group}")
+      end
+    end
+    groups
+  end
 end

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -63,15 +63,16 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Defaults'
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+  command_config(agent, 'no feature tacacs+')
+end
+
 # @test_name [TestCase] Executes defaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
-  # @step [Step] Sets up switch for provider test.
-  step 'TestStep :: TestCase Setup' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
-    logger.info("TestCase Setup :: #{result}")
-  end
+  cleanup
+  teardown { cleanup }
 
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
@@ -127,13 +128,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  step 'TestStep :: TestCase Cleanup' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
-    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_defaults.rb
@@ -66,16 +66,11 @@ testheader = 'AAAGROUP Resource :: All Attributes Defaults'
 # @test_name [TestCase] Executes defaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
-  step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, TacacsServerLib.create_tacacsserver_absent)
+  step 'TestStep :: TestCase Setup' do
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
 
-    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
-    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = PUPPET_BINPATH + 'agent -t'
-    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
-
-    logger.info("Setup switch for provider test :: #{result}")
+    logger.info("TestCase Setup :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -132,6 +127,13 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  step 'TestStep :: TestCase Cleanup' do
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
+
+    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -65,13 +65,8 @@ testheader = 'AAAGROUP Resource :: All Attributes Negatives'
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, TacacsServerLib.create_tacacsserver_absent)
-
-    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
-    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = PUPPET_BINPATH + 'agent -t'
-    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
 
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, TacacsServerLib.create_tacacsserver_present)
@@ -191,6 +186,13 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  step 'TestStep :: TestCase Cleanup' do
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
+
+    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_negatives.rb
@@ -61,13 +61,19 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes Negatives'
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+  command_config(agent, 'no feature tacacs+')
+end
+
 # @test_name [TestCase] Executes negatives testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
+  cleanup
+  teardown { cleanup }
+
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, TacacsServerLib.create_tacacsserver_present)
 
@@ -186,13 +192,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  step 'TestStep :: TestCase Cleanup' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
-    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -63,15 +63,16 @@ require File.expand_path('../../cisco_tacacs_server/tacacsserverlib.rb', __FILE_
 result = 'PASS'
 testheader = 'AAAGROUP Resource :: All Attributes NonDefaults'
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+  command_config(agent, 'no feature tacacs+')
+end
+
 # @test_name [TestCase] Executes nondefaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
-  # @step [Step] Sets up switch for provider test.
-  step 'TestStep :: TestCase Setup' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
-    logger.info("TestCase Setup :: #{result}")
-  end
+  cleanup
+  teardown { cleanup }
 
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource nondefaults manifest from master' do
@@ -133,14 +134,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
-  end
-
-  # @step [Step] Sets up switch for provider test.
-  step 'TestStep :: TestCase Cleanup' do
-    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
-    command_config(agent, 'no feature tacacs+')
-
-    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/aaagroup_provider_nondefaults.rb
@@ -66,16 +66,11 @@ testheader = 'AAAGROUP Resource :: All Attributes NonDefaults'
 # @test_name [TestCase] Executes nondefaults testcase for AAAGROUP Resource.
 test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
-  step 'TestStep :: Setup switch for provider test' do
-    # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, TacacsServerLib.create_tacacsserver_absent)
+  step 'TestStep :: TestCase Setup' do
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
 
-    # Expected exit_code is 0 since this is a puppet agent cmd with no change.
-    # Or expected exit_code is 2 since this is a puppet agent cmd with change.
-    cmd_str = PUPPET_BINPATH + 'agent -t'
-    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
-
-    logger.info("Setup switch for provider test :: #{result}")
+    logger.info("TestCase Setup :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -138,6 +133,14 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_aaa_group resource absence on agent :: #{result}")
+  end
+
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: TestCase Cleanup' do
+    resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+    command_config(agent, 'no feature tacacs+')
+
+    logger.info("TestCase Cleanup :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
@@ -84,13 +84,15 @@ def create_aaalogincfgsvc_defaults(tests, id, title, string=false)
   tests[id][:resource_cmd] = resource_cmd_str
 end
 
-test_name "TestCase :: #{testheader}" do
-  stepinfo = 'Setup switch for provider test'
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_cfg_svc',
-                          stepinfo)
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
   command_config(agent, 'no feature tacacs+')
-  logger.info("TestStep :: #{stepinfo} :: #{result}")
+end
+
+test_name "TestCase :: #{testheader}" do
+  cleanup
+  teardown { cleanup }
 
   tests[id] = {}
   %w(default console).each do |title|
@@ -126,13 +128,6 @@ test_name "TestCase :: #{testheader}" do
 
     tests[id][:desc]  = '1.5 Verify resource absent on agent'
     test_resource(tests, id)
-
-    stepinfo = 'Cleanup'
-    resource_absent_cleanup(agent,
-                            'cisco_aaa_authorization_login_cfg_svc',
-                            stepinfo)
-    command_config(agent, 'no feature tacacs+')
-    logger.info("TestStep :: #{stepinfo} :: #{result}")
   end
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_defaults.rb
@@ -89,6 +89,7 @@ test_name "TestCase :: #{testheader}" do
   resource_absent_cleanup(agent,
                           'cisco_aaa_authorization_login_cfg_svc',
                           stepinfo)
+  command_config(agent, 'no feature tacacs+')
   logger.info("TestStep :: #{stepinfo} :: #{result}")
 
   tests[id] = {}
@@ -125,6 +126,13 @@ test_name "TestCase :: #{testheader}" do
 
     tests[id][:desc]  = '1.5 Verify resource absent on agent'
     test_resource(tests, id)
+
+    stepinfo = 'Cleanup'
+    resource_absent_cleanup(agent,
+                            'cisco_aaa_authorization_login_cfg_svc',
+                            stepinfo)
+    command_config(agent, 'no feature tacacs+')
+    logger.info("TestStep :: #{stepinfo} :: #{result}")
   end
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_negative.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_negative.rb
@@ -65,6 +65,7 @@ tests = {
 test_name "TestCase :: #{testheader}" do
   logger.info('Test Invalid Title Pattern')
   resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
+  command_config(agent, 'no feature tacacs+')
 
   id = 'invalid_name'
   tests[id] = {
@@ -76,6 +77,10 @@ test_name "TestCase :: #{testheader}" do
   }
   create_aaalogincfgsvc_manifest_simple(tests, id)
   test_manifest(tests, id)
+
+  # Cleanup
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
+  command_config(agent, 'no feature tacacs+')
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_negative.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_negative.rb
@@ -62,10 +62,17 @@ tests = {
   :agent  => agent,
 }
 
-test_name "TestCase :: #{testheader}" do
-  logger.info('Test Invalid Title Pattern')
+def cleanup
+  logger.info('Testcase Cleanup:')
   resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
   command_config(agent, 'no feature tacacs+')
+end
+
+test_name "TestCase :: #{testheader}" do
+  logger.info('Test Invalid Title Pattern')
+
+  cleanup
+  teardown { cleanup }
 
   id = 'invalid_name'
   tests[id] = {
@@ -77,10 +84,6 @@ test_name "TestCase :: #{testheader}" do
   }
   create_aaalogincfgsvc_manifest_simple(tests, id)
   test_manifest(tests, id)
-
-  # Cleanup
-  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
-  command_config(agent, 'no feature tacacs+')
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
@@ -64,13 +64,17 @@ tests = {
   :agent  => agent,
 }
 
-test_name "TestCase :: #{testheader}" do
-  si = 'Setup switch for provider test'
-  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc', si)
-  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs', si)
-  resource_absent_cleanup(agent, 'cisco_tacacs_server_host', si)
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc')
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+  resource_absent_cleanup(agent, 'cisco_tacacs_server_host')
   command_config(agent, 'no feature tacacs+')
-  logger.info("TestStep :: #{si} :: #{result}")
+end
+
+test_name "TestCase :: #{testheader}" do
+  cleanup
+  teardown { cleanup }
 
   tests[id] = {}
   %w(console default).each do |title|
@@ -117,12 +121,6 @@ test_name "TestCase :: #{testheader}" do
     test_manifest(tests, id)
     test_resource(tests, id)
   end
-
-  si = 'Cleanup'
-  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc', si)
-  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs', si)
-  resource_absent_cleanup(agent, 'cisco_tacacs_server_host', si)
-  command_config(agent, 'no feature tacacs+')
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_cfg_svc/test_aaalogincfgsvc_nondefaults.rb
@@ -65,11 +65,12 @@ tests = {
 }
 
 test_name "TestCase :: #{testheader}" do
-  stepinfo = 'Setup switch for provider test'
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_cfg_svc',
-                          stepinfo)
-  logger.info("TestStep :: #{stepinfo} :: #{result}")
+  si = 'Setup switch for provider test'
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc', si)
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs', si)
+  resource_absent_cleanup(agent, 'cisco_tacacs_server_host', si)
+  command_config(agent, 'no feature tacacs+')
+  logger.info("TestStep :: #{si} :: #{result}")
 
   tests[id] = {}
   %w(console default).each do |title|
@@ -117,9 +118,11 @@ test_name "TestCase :: #{testheader}" do
     test_resource(tests, id)
   end
 
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_cfg_svc',
-                          stepinfo)
+  si = 'Cleanup'
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_cfg_svc', si)
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs', si)
+  resource_absent_cleanup(agent, 'cisco_tacacs_server_host', si)
+  command_config(agent, 'no feature tacacs+')
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_defaults.rb
@@ -84,12 +84,15 @@ def create_aaaloginexecsvc_defaults(tests, id, title, string=false)
   tests[id][:resource_cmd] = resource_cmd_str
 end
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_exec_svc')
+  command_config(agent, 'no feature tacacs+')
+end
+
 test_name "TestCase :: #{testheader}" do
-  stepinfo = 'Setup switch for provider test'
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_exec_svc',
-                          stepinfo)
-  logger.info("TestStep :: #{stepinfo} :: #{result}")
+  cleanup
+  teardown { cleanup }
 
   tests[id] = {}
   %w(default console).each do |title|
@@ -126,6 +129,7 @@ test_name "TestCase :: #{testheader}" do
     tests[id][:desc]  = '1.5 Verify resource absent on agent'
     test_resource(tests, id)
   end
+
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)
 end

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_negative.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_negative.rb
@@ -62,9 +62,17 @@ tests = {
   :agent  => agent,
 }
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_exec_svc')
+  command_config(agent, 'no feature tacacs+')
+end
+
 test_name "TestCase :: #{testheader}" do
   logger.info('Test Invalid Title Pattern')
-  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_exec_svc')
+
+  cleanup
+  teardown { cleanup }
 
   id = 'invalid_name'
   tests[id] = {

--- a/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
+++ b/tests/beaker_tests/cisco_aaa_login_exec_svc/test_aaaloginexecsvc_nondefaults.rb
@@ -64,12 +64,17 @@ tests = {
   :agent  => agent,
 }
 
+def cleanup
+  logger.info('Testcase Cleanup:')
+  resource_absent_cleanup(agent, 'cisco_aaa_authorization_login_exec_svc')
+  resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')
+  resource_absent_cleanup(agent, 'cisco_tacacs_server_host')
+  command_config(agent, 'no feature tacacs+')
+end
+
 test_name "TestCase :: #{testheader}" do
-  stepinfo = 'Setup switch for provider test'
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_exec_svc',
-                          stepinfo)
-  logger.info("TestStep :: #{stepinfo} :: #{result}")
+  cleanup
+  teardown { cleanup }
 
   tests[id] = {}
   %w(console default).each do |title|
@@ -116,10 +121,6 @@ test_name "TestCase :: #{testheader}" do
     test_manifest(tests, id)
     test_resource(tests, id)
   end
-
-  resource_absent_cleanup(agent,
-                          'cisco_aaa_authorization_login_exec_svc',
-                          stepinfo)
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.
   raise_passfail_exception(result, testheader, self, logger)


### PR DESCRIPTION
**Summary of changes:**
- Add cleanup methods that are called at the beginning and end of each test.
- Use of beaker DSL `teardown` method.
- Add back missing autorequires in `cisco_aaa_authorization_login_exec_svc.rb`
- Removed debug statement causing beaker tests to error.

Tested on: n9k and n5k.