### PR TITLE
Add agent_probe to utility.lib

### DIFF
--- a/tests/beaker_tests/cisco_vlan/test_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_vlan.rb
@@ -102,13 +102,21 @@ tests[:non_default_extended] = {
 # State cannot be modified for extended vlans on N5k and N6k platforms.
 tests[:non_default_extended][:manifest_props].delete(:state) if platform[/n(5|6)k/]
 
-def unsupported_properties(_tests, _id)
+if platform[/n3k/]
+  tests[:vn_segment_unsupported] =
+    resource_probe(agent,
+                   'cisco_vlan 128 mapped_vni=128000',
+                   'Hardware is not capable of supporting vn-segment-vlan-based feature')
+end
+
+def unsupported_properties(tests, _id)
   unprops = []
 
-  unprops << :mapped_vni if platform[/n7k/]
+  unprops << :mapped_vni if platform[/n7k/] || tests[:vn_segment_unsupported]
 
   unprops << :fabric_control unless platform[/n7k/]
 
+  logger.info("  unprops: #{unprops}") unless unprops.empty?
   unprops
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1293,6 +1293,14 @@ def remove_interface(agent, intf)
   command_config(agent, cmd, cmd)
 end
 
+# Issue a command on the agent and check stdout for a pattern.
+# Useful for checking if hardware supports properties, etc.
+def resource_probe(agent, cmd, pattern)
+  cmd = PUPPET_BINPATH + "resource #{cmd}"
+  on(agent, cmd, acceptable_exit_codes: [0, 2, 1], pty: true)
+  stdout.match(pattern) ? true : false
+end
+
 def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
   # TBD: Modify this cleanup to use faster test_get / test_set:
   #  test_get('i ^vlan|^bridge')


### PR DESCRIPTION
* `feature vn-segment-vlan-based` is not supported on some n3k's

* Added a simple helper method to test for h/w support; the result is then used by `unsupported_properties` to update the test cases

* Tested on n3k(3048), n7k, n9k