### PR TITLE
test_interface_ospf: Fix process dependency

### DIFF
--- a/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
@@ -42,7 +42,6 @@ intf = find_interface(tests)
 tests[:default] = {
   desc:           '1.1 Defaults',
   title_pattern:  "#{intf} Sample",
-  preclean_intf:  true,
   manifest_props: {
     area:                           200,
     bfd:                            'default',
@@ -108,7 +107,7 @@ tests[:non_default] = {
 
 def test_harness_dependencies(_tests, id)
   return unless id == :default
-  test_set(agent, 'feature ospf')
+  test_set(agent, 'feature ospf ; router ospf Sample')
 end
 
 def cleanup(agent, intf)


### PR DESCRIPTION
* A previous test cleanup removed 'router ospf Sample' from the harness dependencies; now the nightly if failing when it tries to configure an ospf config on an interface

* Although the router config is not necessary for the interface config, the failure occurs because the ospf process is still starting up (ospf startup is slow on 5k/6k/8k). The ospf provider already has a 'wait_for_process_initialized' method to handle this slow start, while the interface_ospf provider does not. This is only an issue during testing so I do not propose adding the wait_for method to interface_ospf.

* Tested on n5,n7,n9