### PR TITLE
fix backspace issue for dhcp

### DIFF
--- a/lib/puppet/type/cisco_dhcp_relay_global.rb
+++ b/lib/puppet/type/cisco_dhcp_relay_global.rb
@@ -124,7 +124,11 @@ Puppet::Type.newtype(:cisco_dhcp_relay_global) do
 
     munge do |value|
       value = value.strip
-      value = :default if value == 'default'
+      if value == 'default'
+        value = :default
+      else
+        value = "\"#{value}\"" unless value.start_with?('"') && value.end_with?('"')
+      end
       value
     end
   end # property ipv4_sub_option_circuit_id_string

--- a/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
+++ b/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
@@ -99,7 +99,7 @@ tests[:non_default] = {
     ipv4_src_addr_hsrp:                'true',
     ipv4_src_intf:                     'port-channel200',
     ipv4_sub_option_circuit_id_custom: 'true',
-    ipv4_sub_option_circuit_id_string: 'WORD',
+    ipv4_sub_option_circuit_id_string: add_quotes('WORD'),
     ipv4_sub_option_cisco:             'true',
     ipv6_option_cisco:                 'true',
     ipv6_option_vpn:                   'true',


### PR DESCRIPTION
This PR is for fixing backspace issue for dhcp ipv4_sub_option_circuit_id_string. The NU changes are opened in another PR.