### PR TITLE
Suppress fib pending fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ Manages configuration of a BGP instance.
 | `disable_policy_batching_ipv6` | Not supported on N5k, N6k, N7k |
 | `neighbor_down_fib_accelerate` | Not supported on N5k, N6k, N7k |
 | `reconnect_interval`           | Not supported on N5k, N6k, N7k |
+| `suppress_fib_pending`         | Idempotence supported only on I5 images |
 
 #### Parameters
 

--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -65,7 +65,6 @@ tests[:default] = {
     nsr:                                    'default',
     reconnect_interval:                     'default',
     shutdown:                               'default',
-    suppress_fib_pending:                   'default',
     timer_bestpath_limit:                   'default',
     timer_bestpath_limit_always:            'default',
     timer_bgp_holdtime:                     'default',
@@ -98,7 +97,6 @@ tests[:default] = {
     'nsr'                                    => 'false',
     'reconnect_interval'                     => '60',
     'shutdown'                               => 'false',
-    'suppress_fib_pending'                   => 'false',
     'timer_bestpath_limit'                   => '300',
     'timer_bestpath_limit_always'            => 'false',
     'timer_bgp_holdtime'                     => '180',
@@ -217,7 +215,8 @@ def unsupported_properties(tests, id)
         :event_history_periodic <<
         :fast_external_fallover <<
         :flush_routes <<
-        :neighbor_down_fib_accelerate
+        :neighbor_down_fib_accelerate <<
+        :suppress_fib_pending
     end
 
     if platform[/n(5|6|7)k/]

--- a/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
+++ b/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
@@ -307,7 +307,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :title_patterns_1)
   test_harness_run(tests, :title_patterns_2)
   test_harness_run(tests, :title_patterns_3)
-  test_harness_run(tests, :l2vpn_evpn) unless nexus_i2_image
+  test_harness_run(tests, :l2vpn_evpn) unless nexus_image['I2']
 
   # -----------------------------------
   resource_absent_cleanup(agent, 'cisco_bgp')

--- a/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
+++ b/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
@@ -70,7 +70,7 @@ tests[:non_default] = {
 # The harness will remove any "unprops" from the manifests.
 def unsupported_properties(*)
   unprops = []
-  unprops << :route_target_both if nexus_i2_image
+  unprops << :route_target_both if nexus_image['I2']
   unprops
 end
 

--- a/tests/beaker_tests/cisco_itd_device_group/test_itd_device_group.rb
+++ b/tests/beaker_tests/cisco_itd_device_group/test_itd_device_group.rb
@@ -132,7 +132,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_image(tests)
+  skip_nexus_image('I2', tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)

--- a/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
+++ b/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
@@ -138,7 +138,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_image(tests)
+  skip_nexus_image('I2', tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)

--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -238,7 +238,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   logger.info("#### This device is of type: #{device} #####")
-  skip_nexus_i2_image(tests)
+  skip_nexus_image('I2', tests)
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
   test_harness_run(tests, :default)

--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -74,7 +74,7 @@ def unsupported_properties(_tests, _id)
       :vpn_id
 
     unprops << :vni unless platform[/n9k/]
-    unprops << :route_distinguisher if nexus_i2_image
+    unprops << :route_distinguisher if nexus_image['I2']
 
   else
     unprops <<

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1042,20 +1042,20 @@ def platform
 end
 
 # Check if this image is an I2 image
-@i2_image = nil # Cache the lookup result
-def nexus_i2_image
-  return @i2_image unless @i2_image.nil?
+@image = nil # Cache the lookup result
+def nexus_image
+  return @image unless @image.nil?
   on(agent, facter_cmd('-p cisco.images.system_image'))
-  @i2_image = stdout[/7.0.3.I2/] ? true : false
-  @i2_image
+  @image = stdout[/[A-Z]+\d/]
+  @image
 end
 
 # This is a skip-all-testcases-if-I2-image check.
 # Do not use this for skipping individual properties.
-def skip_nexus_i2_image(tests)
-  return unless nexus_i2_image
+def skip_nexus_image(image, tests)
+  return unless nexus_image["#{image}"]
   msg = "Skipping all tests; '#{tests[:resource_name]}' "\
-        'is not supported on 7.0.3(I2) images'
+        "is not supported on #{image} images"
   banner = '#' * msg.length
   raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
 end


### PR DESCRIPTION
### Changes

* Remove default value testing for `suppress_fib_pending`
* Generalize the method for checking nexus images
  * Note: My initial fix involved this method but I eventually ended up not needing it. I'm including the change because it still seems useful

### Platforms Tested

* n3k - I2
* n5k
* n7k
* n9k - I5