### PR TITLE
fix vrf beaker

### DIFF
--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -75,7 +75,7 @@ def unsupported_properties(_tests, _id)
 
     unprops << :vni unless platform[/n9k/]
     unprops << :route_distinguisher if nexus_image['I2']
-    # unprops << :description if image?[/7.3.0.D1.1/] # CSCuy36637
+    unprops << :description if image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
 
   else
     unprops <<


### PR DESCRIPTION
This PR is for fixing vrf beaker test as the vrf description cannot be reset to default due to a bug in older releases. The fix is to skip the property for older images.