### PR TITLE
Remove get_vshell_cmd calls for cisco_tacacs_server* providers

### DIFF
--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_defaults.rb
@@ -74,15 +74,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -116,21 +107,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/,
-                                /tacacs\-server key 7/],
-                               false, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -159,21 +135,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/,
-                                /tacacs\-server key 7/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
@@ -72,15 +72,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -110,20 +101,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server timeout #{TacacsServerLib::TIMEOUT_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -148,20 +125,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server deadtime #{TacacsServerLib::DEADTIME_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -190,20 +153,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server key #{TacacsServerLib::ENCRYPTYPE_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -230,20 +179,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server key 7 #{TacacsServerLib::ENCRYPPASSWD_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -268,20 +203,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/ip tacacs source\-interface #{TacacsServerLib::SOURCEINTF_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
@@ -74,15 +74,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -117,23 +108,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/,
-                                /tacacs\-server key 7 "WXYZ12"/,
-                                %r{ip tacacs source-interface Ethernet1/4},
-                                /tacacs\-server timeout 50/],
-                               false, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -163,23 +137,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserver instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserver instance absence on agent' do
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/,
-                                /tacacs\-server key 7 "WXYZ12"/,
-                                %r{ip tacacs source-interface Ethernet1/4},
-                                /tacacs\-server timeout 50/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserver instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_defaults.rb
@@ -82,15 +82,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -122,20 +113,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server_host presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server host samplehost1/],
-                               false, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -162,20 +139,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server host samplehost1/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_negatives.rb
@@ -80,15 +80,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -118,20 +109,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/timeout #{TacacsServerHostLib::TIMEOUT_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -156,20 +133,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/port #{TacacsServerHostLib::PORT_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
   end
 
   # @step [Step] Requests manifest from the master server to the agent.
@@ -198,20 +161,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/samplehost1 key #{TacacsServerHostLib::ENCRYPTYPE_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -236,20 +185,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/samplehost1 key 7 #{TacacsServerHostLib::ENCRYPPASSWD_NEGATIVE}/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
@@ -82,15 +82,6 @@ test_name "TestCase :: #{testheader}" do
     cmd_str = PUPPET_BINPATH + 'agent -t'
     on(agent, cmd_str, acceptable_exit_codes: [0, 2])
 
-    # Expected exit_code is 16 since this is a vegas shell cmd with exec error.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str, acceptable_exit_codes: [16]) do
-      search_pattern_in_output(stdout,
-                               [/feature tacacs\+/],
-                               true, self, logger)
-    end
-
     logger.info("Setup switch for provider test :: #{result}")
   end
 
@@ -123,20 +114,6 @@ test_name "TestCase :: #{testheader}" do
     logger.info("Check cisco_tacacs_server_host presence on agent :: #{result}")
   end
 
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance presence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server host samplehost1 key 7 "test123" port 90 timeout 39/],
-                               false, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance presence on agent :: #{result}")
-  end
-
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource absent manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
@@ -164,20 +141,6 @@ test_name "TestCase :: #{testheader}" do
     end
 
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
-  end
-
-  # @step [Step] Checks tacacsserverhost instance on agent using show cli cmds.
-  step 'TestStep :: Check tacacsserverhost instance absence on agent' do
-    # Expected exit_code is 0 since this is a vegas shell cmd.
-    # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = get_vshell_cmd('show running-config tacacs')
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               [/tacacs\-server host samplehost1 key 7 "test123" port 90 timeout 39/],
-                               true, self, logger)
-    end
-
-    logger.info("Check tacacsserverhost instance absence on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.


### PR DESCRIPTION
Calls to `get_vshell_cmd` are bad but they are especially bad inside of the guestshell.  They cause the tests to error out.

```
./cisco_tacacs_server/./tacacsserverlib.rb passed in 0.00 seconds
      Test Suite: tests @ 2016-08-05 13:56:44 -0400

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 127.12 seconds
      Average Test Time: 31.78 seconds
              Attempted: 4
                 Passed: 4
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 4

      - Specific Test Case Status -
        

./cisco_tacacs_server_host/./tacacsserverhostlib.rb passed in 0.00 seconds
      Test Suite: tests @ 2016-08-05 14:04:52 -0400

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 158.92 seconds
      Average Test Time: 39.73 seconds
              Attempted: 4
                 Passed: 4
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 4

      - Specific Test Case Status -

```