### PR TITLE
Remove broken snmp_user XR support

### DIFF
--- a/examples/netdev/demo_snmp.pp
+++ b/examples/netdev/demo_snmp.pp
@@ -29,29 +29,14 @@ class ciscopuppet::netdev::demo_snmp {
     acl    => 'testcomacl',
   }
 
-  $password = $operatingsystem ? {
-    'nexus' => '0x7e5030ffd26d7e1b366a9041e9c63c94',
-    default => '0307530A080824414B'
-  }
-
-  $private_key = $operatingsystem ? {
-    'nexus' => '0xcc012f26b3384d4b3da979bff48b4ffe',
-    default => '12491D42475E5A'
-  }
-
-  $localized_key = $operatingsystem ? {
-    'ios_xr' => undef,
-    default  => true
-  }
-
   snmp_user { 'test_snmp_user':
     ensure          => present,
     roles           => ['network-operator'],
     auth            => 'md5',
-    password        => $password,
+    password        => '0x7e5030ffd26d7e1b366a9041e9c63c94',
     privacy         => 'aes128',
-    private_key     => $private_key,
-    localized_key   => $localized_key,
+    private_key     => '0xcc012f26b3384d4b3da979bff48b4ffe',
+    localized_key   => true,
   }
 
   snmp_notification { 'vtp vlandelete':

--- a/lib/puppet/provider/snmp_user/cisco.rb
+++ b/lib/puppet/provider/snmp_user/cisco.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
   desc 'The Cisco provider for snmp_user.'
 
   confine feature: :cisco_node_utils
-  defaultfor operatingsystem: [:nexus, :ios_xr]
+  defaultfor operatingsystem: :nexus
 
   mk_resource_methods
 
@@ -46,19 +46,13 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
     current_state = {
       ensure:      :present,
       name:        snmpuser_name,
+      engine_id:   v.engine_id,
+      roles:       v.groups,
       auth:        v.auth_protocol,
       password:    v.auth_password,
       privacy:     v.priv_protocol,
       private_key: v.priv_password,
-      roles:       v.groups,
     }
-
-    if Facter.value('operatingsystem').eql?('ios_xr')
-      current_state[:version] = v.version
-    else
-      current_state[:engine_id] = v.engine_id
-    end
-
     new(current_state)
   end # self.properties_get
 
@@ -92,7 +86,7 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
     @property_flush[:ensure] = :absent
   end
 
-  def validate # rubocop:disable Metrics/CyclomaticComplexity
+  def validate
     unless @resource[:auth]
       invalid = []
       REQUIRES_AUTH_PROPS.each do |prop|
@@ -112,44 +106,20 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
             if @resource[:private_key].nil? && @resource[:privacy]
 
     fail ArgumentError,
+         "The 'engine_id' and 'roles' properties are mutually exclusive" \
+            if @resource[:engine_id] && @resource[:roles]
+
+    fail ArgumentError,
          "The 'enforce_privacy' property is not supported by this provider" \
             if @resource[:enforce_privacy]
-
-    if Facter.value('operatingsystem').eql?('ios_xr')
-      fail ArgumentError,
-           "The 'engine_id' property is not supported on this platform" \
-            if @resource[:engine_id]
-
-      invalid = []
-      [:roles, :version].each do |prop|
-        invalid << prop unless @resource[prop]
-      end
-      fail ArgumentError,
-           "You must specify the following properties on this platform: #{invalid}" \
-             unless invalid.empty?
-
-      fail ArgumentError,
-           'This paltform only supports a single role per user' \
-             if @resource[:roles].length > 1
-
-      if @resource[:localized_key] && @resource[:localized_key] == :false
-        fail ArgumentError,
-             'This provider only supports providing encrypted passwords on this platform.'
-      end
-    else
-      fail ArgumentError,
-           "The 'engine_id' and 'roles' properties are mutually exclusive" \
-            if @resource[:engine_id] && @resource[:roles]
-    end
   end
 
   def flush
+    validate
     @snmpuser.destroy if @snmpuser
     @snmpuser = nil
 
     return if @property_flush[:ensure] == :absent
-
-    validate
 
     if @resource[:localized_key].eql?(:true)
       localized_key = true
@@ -167,8 +137,6 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
                                     @resource[:privacy] || @property_hash[:privacy] || :none,
                                     @resource[:private_key] || @property_hash[:private_key] || '',
                                     localized_key,
-                                    @resource[:engine_id] || '',
-                                    true,
-                                    @resource[:version] || nil)
+                                    @resource[:engine_id] || '')
   end
 end # Puppet::Type

--- a/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
+++ b/tests/beaker_tests/snmp_user/snmp_user_provider_defaults.rb
@@ -68,7 +68,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpUserLib.create_snmp_user_manifest_present(operating_system))
+    on(master, SnmpUserLib.create_snmp_user_manifest_present)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -89,25 +89,12 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
       search_pattern_in_output(stdout, { 'auth' => 'md5' },
                                false, self, logger)
-
-      if operating_system == 'ios_xr'
-        search_pattern_in_output(stdout, { 'password' => '0307530A080824414B' },
-                                 false, self, logger)
-      else
-        search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
-                                 false, self, logger)
-      end
-
+      search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
+                               false, self, logger)
       search_pattern_in_output(stdout, { 'privacy' => 'aes128' },
                                false, self, logger)
-
-      if operating_system == 'ios_xr'
-        search_pattern_in_output(stdout, { 'private_key' => '12491D42475E59' },
-                                 false, self, logger)
-      else
-        search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
-                                 false, self, logger)
-      end
+      search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
+                               false, self, logger)
     end
 
     logger.info("Check snmp_user resource presence on agent :: #{result}")
@@ -116,7 +103,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present (with changes)manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, SnmpUserLib.create_snmp_user_manifest_present_change(operating_system))
+    on(master, SnmpUserLib.create_snmp_user_manifest_present_change)
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -134,27 +121,15 @@ test_name "TestCase :: #{testheader}" do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'engine_id' => '128:0:0:9:3:8:0:39:34:152:217' },
-                               false, self, logger) unless operating_system == 'ios_xr'
+                               false, self, logger)
       search_pattern_in_output(stdout, { 'auth' => 'sha' },
                                false, self, logger)
-
-      if operating_system == 'ios_xr'
-        search_pattern_in_output(stdout, { 'password' => '0307530A080824414B' },
-                                 false, self, logger)
-      else
-        search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
-                                 false, self, logger)
-      end
-
+      search_pattern_in_output(stdout, { 'password' => '0x7e5030ffd26d7e1b366a9041e9c63c94' },
+                               false, self, logger)
       search_pattern_in_output(stdout, { 'privacy' => 'des' },
                                false, self, logger)
-      if operating_system == 'ios_xr'
-        search_pattern_in_output(stdout, { 'private_key' => '12491D42475E59' },
-                                 false, self, logger)
-      else
-        search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
-                                 false, self, logger)
-      end
+      search_pattern_in_output(stdout, { 'private_key' => '0xcc012f26b3384d4b3da979bff48b4ffe' },
+                               false, self, logger)
     end
 
     logger.info("Check snmp_user resource presence on agent :: #{result}")

--- a/tests/beaker_tests/snmp_user/snmp_userlib.rb
+++ b/tests/beaker_tests/snmp_user/snmp_userlib.rb
@@ -44,8 +44,8 @@ module SnmpUserLib
   # where 'ensure' is set to present.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_snmp_user_manifest_present(type)
-    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_snmp_user_manifest_present
+    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_user { 'test_snmp_user':
     ensure          => present,
@@ -58,34 +58,20 @@ node default {
   }
 }
 EOF"
-
-    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-node default {
-  snmp_user { 'test_snmp_user':
-    ensure          => present,
-    roles           => ['network-operator'],
-    version         => 'v3',
-    auth            => 'md5',
-    password        => '0307530A080824414B',
-    privacy         => 'aes128',
-    private_key     => '12491D42475E59',
-  }
-}
-EOF"
-    type == 'ios_xr' ? ios_xr_str : nxos_str
+    manifest_str
   end
 
   # Method to create a manifest for snmp_user resource attribute 'ensure'
   # where 'ensure' is set to present, and a few changes made from above.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_snmp_user_manifest_present_change(type)
-    nxos_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  def self.create_snmp_user_manifest_present_change
+    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   snmp_user { 'test_snmp_user':
     ensure          => present,
     auth            => 'sha',
-    password        => '0307530A080824414B',
+    password        => '0x7e5030ffd26d7e1b366a9041e9c63c94',
     privacy         => 'des',
     private_key     => '0xcc012f26b3384d4b3da979bff48b4ffe',
     localized_key   => true,
@@ -93,21 +79,7 @@ node default {
   }
 }
 EOF"
-
-    ios_xr_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-node default {
-  snmp_user { 'test_snmp_user':
-    ensure          => present,
-    roles           => ['network-operator'],
-    version         => 'v3',
-    auth            => 'sha',
-    password        => '0307530A080824414B',
-    privacy         => 'des',
-    private_key     => '12491D42475E59',
-  }
-}
-EOF"
-    type == 'ios_xr' ? ios_xr_str : nxos_str
+    manifest_str
   end
 
   # Method to create a manifest for snmp_user resource attribute 'ensure'


### PR DESCRIPTION
This PR is the puppet side of https://github.com/cisco/cisco-network-node-utils/pull/459

This simply reverses the changes from: https://github.com/cisco/cisco-network-puppet-module/pull/353

Tested on: n9k, n3k

```
|   `-- runBeakerTests                                                    PASSED
|       |-- Step 1: Beaker: Create Beaker Host Config                     PASSED
|       `-- Step 2: Beaker: Run Tests                                     PASSED
|-- beaker_native_results[suite=./snmp_user/snmp_user_provider_defaults.rb]    PASSED
|   `-- report                                                            PASSED
```