### PR TITLE
pim and interface bfd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - `hsrp_mac_refresh`
  - `hsrp_use_bia`
  - `hsrp_version`
+ - `pim_bfd`
+
+- Extend cisco_pim with attributes:
+ - `bfd`
+
 * Added support for Cisco NX-OS software release `7.3(0)F1(1)`
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Symbol | Meaning | Description
 | [cisco_ospf_vrf](#type-cisco_ospf_vrf)                     | ✅  | ✅  | ✅ | ✅  | ✅ | ✅ |
 | ✅ = Supported <br> :heavy_minus_sign: = Not Applicable | N9k | N3k | N5k | N6k | N7k | N9k-F | Caveats |
 | [cisco_overlay_global](#type-cisco_overlay_global)         | ✅  | :heavy_minus_sign: | ✅ | ✅ | ✅ | ✅ |
-| [cisco_pim](#type-cisco_pim)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
+| [cisco_pim](#type-cisco_pim)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | \*[caveats](#cisco_pim-caveats) |
 | [cisco_pim_rp_address](#type-cisco_pim_rp_address)         | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_pim_grouplist](#type-cisco_pim_grouplist)           | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_portchannel_global](#type-cisco_portchannel_global) | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | \*[caveats](#cisco_portchannel_global-caveats) |
@@ -1984,6 +1984,7 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 | `hsrp_mac_refresh`                    | Not supported on N5k,N6k,N7k <br> Minimum puppet module version 1.5.0 |
 | `hsrp_use_bia`                        | Not supported on N5k,N6k,N7k <br> Minimum puppet module version 1.5.0 |
 | `hsrp_version`                        | Not supported on N5k,N6k,N7k <br> Minimum puppet module version 1.5.0 |
+| `pim_bfd`                             | Minimum puppet module version 1.5.0 |
 
 #### Parameters
 
@@ -2197,6 +2198,9 @@ ipv6_dhcp_relay_addr => ['2000::11', '2001::22']
 ```
 ###### `ipv6_dhcp_relay_src_intf`
 Source interface for the DHCPV6 relay. Valid values are string, keyword 'default'.
+
+###### `pim_bfd`
+Enables PIM BFD on the interface. Valid values are 'true', 'false', and 'default'.
 
 ###### `vlan_mapping`
 This property is a nested array of [original_vlan, translated_vlan] pairs. Valid values are an array specifying the mapped vlans or keyword 'default'; e.g.:
@@ -3082,6 +3086,12 @@ Manages configuration of an Protocol Independent Multicast (PIM) instance.
 | N7k      | 7.3(0)D1(1)        | 1.2.0                  |
 | N9k-F    | 7.0(3)F1(1)        | 1.5.0                  |
 
+#### <a name="cisco_pim-caveats">Caveats</a>
+
+| Property | Caveat Description |
+|:---------|:-------------|
+| `bfd`    | Minimum puppet module version 1.5.0 |
+
 #### Parameters
 
 ##### `afi`
@@ -3091,6 +3101,9 @@ Address Family Identifier (AFI). Required. Valid value is ipv4.
 Name of the resource instance. Required. Valid values are string. The name 'default' is a valid VRF representing the global vrf.
 
 #### Properties
+
+##### `bfd`
+Enables BFD for all PIM interfaces in the current VRF. Valid values are true, false or 'default'.
 
 ##### `ssm_range`
 Configure group ranges for Source Specific Multicast (SSM). Valid values are multicast addresses or the keyword ‘none’.

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -66,6 +66,7 @@ class ciscopuppet::cisco::demo_interface {
       ipv4_acl_out                  => 'v4acl2',
       ipv6_acl_in                   => 'v6acl1',
       ipv6_acl_out                  => 'v6acl2',
+      pim_bfd                       => true,
     }
 
     cisco_interface { 'Ethernet1/1.1':

--- a/examples/cisco/demo_pim.pp
+++ b/examples/cisco/demo_pim.pp
@@ -19,7 +19,8 @@ class ciscopuppet::cisco::demo_pim {
     cisco_pim { 'ipv4' :
       ensure         => present,
       vrf            => 'default',
-      ssm_range      => '224.0.0.0/8 225.0.0.0/8'
+      ssm_range      => '224.0.0.0/8 225.0.0.0/8',
+      bfd            => true
     }
 
     cisco_pim_rp_address { 'ipv4' :

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -94,6 +94,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :ipv4_dhcp_relay_subnet_broadcast,
     :ipv4_dhcp_smart_relay,
     :negotiate_auto,
+    :pim_bfd,
     :shutdown,
     :switchport_autostate_exclude,
     :switchport_pvlan_host,

--- a/lib/puppet/provider/cisco_pim/cisco.rb
+++ b/lib/puppet/provider/cisco_pim/cisco.rb
@@ -33,6 +33,7 @@ Puppet::Type.type(:cisco_pim).provide(:cisco) do
   ]
 
   PIM_BOOL_PROPS = [
+    :bfd
   ]
 
   PIM_ALL_PROPS = PIM_NON_BOOL_PROPS + PIM_BOOL_PROPS
@@ -61,6 +62,14 @@ Puppet::Type.type(:cisco_pim).provide(:cisco) do
     # Call node_utils getter for each property
     PIM_NON_BOOL_PROPS.each do |prop|
       current_state[prop] = nu_obj.send(prop)
+    end
+    PIM_BOOL_PROPS.each do |prop|
+      val = nu_obj.send(prop)
+      if val.nil?
+        current_state[prop] = nil
+      else
+        current_state[prop] = val ? :true : :false
+      end
     end
     new(current_state)
   end # self.properties_get

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -64,6 +64,7 @@ Puppet::Type.newtype(:cisco_interface) do
      ipv4_dhcp_smart_relay          => true,
      ipv6_dhcp_relay_addr           => ['2000::11', '2001::22'],
      ipv6_dhcp_relay_src_intf       => 'ethernet 2/2',
+     pim_bfd                        => true,
     }
     cisco_interface { 'ethernet1/17' :
      stp_bpdufilter               => 'enable',
@@ -287,6 +288,12 @@ Puppet::Type.newtype(:cisco_interface) do
   ########################################
   # Begin L3 interface config attributes #
   ########################################
+
+  newproperty(:pim_bfd) do
+    desc 'Enables pim BFD on this interface.'
+
+    newvalues(:true, :false, :default)
+  end # property pim_bfd
 
   newproperty(:ipv4_pim_sparse_mode) do
     desc '<L3 attribute> Enables or disables ipv4 pim sparse mode '\

--- a/lib/puppet/type/cisco_pim.rb
+++ b/lib/puppet/type/cisco_pim.rb
@@ -43,7 +43,8 @@ Puppet::Type.newtype(:cisco_pim) do
   ~~~puppet
     cisco_pim { 'ipv4 red' :
       ensure          => present,
-      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8',
+      bfd             => true
     }
   ~~~
 
@@ -54,7 +55,8 @@ Puppet::Type.newtype(:cisco_pim) do
       ensure          => present,
       afi             => 'ipv4',
       vrf             => 'default',
-      ssm_range       => default
+      ssm_range       => default,
+      bfd             => true
     }
   ~~~
 
@@ -62,14 +64,16 @@ Puppet::Type.newtype(:cisco_pim) do
     cisco_pim { 'ipv4' :
       ensure          => present,
       vrf             => 'default',
-      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8',
+      bfd             => true
     }
   ~~~
 
   ~~~puppet
     cisco_pim { 'ipv4 blue' :
       ensure          => present,
-      ssm_range       => '224.0.0.0/8 225.0.0.0/8'
+      ssm_range       => '224.0.0.0/8 225.0.0.0/8',
+      bfd             => true
     }
   ~~~
   "
@@ -133,6 +137,12 @@ Puppet::Type.newtype(:cisco_pim) do
   # ---------------------------------------------------------------
   # Definition of properties.
   # ---------------------------------------------------------------
+
+  newproperty(:bfd) do
+    desc 'Enables BFD for all PIM interfaces in the VRF.'
+
+    newvalues(:true, :false, :default)
+  end # property bfd
 
   newproperty(:ssm_range) do
     desc "Sets the ssm range for Pim. Valid

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -62,6 +62,7 @@ tests[:default] = {
     ipv4_dhcp_smart_relay:            'default',
     ipv6_dhcp_relay_addr:             'default',
     ipv6_dhcp_relay_src_intf:         'default',
+    pim_bfd:                          'default',
     mtu:                              'default',
     shutdown:                         'default',
     vrf:                              'default',
@@ -78,6 +79,7 @@ tests[:default] = {
     ipv4_dhcp_relay_subnet_broadcast: 'false',
     ipv4_dhcp_smart_relay:            'false',
     ipv6_dhcp_relay_src_intf:         'false',
+    pim_bfd:                          'false',
     mtu:                              operating_system == 'nexus' ? '1500' : '1514',
     shutdown:                         'false',
   },
@@ -117,6 +119,7 @@ tests[:non_default] = {
     ipv4_dhcp_smart_relay:            'true',
     ipv6_dhcp_relay_addr:             v6_relay,
     ipv6_dhcp_relay_src_intf:         'ethernet1/1',
+    pim_bfd:                          true,
     switchport_mode:                  'disabled',
     vrf:                              'test1',
   },
@@ -170,6 +173,7 @@ def unsupported_properties(_tests, id)
       :ipv4_dhcp_smart_relay <<
       :ipv6_dhcp_relay_addr <<
       :ipv6_dhcp_relay_src_intf <<
+      :pim_bfd <<
       :switchport_mode
   end
 

--- a/tests/beaker_tests/cisco_pim/test_pim.rb
+++ b/tests/beaker_tests/cisco_pim/test_pim.rb
@@ -25,9 +25,10 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
 # Test hash top-level keys
 tests = {
-  master:        master,
-  agent:         agent,
-  resource_name: 'cisco_pim',
+  master:           master,
+  agent:            agent,
+  operating_system: 'nexus',
+  resource_name:    'cisco_pim',
 }
 
 # Test hash test cases
@@ -35,7 +36,8 @@ tests[:non_def_S1] = {
   desc:           ' 1.1 Non default properties',
   title_pattern:  'ipv4 red',
   manifest_props: {
-    ssm_range: '224.0.0.0/8'
+    bfd:       true,
+    ssm_range: '224.0.0.0/8',
   },
 }
 


### PR DESCRIPTION
This PR is for adding bfd property to cisco_pim and pim_bfd property to cisco_interface providers. All tests pass.