### PR TITLE
fix the case sensitive issue for interface_hsrp_group

### DIFF
--- a/lib/puppet/type/cisco_interface_hsrp_group.rb
+++ b/lib/puppet/type/cisco_interface_hsrp_group.rb
@@ -103,6 +103,7 @@ Puppet::Type.newtype(:cisco_interface_hsrp_group) do
 
   newparam(:interface, namevar: true) do
     desc 'Name of the interface instance. Valid values are string.'
+    munge(&:downcase)
   end # param interface
 
   ##############


### PR DESCRIPTION
Summary:
This update fixes the issue with the cisco_interface_hsrp_group provider described in cisco/cisco-network-puppet-module#415

As the name of the interface is case sensitive, it was causing idempotent issues. Fixed