### PR TITLE
purge_config add to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### New feature support
 
 ### Added
+- Extend cisco_interface with attributes:
+ - `purge_config`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -2022,7 +2022,14 @@ Description of the interface. Valid values are a string or the keyword 'default'
 Duplex of the interface. Valid values are 'full', and 'auto'.
 
 ###### `purge_config`
-Puts the ethenet interface into default state. Valid value is 'true'.
+Puts the ethenet interface into default state. Valid value is 'true'. When this property is set to 'true', the manifest can have no other properties.
+
+#### Example Usage
+
+```puppet
+cisco_interface { 'ethernet1/10':
+    purge_config => true,
+  }
 
 ###### `speed`
 Speed of the interface. Valid values are 100, 1000, 10000, 40000, 1000000, and 'auto'.

--- a/README.md
+++ b/README.md
@@ -2022,7 +2022,7 @@ Description of the interface. Valid values are a string or the keyword 'default'
 Duplex of the interface. Valid values are 'full', and 'auto'.
 
 ###### `purge_config`
-Puts the ethenet interface into default state. Valid value is 'true'. When this property is set to 'true', the manifest can have no other properties.
+Puts the ethernet interface into default state. Valid value is 'true'. When this property is set to 'true', the manifest can have no other properties.
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -1996,6 +1996,7 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 | `load_interval_counter_1_delay`       | Minimum puppet module version 1.6.0 |
 | `load_interval_counter_2_delay`       | Minimum puppet module version 1.6.0 |
 | `load_interval_counter_3_delay`       | Minimum puppet module version 1.6.0 |
+| `purge_config`                        | Minimum puppet module version 1.7.0 |
 
 #### Parameters
 
@@ -2019,6 +2020,9 @@ Description of the interface. Valid values are a string or the keyword 'default'
 
 ###### `duplex`
 Duplex of the interface. Valid values are 'full', and 'auto'.
+
+###### `purge_config`
+Puts the ethenet interface into default state. Valid value is 'true'.
 
 ###### `speed`
 Speed of the interface. Valid values are 100, 1000, 10000, 40000, 1000000, and 'auto'.

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -98,6 +98,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :ipv4_dhcp_smart_relay,
     :negotiate_auto,
     :pim_bfd,
+    :purge_config,
     :shutdown,
     :switchport_autostate_exclude,
     :switchport_pvlan_host,

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -1279,4 +1279,14 @@ Puppet::Type.newtype(:cisco_interface) do
 
     munge { |value| value == 'default' ? :default : Integer(value) }
   end # property load_interval_counter_3_delay
+
+  newproperty(:purge_config) do
+    desc 'Puts the ethernet interface in default state.'
+
+    newvalues(:true)
+  end
+
+  validate do
+    fail ArgumentError, 'All params MUST be nil if purge_config is true' if self[:purge_config] == :true && properties.length > 2
+  end
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -126,6 +126,9 @@ Puppet::Type.newtype(:cisco_interface) do
      switchport_pvlan_trunk_allowed_vlan => '88-91,94',
      switchport_pvlan_trunk_native_vlan  => 12,
     }
+    cisco_interface { 'ethernet8/2' :
+     purge_config                        => true,
+    }
     cisco_interface {'Vlan98':
      pvlan_mapping => '10-11,13',
     }

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -135,6 +135,14 @@ tests[:non_default_trunk] = {
   },
 }
 
+tests[:purge] = {
+  desc:           '2.3 Purge Properties',
+  title_pattern:  intf,
+  manifest_props: {
+    purge_config: 'true'
+  },
+}
+
 def unsupported_properties(_tests, _id)
   unprops = []
   unprops <<
@@ -161,6 +169,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("\n#{'-' * 60}\nSection 1. 'trunk' Property Testing")
   test_harness_run(tests, :default_trunk)
   test_harness_run(tests, :non_default_trunk)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2.3 Purge_config Testing")
+  test_harness_run(tests, :purge)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
This PR for adding purge_config property to interface provider so that the physical interface can be put back into default state. All tests pass on n3k, n6k, n9k.
This update fixes the issue with the cisco_interface provider described in https://github.com/cisco/cisco-network-puppet-module/issues/424