### PR TITLE
bgp event_history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### New feature support
 
 ### Added
+- Extend cisco_bgp with attributes:
+ - `event_history_errors`
+ - `event_history_objstore`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,9 @@ Manages configuration of a BGP instance.
 |:--------|:-------------|
 | `disable_policy_batching_ipv4` | Not supported on N5k, N6k, N7k |
 | `disable_policy_batching_ipv6` | Not supported on N5k, N6k, N7k |
+| `event_history_errors        ` | supported on N3|9k on 7.0(3)I5(1) and later images |
+| `event_history_events        ` | default value is 'large' for N3|9k on 7.0(3)I5(1) and later images |
+| `event_history_objstore      ` | supported on N3|9k on 7.0(3)I5(1) and later images |
 | `event_history_periodic      ` | default value is 'false' for N3|9k on 7.0(3)I5(1) and later images |
 | `neighbor_down_fib_accelerate` | Not supported on N5k, N6k, N7k |
 | `reconnect_interval`           | Not supported on N5k, N6k, N7k |
@@ -1104,8 +1107,14 @@ Enable/Disable/specify size of cli event history buffer. Valid values are 'true'
 ##### `event_history_detail`
 Enable/Disable/specify size of detail event history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. Size can also be specified in bytes.
 
+##### `event_history_errors`
+Enable/Disable/specify size of error history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. Size can also be specified in bytes.
+
 ##### `event_history_events`
 Enable/Disable/specify size of event history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. Size can also be specified in bytes.
+
+##### `event_history_objstore`
+Enable/Disable/specify size of objstore history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. Size can also be specified in bytes.
 
 ##### `event_history_periodic`
 Enable/Disable/specify size of periodic event history buffer. Valid values are 'true', 'false', 'size_small', 'size_medium', 'size_large', 'size_disable' and 'default'. Size can also be specified in bytes.

--- a/examples/cisco/demo_bgp.pp
+++ b/examples/cisco/demo_bgp.pp
@@ -58,6 +58,22 @@ class ciscopuppet::cisco::demo_bgp {
     default => undef
   }
 
+  $event_history_errors = platform_get() ? {
+    /(n3k|n9k)/ => $facts['cisco']['images']['system_image'] ? {
+      /(I2|I3|I4)/ => undef,
+      default => 'size_small'
+    },
+    default => undef
+  }
+
+  $event_history_objstore = platform_get() ? {
+    /(n3k|n9k)/ => $facts['cisco']['images']['system_image'] ? {
+      /(I2|I3|I4)/ => undef,
+      default => 'size_small'
+    },
+    default => undef
+  }
+
   cisco_bgp { '55.77 default':
     ensure                                 => present,
 
@@ -73,11 +89,9 @@ class ciscopuppet::cisco::demo_bgp {
     enforce_first_as                       => false,
     event_history_cli                      => 'size_small',
     event_history_detail                   => 'size_medium',
-    # event_history_errors is not supported on all platforms
-    # event_history_errors                   => 'size_small',
+    event_history_errors                   => $event_history_errors,
     event_history_events                   => 'size_large',
-    # event_history_objstore is not supported on all platforms
-    # event_history_objstore                 => 'size_large',
+    event_history_objstore                 => $event_history_objstore,
     event_history_periodic                 => 'size_disable',
     maxas_limit                            => $maxas_limit,
     suppress_fib_pending                   => $suppress_fib_pending,

--- a/examples/cisco/demo_bgp.pp
+++ b/examples/cisco/demo_bgp.pp
@@ -73,7 +73,11 @@ class ciscopuppet::cisco::demo_bgp {
     enforce_first_as                       => false,
     event_history_cli                      => 'size_small',
     event_history_detail                   => 'size_medium',
+    # event_history_errors is not supported on all platforms
+    # event_history_errors                   => 'size_small',
     event_history_events                   => 'size_large',
+    # event_history_objstore is not supported on all platforms
+    # event_history_objstore                 => 'size_large',
     event_history_periodic                 => 'size_disable',
     maxas_limit                            => $maxas_limit,
     suppress_fib_pending                   => $suppress_fib_pending,

--- a/lib/puppet/provider/cisco_bgp/cisco.rb
+++ b/lib/puppet/provider/cisco_bgp/cisco.rb
@@ -218,68 +218,95 @@ Puppet::Type.type(:cisco_bgp).provide(:cisco) do
     image[/7.0.3.I2|I3|I4/] || pid[/N(5|6|7|8)/]
   end
 
+  def event_history_default?(prop)
+    @property_hash[prop.to_sym] == @bgp_vrf.send("default_#{prop}")
+  end
+
+  def event_history_false?(prop)
+    @property_hash[prop.to_sym] == 'false'
+  end
+
   def event_history_cli
-    return 'default' if @property_hash[:event_history_cli] == @bgp_vrf.default_event_history_cli &&
-                        resource[:event_history_cli] == 'default'
-    return 'true' if @property_hash[:event_history_cli] == @bgp_vrf.default_event_history_cli &&
-                     resource[:event_history_cli] == 'true'
-    return 'size_disable' if @property_hash[:event_history_cli] == 'false' &&
-                             resource[:event_history_cli] == 'size_disable' && !legacy_image?
+    case resource[:event_history_cli]
+    when 'default'
+      return 'default' if event_history_default?('event_history_cli')
+    when 'true'
+      return 'true' if event_history_default?('event_history_cli')
+    when 'size_disable'
+      return 'size_disable' if
+        event_history_false?('event_history_cli') && !legacy_image?
+    end
     @property_hash[:event_history_cli]
   end
 
   def event_history_cli=(should_value)
-    should_value = @bgp_vrf.default_event_history_cli if should_value == 'default' || should_value == 'true'
+    should_value = @bgp_vrf.default_event_history_cli if
+      should_value == 'default' || should_value == 'true'
     should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
     @property_flush[:event_history_cli] = should_value
   end
 
   def event_history_detail
-    return 'default' if @property_hash[:event_history_detail] == @bgp_vrf.default_event_history_detail &&
-                        resource[:event_history_detail] == 'default'
-    return 'size_disable' if @property_hash[:event_history_detail] == @bgp_vrf.default_event_history_detail &&
-                             resource[:event_history_detail] == 'size_disable' && !legacy_image?
+    case resource[:event_history_detail]
+    when 'default'
+      return 'default' if event_history_default?('event_history_detail')
+    when 'size_disable'
+      return 'size_disable' if
+        event_history_default?('event_history_detail') && !legacy_image?
+    end
     @property_hash[:event_history_detail]
   end
 
   def event_history_detail=(should_value)
-    should_value = @bgp_vrf.default_event_history_detail if should_value == 'default'
-    should_value = @bgp_vrf.default_event_history_detail if should_value == 'size_disable' && !legacy_image?
+    should_value = @bgp_vrf.default_event_history_detail if
+      should_value == 'default'
+    should_value = @bgp_vrf.default_event_history_detail if
+      should_value == 'size_disable' && !legacy_image?
     should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
     @property_flush[:event_history_detail] = should_value
   end
 
   def event_history_events
-    return 'default' if @property_hash[:event_history_events] == @bgp_vrf.default_event_history_events &&
-                        resource[:event_history_events] == 'default'
-    return 'true' if @property_hash[:event_history_events] == @bgp_vrf.default_event_history_events &&
-                     resource[:event_history_events] == 'true'
-    return 'size_disable' if @property_hash[:event_history_events] == 'false' &&
-                             resource[:event_history_events] == 'size_disable'
+    case resource[:event_history_events]
+    when 'default'
+      return 'default' if event_history_default?('event_history_events')
+    when 'true'
+      return 'true' if event_history_default?('event_history_events')
+    when 'size_disable'
+      return 'size_disable' if event_history_false?('event_history_events')
+    end
     @property_hash[:event_history_events]
   end
 
   def event_history_events=(should_value)
-    should_value = @bgp_vrf.default_event_history_events if should_value == 'default' || should_value == 'true'
+    should_value = @bgp_vrf.default_event_history_events if
+      should_value == 'default' || should_value == 'true'
     should_value = 'false' if should_value == 'size_disable' && !legacy_image?
     should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
     @property_flush[:event_history_events] = should_value
   end
 
   def event_history_periodic
-    return 'default' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
-                        resource[:event_history_periodic] == 'default'
-    return 'true' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
-                     resource[:event_history_periodic] == 'true' && legacy_image?
-    return 'size_disable' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
-                             resource[:event_history_periodic] == 'size_disable' && !legacy_image?
+    case resource[:event_history_periodic]
+    when 'default'
+      return 'default' if event_history_default?('event_history_periodic')
+    when 'true'
+      return 'true' if event_history_default?('event_history_periodic') &&
+                       legacy_image?
+    when 'size_disable'
+      return 'size_disable' if
+        event_history_default?('event_history_periodic') && !legacy_image?
+    end
     @property_hash[:event_history_periodic]
   end
 
   def event_history_periodic=(should_value)
-    should_value = @bgp_vrf.default_event_history_periodic if should_value == 'default'
-    should_value = @bgp_vrf.default_event_history_periodic if should_value == 'true' && legacy_image?
-    should_value = @bgp_vrf.default_event_history_periodic if should_value == 'size_disable' && !legacy_image?
+    should_value = @bgp_vrf.default_event_history_periodic if
+      should_value == 'default'
+    should_value = @bgp_vrf.default_event_history_periodic if
+      should_value == 'true' && legacy_image?
+    should_value = @bgp_vrf.default_event_history_periodic if
+      should_value == 'size_disable' && !legacy_image?
     should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
     @property_flush[:event_history_periodic] = should_value
   end

--- a/lib/puppet/provider/cisco_bgp/cisco.rb
+++ b/lib/puppet/provider/cisco_bgp/cisco.rb
@@ -41,7 +41,9 @@ Puppet::Type.type(:cisco_bgp).provide(:cisco) do
     :confederation_peers,
     :event_history_cli,
     :event_history_detail,
+    :event_history_errors,
     :event_history_events,
+    :event_history_objstore,
     :event_history_periodic,
     :disable_policy_batching_ipv4,
     :disable_policy_batching_ipv6,
@@ -216,17 +218,68 @@ Puppet::Type.type(:cisco_bgp).provide(:cisco) do
     image[/7.0.3.I2|I3|I4/] || pid[/N(5|6|7|8)/]
   end
 
+  def event_history_cli
+    return 'default' if @property_hash[:event_history_cli] == @bgp_vrf.default_event_history_cli &&
+                        resource[:event_history_cli] == 'default'
+    return 'true' if @property_hash[:event_history_cli] == @bgp_vrf.default_event_history_cli &&
+                     resource[:event_history_cli] == 'true'
+    return 'size_disable' if @property_hash[:event_history_cli] == 'false' &&
+                             resource[:event_history_cli] == 'size_disable' && !legacy_image?
+    @property_hash[:event_history_cli]
+  end
+
+  def event_history_cli=(should_value)
+    should_value = @bgp_vrf.default_event_history_cli if should_value == 'default' || should_value == 'true'
+    should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
+    @property_flush[:event_history_cli] = should_value
+  end
+
+  def event_history_detail
+    return 'default' if @property_hash[:event_history_detail] == @bgp_vrf.default_event_history_detail &&
+                        resource[:event_history_detail] == 'default'
+    return 'size_disable' if @property_hash[:event_history_detail] == @bgp_vrf.default_event_history_detail &&
+                             resource[:event_history_detail] == 'size_disable' && !legacy_image?
+    @property_hash[:event_history_detail]
+  end
+
+  def event_history_detail=(should_value)
+    should_value = @bgp_vrf.default_event_history_detail if should_value == 'default'
+    should_value = @bgp_vrf.default_event_history_detail if should_value == 'size_disable' && !legacy_image?
+    should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
+    @property_flush[:event_history_detail] = should_value
+  end
+
+  def event_history_events
+    return 'default' if @property_hash[:event_history_events] == @bgp_vrf.default_event_history_events &&
+                        resource[:event_history_events] == 'default'
+    return 'true' if @property_hash[:event_history_events] == @bgp_vrf.default_event_history_events &&
+                     resource[:event_history_events] == 'true'
+    return 'size_disable' if @property_hash[:event_history_events] == 'false' &&
+                             resource[:event_history_events] == 'size_disable'
+    @property_hash[:event_history_events]
+  end
+
+  def event_history_events=(should_value)
+    should_value = @bgp_vrf.default_event_history_events if should_value == 'default' || should_value == 'true'
+    should_value = 'false' if should_value == 'size_disable' && !legacy_image?
+    should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
+    @property_flush[:event_history_events] = should_value
+  end
+
   def event_history_periodic
     return 'default' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
                         resource[:event_history_periodic] == 'default'
-    return 'true' if @property_hash[:event_history_periodic] == 'size_small' &&
+    return 'true' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
                      resource[:event_history_periodic] == 'true' && legacy_image?
+    return 'size_disable' if @property_hash[:event_history_periodic] == @bgp_vrf.default_event_history_periodic &&
+                             resource[:event_history_periodic] == 'size_disable' && !legacy_image?
     @property_hash[:event_history_periodic]
   end
 
   def event_history_periodic=(should_value)
     should_value = @bgp_vrf.default_event_history_periodic if should_value == 'default'
-    should_value = 'size_small' if should_value == 'true' && legacy_image?
+    should_value = @bgp_vrf.default_event_history_periodic if should_value == 'true' && legacy_image?
+    should_value = @bgp_vrf.default_event_history_periodic if should_value == 'size_disable' && !legacy_image?
     should_value = should_value.to_sym unless should_value =~ /\A\d+\z/
     @property_flush[:event_history_periodic] = should_value
   end

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -53,7 +53,9 @@ Puppet::Type.newtype(:cisco_bgp) do
       enforce_first_as                       => true,
       event_history_cli                      => 'true',
       event_history_detail                   => 'small',
+      event_history_errors                   => 'large',
       event_history_events                   => 'large',
+      event_history_objstore                 => 'medium',
       event_history_periodic                 => 'disable',
       fast_external_fallover                 => true,
       flush_routes                           => false,
@@ -348,36 +350,40 @@ Puppet::Type.newtype(:cisco_bgp) do
   newproperty(:event_history_cli) do
     desc "event_history_cli state. Valid values are True, False, size_small,
           size_medium, size_large, size_disable, size in bytes or 'default'"
-
-    munge do |value|
-      value = 'size_small' if value == 'true'
-      value = value.to_sym unless value =~ /\A\d+\z/
-      value
-    end
   end # property event_history_cli
 
   newproperty(:event_history_detail) do
     desc "event_history_detail state. Valid values are True, False, size_small,
           size_medium, size_large, size_disable, size in bytes or 'default'"
+  end # property event_history_detail
+
+  newproperty(:event_history_errors) do
+    desc "event_history_errors state. Valid values are True, False, size_small,
+          size_medium, size_large, size_disable, size in bytes or 'default'"
 
     munge do |value|
-      value = 'size_disable' if value == 'true'
+      value = 'size_medium' if value == 'true'
+      value = 'false' if value == 'size_disable'
       value = value.to_sym unless value =~ /\A\d+\z/
       value
     end
-  end # property event_history_detail
+  end # property event_history_errors
 
   newproperty(:event_history_events) do
     desc "event_history_events state. Valid values are True, False, size_small,
           size_medium, size_large, size_disable, size in bytes or 'default'"
+  end # property event_history_events
+
+  newproperty(:event_history_objstore) do
+    desc "event_history_objstore state. Valid values are True, False, size_small,
+          size_medium, size_large, size_disable, size in bytes or 'default'"
 
     munge do |value|
-      value = 'size_small' if value == 'true'
-      value = 'size_disable' if value == 'false'
+      value = 'false' if value == 'size_disable'
       value = value.to_sym unless value =~ /\A\d+\z/
       value
     end
-  end # property event_history_events
+  end # property event_history_objstore
 
   newproperty(:event_history_periodic) do
     desc "event_history_periodic state. Valid values are True, False, size_small,


### PR DESCRIPTION
This PR is for fixing few issues with event history properties as their defaults and behaviors have changed in the latest platform code release. Also added two new properties to event_history (errors and objstore) to the bgp provider which are available in the latest platform release. 