### PR TITLE
Update test_harness_dependencies for test_interface_ospf.rb

### DIFF
--- a/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
@@ -106,9 +106,12 @@ tests[:non_default] = {
   },
 }
 
-def test_harness_dependencies(_tests, id)
+def test_harness_dependencies(tests, id)
   return unless id == :default
   test_set(agent, 'feature ospf ; router ospf Sample')
+  # System-level switchport dependencies
+  config_system_default_switchport?(tests, id)
+  config_system_default_switchport_shutdown?(tests, id)
 end
 
 def cleanup(agent, intf)

--- a/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
@@ -115,7 +115,6 @@ def test_harness_dependencies(tests, id)
 end
 
 def cleanup(agent, intf)
-  logger.error(test_get(agent, 'incl .*')) # DEBUGGING ONLY - REMOVE
   test_set(agent, 'no feature ospf ; no feature bfd')
   interface_cleanup(agent, intf)
 end


### PR DESCRIPTION
This update adds calls to `config_system_default_switchport` and `config_system_default_switchport_shutdown?` to ensure the interface under test is setup as an L3 interface before the test starts.