### PR TITLE
Munge events value 'false' to 'size_disable'

### DIFF
--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -377,6 +377,7 @@ Puppet::Type.newtype(:cisco_bgp) do
 
     munge do |value|
       value = 'size_small' if value == 'true'
+      value = 'size_disable' if value == 'false'
       value.to_sym
     end
 

--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -235,6 +235,10 @@ end
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
+  teardown do
+    resource_absent_cleanup(agent, 'cisco_bgp')
+  end
+
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
@@ -263,9 +267,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
   test_harness_run(tests, :title_patterns_1)
   test_harness_run(tests, :title_patterns_2)
-
-  # -------------------------------------------------------------------
-  resource_absent_cleanup(agent, 'cisco_bgp')
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
Due to recent platform changes, the CLI for `event_history events
size disable` now results in the config `no event-history events`.

This change munges the manifest value of `false` to `size_disable`.

### Manual Resource Testing

```bash
bash-4.2# /opt/puppetlabs/bin/puppet resource cisco_bgp '1 default' event_history_events='true'
cisco_bgp { '1 default':
  ensure               => 'present',
  event_history_events => 'size_small',
}
bash-4.2# /opt/puppetlabs/bin/puppet resource cisco_bgp '1 default' event_history_events='size_disable'
Notice: /Cisco_bgp[1 default]/event_history_events: event_history_events changed 'size_small' to 'size_disable'
cisco_bgp { '1 default':
  ensure               => 'present',
  event_history_events => 'size_small',
}
bash-4.2# /opt/puppetlabs/bin/puppet resource cisco_bgp '1 default' event_history_events='false'
cisco_bgp { '1 default':
  ensure               => 'present',
  event_history_events => 'size_disable',
}
```

### Beaker Results

| Platform | Image | Pass |
|-----------|---------|-------|
| n3k | I3 | y |
| n5k | N1 | y |
| n6k | N1 | y |
| n7k | D1 | y |
| n9k | I4, I5 | y |
| n9kv | I2 | y |