### PR TITLE
Fix half/full in test_duplex

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1202,6 +1202,7 @@ def interface_capabilities(agent, intf)
     k.gsub!(/ \(.*\)/, '') # Remove any parenthetical text from key
     k.strip!
     v.strip!
+    v.gsub!(%r{half/full}, 'half,full') if k[/Duplex/]
     hash[k] = v
   end
   hash


### PR DESCRIPTION
* For some 3k, need to munge 'half/full' into csv-style 'half,full' to play nice with interface_capabilities

* This fix is a little trickier than the NU fix because the output from puppet resource is 'raw' whereas the NU output is a pre-processed hash of capabilities; thus we have to be careful not to munge the vsh or puppet resource output.

* Tested on n3048