### PR TITLE
remove all route maps after beaker test

### DIFF
--- a/tests/beaker_tests/cisco_route_map/test_route_map.rb
+++ b/tests/beaker_tests/cisco_route_map/test_route_map.rb
@@ -540,11 +540,7 @@ def unsupported_properties(_tests, _id)
 end
 
 def cleanup(agent)
-  test_set(agent, 'no route-map rm1')
-  test_set(agent, 'no route-map rm2')
-  test_set(agent, 'no route-map rm3')
-  test_set(agent, 'no route-map rm4')
-  test_set(agent, 'no route-map rm5')
+  remove_all_route_maps(agent)
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_route_map/test_route_map.rb
+++ b/tests/beaker_tests/cisco_route_map/test_route_map.rb
@@ -540,7 +540,7 @@ def unsupported_properties(_tests, _id)
 end
 
 def cleanup(agent)
-  remove_all_route_maps(agent)
+  resource_absent_cleanup(agent, 'cisco_route_map')
 end
 
 #################################################################

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1414,12 +1414,6 @@ def remove_all_vrfs(agent)
   test_set(agent, found.compact.join(' ; '))
 end
 
-def remove_all_route_maps(agent)
-  found = test_get(agent, 'incl ^route-map').split("\n")
-  found.map! { |cmd| "no #{cmd}" if cmd[/^route-map/] }
-  test_set(agent, found.compact.join(' ; '))
-end
-
 # Return yum patch version from host
 def get_patch_version(name)
   cmd = get_vshell_cmd("show install packages | inc #{name}")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1414,6 +1414,12 @@ def remove_all_vrfs(agent)
   test_set(agent, found.compact.join(' ; '))
 end
 
+def remove_all_route_maps(agent)
+  found = test_get(agent, 'incl ^route-map').split("\n")
+  found.map! { |cmd| "no #{cmd}" if cmd[/^route-map/] }
+  test_set(agent, found.compact.join(' ; '))
+end
+
 # Return yum patch version from host
 def get_patch_version(name)
   cmd = get_vshell_cmd("show install packages | inc #{name}")


### PR DESCRIPTION
This PR is for removing all route maps before/after the beaker tests so that no residual configuration is left on the system