### PR TITLE
Fix beaker test bug in network_snmp

### DIFF
--- a/tests/beaker_tests/network_snmp/network_snmp_provider_defaults.rb
+++ b/tests/beaker_tests/network_snmp/network_snmp_provider_defaults.rb
@@ -116,15 +116,10 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check network_snmp resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
+    enable_pat = operating_system == 'ios_xr' ? { 'enable' => 'true' } : { 'enable' => 'false' }
     cmd_str = PUPPET_BINPATH + 'resource network_snmp default'
     on(agent, cmd_str) do
-      if operating_system == 'ios_xr'
-        search_pattern_in_output(stdout, { 'enable' => 'true' },
-                                 false, self, logger)
-      else
-        search_pattern_in_output(stdout, { 'enable' => 'false' },
-                                 false, self, logger)
-      end
+      search_pattern_in_output(stdout, enable_pat, false, self, logger)
       search_pattern_in_output(stdout, { 'contact' => 'unset' },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'location' => 'unset' },


### PR DESCRIPTION
The addition of `xr` support to the netdev `network_snmp` beaker tests introduced the defect.  The call to the `operating_system` api inside the `on ... do` block resulted in the `stdout` buffer being overwritten with the os info instead of the output from the `puppet resource` command.

This fix moves the call outside of the `on ... do`  and further streamlines the code.

Issue:
```
    n9k-108.cisco.com executed in 0.18 seconds
MGW: stdout: nexus
MGW: output: nexus
MGW: pattern: (?-mix:enable +=> +'?false'?)
    Warning: 
    TestStep :: Match (?-mix:enable +=> +'?false'?) :: FAIL
```

With fix in place:
```
    n9k-108.cisco.com 11:14:09$ source /etc/profile; sudo sh -c " ip netns exec management /opt/puppetlabs/bin/puppet resource network_snmp default "
      network_snmp { 'default':
        contact  => 'unset',
        enable   => 'false',
        location => 'unset',
      }
    
    n9k-108.cisco.com executed in 3.63 seconds
    TestStep :: Match (?-mix:enable +=> +'?false'?) :: PASS
    TestStep :: Match (?-mix:contact +=> +'?unset'?) :: PASS
    TestStep :: Match (?-mix:location +=> +'?unset'?) :: PASS
    Check network_snmp resource presence on agent :: PASS


./network_snmp/network_snmp_provider_defaults.rb passed in 38.16 seconds
      Test Suite: tests @ 2016-08-10 11:13:35 -0400

      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 38.16 seconds
      Average Test Time: 38.16 seconds
              Attempted: 1
                 Passed: 1
                 Failed: 0
                Errored: 0
                Skipped: 0
                Pending: 0
                  Total: 1

      - Specific Test Case Status -

```