### PR TITLE
Update service provider beaker test to work in guestshell

### DIFF
--- a/tests/beaker_tests/file_service_package/filesvcpkglib.rb
+++ b/tests/beaker_tests/file_service_package/filesvcpkglib.rb
@@ -33,8 +33,6 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 # The module has a single set of methods:
 # A. Methods to create manifests for file, service and pkg Puppet test cases.
 module FileSvcPkgLib
-  TEST_SERVICE = 'bootlogd'
-
   # A. Methods to create manifests for file, service and pkg Puppet test cases.
 
   # Method to create a manifest for FILE resource attributes:
@@ -78,11 +76,11 @@ EOF"
   # name, ensure and enable.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_service_manifest_nondefaults
+  def self.create_service_manifest_nondefaults(service)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
-    service { '#{TEST_SERVICE}':
-        name            => '#{TEST_SERVICE}',
+    service { '#{service}':
+        name            => '#{service}',
         ensure          => 'running',
         enable          => 'true',
     }
@@ -95,11 +93,11 @@ EOF"
   # 'ensure' is set to stopped.
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_service_manifest_stopped
+  def self.create_service_manifest_stopped(service)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
-    service { '#{TEST_SERVICE}':
-        name            => '#{TEST_SERVICE}',
+    service { '#{service}':
+        name            => '#{service}',
         ensure          => 'stopped',
     }
 }

--- a/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
@@ -68,7 +68,7 @@ when 'cisco-wrlinux'
 when 'RedHat'
   os_service = 'systemd-tmpfiles-clean.timer'
 else
-  testcase.fail_test('Unable to identify os family')
+  fail_test("Unable to identify/set service for OS family: #{os_family}")
 end
 
 # @test_name [TestCase] Executes nondefaults testcase for SERVICE Resource.

--- a/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
+++ b/tests/beaker_tests/file_service_package/service_provider_nondefaults.rb
@@ -61,6 +61,16 @@ require File.expand_path('../filesvcpkglib.rb', __FILE__)
 result = 'PASS'
 testheader = 'SERVICE Resource :: All Attributes NonDefaults'
 
+# Identify service for testing based on os family.
+case os_family
+when 'cisco-wrlinux'
+  os_service = 'bootlogd'
+when 'RedHat'
+  os_service = 'systemd-tmpfiles-clean.timer'
+else
+  testcase.fail_test('Unable to identify os family')
+end
+
 # @test_name [TestCase] Executes nondefaults testcase for SERVICE Resource.
 test_name "TestCase :: #{testheader}" do
   raise_skip_exception('Not supported for OAC platforms', self) if
@@ -68,7 +78,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, FileSvcPkgLib.create_service_manifest_stopped)
+    on(master, FileSvcPkgLib.create_service_manifest_stopped(os_service))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     # Or expected exit_code is 0 since this is a puppet agent cmd with no change.
@@ -81,7 +91,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource nondefaults manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, FileSvcPkgLib.create_service_manifest_nondefaults)
+    on(master, FileSvcPkgLib.create_service_manifest_nondefaults(os_service))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -94,7 +104,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check service resource presence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
-    cmd_str = PUPPET_BINPATH + "resource service '#{FileSvcPkgLib::TEST_SERVICE}'"
+    cmd_str = PUPPET_BINPATH + "resource service '#{os_service}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'running' },
@@ -107,7 +117,7 @@ test_name "TestCase :: #{testheader}" do
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource stopped manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
-    on(master, FileSvcPkgLib.create_service_manifest_stopped)
+    on(master, FileSvcPkgLib.create_service_manifest_stopped(os_service))
 
     # Expected exit_code is 2 since this is a puppet agent cmd with change.
     cmd_str = PUPPET_BINPATH + 'agent -t'
@@ -122,7 +132,7 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Check service resource absence on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
-    cmd_str = PUPPET_BINPATH + "resource service '#{FileSvcPkgLib::TEST_SERVICE}'"
+    cmd_str = PUPPET_BINPATH + "resource service '#{os_service}'"
     on(agent, cmd_str) do
       search_pattern_in_output(stdout,
                                { 'ensure' => 'running' },

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -987,6 +987,12 @@ def operating_system
   @cisco_os = on(agent, facter_cmd('os.name')).stdout.chomp
 end
 
+@os_family = nil
+def os_family
+  return @os_family unless @os_family.nil?
+  @os_family = on(agent, facter_cmd('os.family')).stdout.chomp
+end
+
 # Used to cache the cisco hardware type
 @cisco_hardware = nil
 # Use facter to return cisco hardware type


### PR DESCRIPTION
Our service provider beaker test was passing in native but failing in guestshell because the `bootlogd` service is only available in native.  With this update the test case now selects the service to test based on the OS family.

Tested on: n3k(native, guestshell), n9k(native, guestshell)
Not supported on OAC.