### PR TITLE
Rel141/lacp suspend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2395,6 +2395,7 @@ Manages configuration of a portchannel interface instance.
 | Property | Caveat Description |
 |:--------|:-------------|
 | `port_hash_distribution ` <br> `port_load_defer ` | Not supported on N5k, N6k |
+| `lacp_suspend_individual` | **WARNING:** On N9k, the portchannel interface must be shutdown before the property can be set.  This provider automatically shuts the interface down if needed. |
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -2395,7 +2395,7 @@ Manages configuration of a portchannel interface instance.
 | Property | Caveat Description |
 |:--------|:-------------|
 | `port_hash_distribution ` <br> `port_load_defer ` | Not supported on N5k, N6k |
-| `lacp_suspend_individual` | **WARNING:** On N9k, the portchannel interface must be shutdown before the property can be set.  This provider automatically shuts the interface down if needed.<br> The interface is automatically restored to the original state. |
+| `lacp_suspend_individual` | **WARNING:** On N9k, the portchannel interface must be shutdown before the property can be set.  This provider automatically shuts the interface down if needed.<br> The interface is automatically restored to the original state after the property is set. |
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -2395,7 +2395,7 @@ Manages configuration of a portchannel interface instance.
 | Property | Caveat Description |
 |:--------|:-------------|
 | `port_hash_distribution ` <br> `port_load_defer ` | Not supported on N5k, N6k |
-| `lacp_suspend_individual` | **WARNING:** On N9k, the portchannel interface must be shutdown before the property can be set.  This provider automatically shuts the interface down if needed. |
+| `lacp_suspend_individual` | **WARNING:** On N9k, the portchannel interface must be shutdown before the property can be set.  This provider automatically shuts the interface down if needed.<br> The interface is automatically restored to the original state. |
 
 #### Parameters
 

--- a/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
+++ b/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
@@ -105,7 +105,7 @@ tests[:non_default_sym] = {
     lacp_graceful_convergence: 'false',
     lacp_max_bundle:           '10',
     lacp_min_links:            '3',
-    lacp_suspend_individual:   'false',
+    lacp_suspend_individual:   platform[/n3k/] ? 'true' : 'false',
     port_hash_distribution:    'fixed',
     port_load_defer:           'true',
   },

--- a/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
+++ b/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
@@ -90,7 +90,7 @@ tests[:default_sym] = {
     'lacp_graceful_convergence' => 'true',
     'lacp_max_bundle'           => '32',
     'lacp_min_links'            => '1',
-    'lacp_suspend_individual'   => 'true',
+    'lacp_suspend_individual'   => platform[/n3k/] ? 'false' : 'true',
     'port_hash_distribution'    => 'false',
     'port_load_defer'           => 'false',
   },
@@ -171,7 +171,12 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_run(tests, :non_default_asym)
+
+  # The port-channel interface must be in admin state down to set
+  # the lacp_suspend_individual property.
+  test_set(agent, "interface #{intf} ; shutdown")
   test_harness_run(tests, :non_default_sym)
+
   test_harness_run(tests, :non_default_eth)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
+++ b/tests/beaker_tests/cisco_interface_portchannel/test_interface_portchannel.rb
@@ -171,12 +171,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_run(tests, :non_default_asym)
-
-  # The port-channel interface must be in admin state down to set
-  # the lacp_suspend_individual property.
-  test_set(agent, "interface #{intf} ; shutdown")
   test_harness_run(tests, :non_default_sym)
-
   test_harness_run(tests, :non_default_eth)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
**Summary of changes:**
* Update beaker test to verify the correct default value on `n3k` and other nxos platforms.
* Update caveat for lacp_suspend property to indicate the the interface is automatically shutdown on `n9k` platforms.

Tested on: n3k(I2, I5), n9k(I5)