### PR TITLE
Enable yum package testing in guestshell

### DIFF
--- a/tests/beaker_tests/file_service_package/test_package.rb
+++ b/tests/beaker_tests/file_service_package/test_package.rb
@@ -43,7 +43,7 @@ when /7.0.3.I4.1/
 when /7.0.3.I4.2/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.2.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I4.2'
-when /7.0.3.I5.1/
+when /7.0.3.I5/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I5.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I5.1'
 else

--- a/tests/beaker_tests/file_service_package/test_package.rb
+++ b/tests/beaker_tests/file_service_package/test_package.rb
@@ -28,6 +28,10 @@ case image?
 when /7.0.3.I2/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I2.1'
+when /7.0.3.I2.1/
+  name =     'n9000_sample'
+  filename = 'n9000_sample-1.0.0-7.0.3.x86_64.rpm'
+  version =  '1.0.0-7.0.3'
 when /7.0.3.I3/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I3.1'

--- a/tests/beaker_tests/file_service_package/test_package.rb
+++ b/tests/beaker_tests/file_service_package/test_package.rb
@@ -25,13 +25,15 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
 name = 'nxos.sample-n9k_EOR'
 case image?
-when /7.0.3.I2/
-  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.1.lib32_n9000.rpm'
-  version =  '1.0.0-7.0.3.I2.1'
 when /7.0.3.I2.1/
+  # Version 7.0.3.I2.1 needs this specific patch.  Attempts to build
+  # new patches for this version with the patch tool don't work.
   name =     'n9000_sample'
   filename = 'n9000_sample-1.0.0-7.0.3.x86_64.rpm'
   version =  '1.0.0-7.0.3'
+when /7.0.3.I2/
+  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.1.lib32_n9000.rpm'
+  version =  '1.0.0-7.0.3.I2.1'
 when /7.0.3.I3/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I3.1'

--- a/tests/beaker_tests/file_service_package/test_package.rb
+++ b/tests/beaker_tests/file_service_package/test_package.rb
@@ -62,16 +62,15 @@ tests = {
 skip_unless_supported(tests)
 
 tests[:yum_patch_install] = {
-  desc:                 "1.1 Apply sample patch to image #{image?}",
-  title_pattern:        name,
-  ensure_prop_override: true,
-  manifest_props:       {
+  desc:           "1.1 Apply sample patch to image #{image?}",
+  title_pattern:  name,
+  manifest_props: {
     name:             filename,
     provider:         'cisco',
     source:           "/bootflash/#{filename}",
     package_settings: { 'target' => 'host' },
   },
-  resource:             {
+  resource:       {
     'ensure' => version
   },
 }
@@ -79,9 +78,9 @@ tests[:yum_patch_install] = {
 tests[:yum_patch_remove] = {
   desc:           '1.2 Remove sample patch',
   code:           [0, 2],
+  ensure:         :absent,
   title_pattern:  name,
   manifest_props: {
-    ensure:           'absent',
     name:             filename,
     provider:         'cisco',
     package_settings: { 'target' => 'host' },
@@ -112,6 +111,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
     teardown { resource_absent_by_title(agent, 'package', name) }
     resource_absent_by_title(agent, 'package', name)
 
+    tests[:yum_patch_install][:ensure_prop_override] = true
     test_harness_run(tests, :yum_patch_install)
   end
 end

--- a/tests/beaker_tests/file_service_package/test_package.rb
+++ b/tests/beaker_tests/file_service_package/test_package.rb
@@ -31,20 +31,23 @@ when /7.0.3.I2.1/
   name =     'n9000_sample'
   filename = 'n9000_sample-1.0.0-7.0.3.x86_64.rpm'
   version =  '1.0.0-7.0.3'
-when /7.0.3.I2/
-  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.1.lib32_n9000.rpm'
-  version =  '1.0.0-7.0.3.I2.1'
-when /7.0.3.I3/
+when /7.0.3.I2.2e/
+  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.2e.lib32_n9000.rpm'
+  version =  '1.0.0-7.0.3.I2.2e'
+when /7.0.3.I3.1/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I3.1'
-when /7.0.3.I4/
+when /7.0.3.I4.1/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I4.1'
-when /7.0.3.I5/
+when /7.0.3.I4.2/
+  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.2.lib32_n9000.rpm'
+  version =  '1.0.0-7.0.3.I4.2'
+when /7.0.3.I5.1/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I5.1.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I5.1'
 else
-  raise_skip_exception("No patch specified for image #{image?}", self)
+  raise_skip_exception("No patch available for image #{image?}", self)
 end
 
 unless resource_present?(agent, 'file', "/bootflash/#{filename}")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1421,7 +1421,7 @@ end
 def test_patch_version(tests, id, name, ver)
   stepinfo = format_stepinfo(tests, id, 'YUM PACKAGE VERSION')
   step "TestStep :: #{stepinfo}" do
-    logger.debug("test_yum_version ::")
+    logger.debug("test_yum_version :: #{ver}")
     iv = get_patch_version(name)
     if iv == ver
       logger.info("#{stepinfo} :: PASS")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -633,6 +633,31 @@ def create_manifest_and_resource(tests, id)
   true
 end
 
+# Special create manifest/resource method for yum packages only.
+def create_package_manifest_resource(tests, id)
+  puppet_resource_cmd_from_params(tests, id)
+  state = ''
+  manifest = ''
+  if tests[id][:ensure] == :absent
+    state = 'ensure => absent,'
+  else
+    state = 'ensure => present,'
+  end
+
+  manifest_props = tests[id][:manifest_props]
+  manifest += prop_hash_to_manifest(manifest_props)
+  tests[id][:resource] = manifest_props
+
+  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+  \nnode default {
+  #{dependency_manifest(tests, id)}
+  #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
+    #{state}\n#{manifest}
+  }\n}\nEOF"
+
+  true
+end
+
 # test_harness_dependencies
 #
 # This method is used for additional testbed setup beyond the basics
@@ -1005,6 +1030,12 @@ def os_family
   @os_family = on(agent, facter_cmd('os.family')).stdout.chomp
 end
 
+@virtual = nil
+def virtual
+  return @virtual unless @virtual.nil?
+  @virtual = on(agent, facter_cmd('virtual')).stdout.chomp
+end
+
 # Used to cache the cisco hardware type
 @cisco_hardware = nil
 # Use facter to return cisco hardware type
@@ -1375,4 +1406,28 @@ def remove_all_vrfs(agent)
   found = test_get(agent, "incl 'vrf context' | excl management").split("\n")
   found.map! { |cmd| "no #{cmd}" if cmd[/^vrf context/] }
   test_set(agent, found.compact.join(' ; '))
+end
+
+# Return yum patch version from host
+def get_patch_version(name)
+  cmd = get_vshell_cmd("show install packages | inc #{name}")
+  # Sample Output:
+  # nxos.sample-n9k_EOR.lib32_n9000   1.0.0-7.0.3.I5.1    @patching
+  out = on(agent, cmd, pty: true).stdout[/\S+\s+(\S+).*@patching/]
+  out.nil? ? nil : Regexp.last_match[1]
+end
+
+# Test yum version
+def test_patch_version(tests, id, name, ver)
+  stepinfo = format_stepinfo(tests, id, 'YUM PACKAGE VERSION')
+  step "TestStep :: #{stepinfo}" do
+    logger.debug("test_yum_version ::")
+    iv = get_patch_version(name)
+    if iv == ver
+      logger.info("#{stepinfo} :: PASS")
+    else
+      msg = "Installed version: #{iv}, does not match expected ver: #{ver}"
+      fail_test("TestStep :: #{msg} :: FAIL")
+    end
+  end
 end


### PR DESCRIPTION
This update allows us to test yum patching in both native and guestshell.  The workflow is different since we cannot use the puppet resource command in the guestshell to query information about patches applied to the native bash environment.

Tested on: n9k(I2, I3, I4, I5)