### PR TITLE
f3 handling for test_vrf

### DIFF
--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -117,9 +117,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_run(tests, :non_default)
-
-  # -------------------------------------------------------------------
-  resource_absent_cleanup(agent, 'cisco_vrf', 'VRF CLEAN :: ')
   skipped_tests_summary(tests)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -75,7 +75,7 @@ def unsupported_properties(_tests, _id)
 
     unprops << :vni unless platform[/n9k/]
     unprops << :route_distinguisher if nexus_i2_image
-    unprops << :description if image?[/7.3.0.D1.1/] # CSCuy36637
+    # unprops << :description if image?[/7.3.0.D1.1/] # CSCuy36637
 
   else
     unprops <<


### PR DESCRIPTION
* N7k setup/cleanup when missing F3 cards

* New `image?` method for checking image version pattern; used as test for unprops

* New `remove_all_vrfs` method that uses `test_get`/`test_set`; this is much faster than removing vrfs one at a time