### PR TITLE
Rel150/atherton fretta fixes

### DIFF
--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
@@ -94,16 +94,16 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'ensure'              => 'present',
-                                 'timeout'             => '50',
-                                 'deadtime'            => '0',
-                                 'encryption_password' => 'WXYZ12',
-                                 'directed_request'    => 'false',
-                                 'source_interface'    => 'Ethernet1/4' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output,
+                             { 'ensure'              => 'present',
+                               'timeout'             => '50',
+                               'deadtime'            => '0',
+                               'encryption_password' => add_quotes('WXYZ12'),
+                               'directed_request'    => 'false',
+                               'source_interface'    => 'Ethernet1/4' },
+                             false, self, logger)
 
     logger.info("Check cisco_tacacs_server presence on agent :: #{result}")
   end
@@ -125,16 +125,16 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'ensure'              => 'present',
-                                 'timeout'             => '50',
-                                 'deadtime'            => '0',
-                                 'encryption_password' => 'WXYZ12',
-                                 'directed_request'    => 'false',
-                                 'source_interface'    => 'Ethernet1/4' },
-                               true, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output,
+                             { 'ensure'              => 'present',
+                               'timeout'             => '50',
+                               'deadtime'            => '0',
+                               'encryption_password' => add_quotes('WXYZ12'),
+                               'directed_request'    => 'false',
+                               'source_interface'    => 'Ethernet1/4' },
+                             true, self, logger)
 
     logger.info("Check cisco_tacacs_server absence on agent :: #{result}")
   end

--- a/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/tacacsserverhost_provider_nondefaults.rb
@@ -102,14 +102,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'ensure'              => 'present',
-                                 'port'                => '90',
-                                 'timeout'             => '39',
-                                 'encryption_password' => 'test123' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output,
+                             { 'ensure'              => 'present',
+                               'port'                => '90',
+                               'timeout'             => '39',
+                               'encryption_password' => add_quotes('test123') },
+                             false, self, logger)
 
     logger.info("Check cisco_tacacs_server_host presence on agent :: #{result}")
   end
@@ -131,14 +131,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to true to check for absence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource cisco_tacacs_server_host'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout,
-                               { 'ensure'              => 'present',
-                                 'port'                => '90',
-                                 'timeout'             => '39',
-                                 'encryption_password' => 'test123' },
-                               true, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output,
+                             { 'ensure'              => 'present',
+                               'port'                => '90',
+                               'timeout'             => '39',
+                               'encryption_password' => add_quotes('test123') },
+                             true, self, logger)
 
     logger.info("Check cisco_tacacs_server_host absence on agent :: #{result}")
   end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1436,3 +1436,19 @@ def test_patch_version(tests, id, name, ver)
     end
   end
 end
+
+# Add double quotes to string.
+#
+# Helper method to add a double quote to the beginning
+# and end of a string.
+#
+# Nxapi adds an escape character to config lines that
+# nvgen in this way in some but not all nxos releases.
+#
+# Input: String (Example 'foo')
+# Returns: String with double quotes: (Example: '"foo"'
+#
+def add_quotes(string)
+  string = "\"#{string}\"" if image?[/8.0/]
+  string
+end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1105,8 +1105,9 @@ end
 @image = nil # Cache the lookup result
 def nexus_image
   facter_opt = '-p cisco.images.system_image'
-  image_regexp = /[A-Z]+\d+\.\d+/
-  @image ||= on(agent, facter_cmd(facter_opt)).output[image_regexp]
+  image_regexp = /.*\.(\S+\.\S+)\.bin/
+  data = on(agent, facter_cmd(facter_opt)).output
+  @image ||= image_regexp.match(data)[1]
 end
 
 # On match will skip all testcases

--- a/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
+++ b/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
@@ -82,16 +82,16 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource radius_global default'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'retransmit_count' => '4' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '4' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check radius_global resource presence on agent :: #{result}")
   end
@@ -113,16 +113,16 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource radius_global default'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'retransmit_count' => '3' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '1' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '3' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '1' },
+                             false, self, logger)
 
     logger.info("Check radius_global resource presence on agent :: #{result}")
   end

--- a/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
+++ b/tests/beaker_tests/radius_server/radius_server_provider_defaults.rb
@@ -83,26 +83,26 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource radius_server 8.8.8.8'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'ensure' => 'present' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'accounting_only' => 'true' },
-                               false, self, logger) unless operating_system == 'ios_xr'
-      search_pattern_in_output(stdout, { 'acct_port' => '66' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'auth_port' => '77' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'authentication_only' => 'true' },
-                               false, self, logger) unless operating_system == 'ios_xr'
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'retransmit_count' => '4' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'ensure' => 'present' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'accounting_only' => 'true' },
+                             false, self, logger) unless operating_system == 'ios_xr'
+    search_pattern_in_output(output, { 'acct_port' => '66' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'auth_port' => '77' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'authentication_only' => 'true' },
+                             false, self, logger) unless operating_system == 'ios_xr'
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '4' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check radius_server resource presence on agent :: #{result}")
   end
@@ -190,26 +190,26 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource radius_server 2003::7'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'ensure' => 'present' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'accounting_only' => 'true' },
-                               false, self, logger) unless operating_system == 'ios_xr'
-      search_pattern_in_output(stdout, { 'acct_port' => '66' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'auth_port' => '77' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'authentication_only' => 'true' },
-                               false, self, logger) unless operating_system == 'ios_xr'
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'retransmit_count' => '4' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'ensure' => 'present' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'accounting_only' => 'true' },
+                             false, self, logger) unless operating_system == 'ios_xr'
+    search_pattern_in_output(output, { 'acct_port' => '66' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'auth_port' => '77' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'authentication_only' => 'true' },
+                             false, self, logger) unless operating_system == 'ios_xr'
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '4' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check radius_server resource presence on agent :: #{result}")
   end

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
@@ -77,14 +77,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check tacacs_global resource presence on agent :: #{result}")
   end
@@ -106,14 +106,14 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '1' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '1' },
+                             false, self, logger)
 
     logger.info("Check tacacs_global resource presence on agent :: #{result}")
   end

--- a/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_server/tacacs_server_provider_defaults.rb
@@ -81,18 +81,18 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource tacacs_server 8.8.8.8'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'ensure' => 'present' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'port' => '48' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'ensure' => 'present' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'port' => '48' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check tacacs_server resource presence on agent :: #{result}")
   end
@@ -114,18 +114,18 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource tacacs_server 8.8.8.8'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'ensure' => 'present' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'port' => '47' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '3' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'ensure' => 'present' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'port' => '47' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '3' },
+                             false, self, logger)
 
     logger.info("Check tacacs_server resource presence on agent :: #{result}")
   end
@@ -172,18 +172,18 @@ test_name "TestCase :: #{testheader}" do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource tacacs_server 2020::20'
-    on(agent, cmd_str) do
-      search_pattern_in_output(stdout, { 'ensure' => 'present' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key' => '44444444' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'key_format' => '7' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'port' => '48' },
-                               false, self, logger)
-      search_pattern_in_output(stdout, { 'timeout' => '2' },
-                               false, self, logger)
-    end
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'ensure' => 'present' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'port' => '48' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
 
     logger.info("Check tacacs_server resource presence on agent :: #{result}")
   end


### PR DESCRIPTION
**Summary of changes:**
- Add new utility method `add_quotes` that adds starting/trailing double quotes to a string.
  - Used to match strings in cases where nxapi preserves the double quotes.
- Modified beaker tests that call the `add_quotes` method for the following reason.
  - Calling the `add_quotes` method updates the stdout buffer with the image version and overwrites the output of the `puppet resource` command used for the test.
  - Update saves the stdout buffer to be used in the test.
- Updates utility method `nexus_image` to handle Atherton versions and be more generally flexible.

**Tested on:** n7k(helsinki and atherton), n9k evergreen