### PR TITLE
Channel group mode addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Extend cisco_interface with attributes:
  - `purge_config`
 
+- Extend cisco_interface_channel_group with attributes:
+ - `channel_group_mode`
+
 ### Changed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Symbol | Meaning | Description
 | [cisco_fabricpath_topology](#type-cisco_fabricpath_topology) | ➖ | ➖ | ✅ | ✅ | ✅  | ➖ |
 | [cisco_hsrp_global](#type-cisco_hsrp_global)                         | ✅  | ✅* | ✅  | ✅  | ✅  | ✅  | \*[caveats](#cisco_hsrp_global-caveats) |
 | [cisco_interface](#type-cisco_interface)                             | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | \*[caveats](#cisco_interface-caveats) |
-| [cisco_interface_channel_group](#type-cisco_interface_channel_group) | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
+| [cisco_interface_channel_group](#type-cisco_interface_channel_group) | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | \*[caveats](#cisco_interface_channel_group-caveats) |
 | [cisco_interface_hsrp_group](#type-cisco_interface_hsrp_group)       | ✅  | ✅ | ➖ | ➖ | ✅* | ✅ | \*[caveats](#cisco_interface_hsrp_group-caveats) |
 | [cisco_interface_ospf](#type-cisco_interface_ospf)                   | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_interface_portchannel](#type-cisco_interface_portchannel)     | ✅* | ✅* | ✅* | ✅* | ✅* | ✅ | \*[caveats](#cisco_interface_portchannel-caveats) |
@@ -2336,6 +2336,12 @@ Manages a Cisco Network Interface Channel-group.
 | N7k      | 7.3(0)D1(1)        | 1.3.0                  |
 | N9k-F    | 7.0(3)F1(1)        | 1.5.0                  |
 
+#### <a name="cisco_interface_channel_group-caveats">Caveats</a>
+
+| Property | Caveat Description |
+|:---------|:-------------|
+| `channel_group_mode`    | Minimum puppet module version 1.7.0 |
+
 #### Parameters
 
 ##### Basic interface channel-group config attributes
@@ -2350,6 +2356,9 @@ Name of the interface where the service resides. Valid value is a string.
 channel_group is an aggregation of multiple physical interfaces that creates a logical interface. Valid values are 1 to 4096 and 'default'.
 
 Note: On some platforms a normal side-effect of adding the channel-group property is that an independent port-channel interface will be created; however, removing the channel-group configuration by itself will not also remove the port-channel interface. Therefore, the port-channel interface itself may be explicitly removed by using the `cisco_interface` provider with `ensure => absent`.
+
+###### `channel_group_mode`
+channel_group_mode is the port-channel mode of the interface. Valid values are 'active', 'passive', 'on', and 'default'.
 
 ###### `description`
 Description of the interface. Valid values are a string or the keyword 'default'.

--- a/README.md
+++ b/README.md
@@ -2030,6 +2030,7 @@ Puts the ethernet interface into default state. Valid value is 'true'. When this
 cisco_interface { 'ethernet1/10':
     purge_config => true,
   }
+```
 
 ###### `speed`
 Speed of the interface. Valid values are 100, 1000, 10000, 40000, 1000000, and 'auto'.
@@ -2340,7 +2341,7 @@ Manages a Cisco Network Interface Channel-group.
 
 | Property | Caveat Description |
 |:---------|:-------------|
-| `channel_group_mode`    | Minimum puppet module version 1.7.0 |
+| `channel_group_mode`          | Minimum puppet module version 1.7.0 |
 
 #### Parameters
 

--- a/examples/cisco/demo_interface.pp
+++ b/examples/cisco/demo_interface.pp
@@ -74,7 +74,8 @@ class ciscopuppet::cisco::demo_interface {
     }
 
     cisco_interface_channel_group { 'Ethernet1/2':
-      channel_group   => 200,
+      channel_group      => 200,
+      channel_group_mode => 'active',
     }
 
     cisco_interface { 'Ethernet1/3':
@@ -130,19 +131,19 @@ class ciscopuppet::cisco::demo_interface {
     }
 
     if platform_get() =~ /n7k/ {
-      cisco_bridge_domain { "100":
-        ensure    => 'present',
-        shutdown  => false,
-        bd_name   => 'test1'
+      cisco_bridge_domain { '100':
+        ensure   => 'present',
+        shutdown => false,
+        bd_name  => 'test1'
       }
 
       cisco_interface { 'Bdi100':
-        require               => Cisco_bridge_domain['100'],
-        ensure                => 'present',
-        shutdown              => false,
-        ipv4_address          => "10.10.10.1",
-        ipv4_netmask_length   => 24,
-        vrf                   => 'test1'
+        require             => Cisco_bridge_domain['100'],
+        ensure              => 'present',
+        shutdown            => false,
+        ipv4_address        => '10.10.10.1',
+        ipv4_netmask_length => 24,
+        vrf                 => 'test1'
       }
     } else {
       warning('This platform does not support cisco_bridge_domain')
@@ -154,9 +155,9 @@ class ciscopuppet::cisco::demo_interface {
       cisco_vlan {  '2': pvlan_type => 'primary', pvlan_association => '12' }
 
       cisco_interface { 'Ethernet1/6':
-        description                         => 'Private-vlan Host Port',
-        switchport_pvlan_host               => true,
-        switchport_pvlan_host_association   => [2, 12],
+        description                       => 'Private-vlan Host Port',
+        switchport_pvlan_host             => true,
+        switchport_pvlan_host_association => [2, 12],
       }
 
       cisco_vlan { '13': pvlan_type => 'isolated' }
@@ -194,8 +195,8 @@ class ciscopuppet::cisco::demo_interface {
         switchport_pvlan_mapping_trunk      => $trunk_map,
       }
       cisco_interface { 'vlan29':
-        description                         => 'SVI Private-vlan Mapping',
-        pvlan_mapping                       => '108-109',
+        description   => 'SVI Private-vlan Mapping',
+        pvlan_mapping => '108-109',
       }
     } else {
       warning('This platform does not support the private-vlan feature')

--- a/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
   # Note: channel_group should always process first.
   INTF_CG_NON_BOOL_PROPS = [
     :channel_group,
+    :channel_group_mode,
     :description,
   ]
   INTF_CG_BOOL_PROPS = [
@@ -119,6 +120,16 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
           @nu.respond_to?("#{prop}=")
       end
     end
+    # custom setters which require one-shot multi-param setters
+    channel_group_mode_set
+  end
+
+  def channel_group_mode_set
+    group = @property_flush[:channel_group] ? @property_flush[:channel_group] : @nu.channel_group
+    mode = @property_flush[:channel_group_mode] ? @property_flush[:channel_group_mode] : @nu.channel_group_mode
+    group = false if @resource[:channel_group] == :default
+    mode = false if @resource[:channel_group_mode] == :default
+    @nu.channel_group_mode_set(group, mode)
   end
 
   def flush

--- a/lib/puppet/provider/port_channel/cisco.rb
+++ b/lib/puppet/provider/port_channel/cisco.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:port_channel).provide(:cisco, parent: Puppet::Type.type(:cisc
       if @resource[:interfaces]
         @resource[:interfaces].each do |i|
           bla = Cisco::InterfaceChannelGroup.interfaces[i]
-          bla.channel_group = @resource[:id] if @resource[:id]
+          bla.channel_group_mode_set(@resource[:id]) if @resource[:id]
         end
       end
     end

--- a/lib/puppet/type/cisco_interface_channel_group.rb
+++ b/lib/puppet/type/cisco_interface_channel_group.rb
@@ -69,6 +69,13 @@ Puppet::Type.newtype(:cisco_interface_channel_group) do
     munge { |value| value == 'default' ? :default : value.to_i }
   end # property channel_group
 
+  newproperty(:channel_group_mode) do
+    desc 'Port-channel mode of the interface. Valid values are string'
+
+    munge { |value| value == 'on' || value == 'default' ? :default : value }
+    newvalues(:active, :passive, :on, :default)
+  end
+
   newproperty(:description) do
     desc "Description of the interface. Valid values are string, keyword
          'default'."
@@ -84,4 +91,10 @@ Puppet::Type.newtype(:cisco_interface_channel_group) do
 
     newvalues(:true, :false, :default)
   end # property shutdown
+
+  validate do
+    return unless self[:channel_group] == :default
+    fail ArgumentError, 'channel_group_mode MUST be default if channel_group_mode is default' unless
+      self[:channel_group_mode] == :default
+  end
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_interface_channel_group.rb
+++ b/lib/puppet/type/cisco_interface_channel_group.rb
@@ -29,9 +29,10 @@ Puppet::Type.newtype(:cisco_interface_channel_group) do
 
   Example:
   cisco_interface_channel_group {'Ethernet1/15':
-    channel_group   => 201,
-    description     => 'my channel group',
-    shutdown        => true,
+    channel_group      => 201,
+    channel_group_mode => 'active',
+    description        => 'myChannelGroup',
+    shutdown           => true,
   }
   "
 

--- a/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
+++ b/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
@@ -49,8 +49,23 @@ tests[:default] = {
   },
 }
 
-tests[:non_default] = {
-  desc:           '2.1 Non Default Properties commands',
+tests[:non_default_no_mode] = {
+  desc:           '2.1 Non Default Properties with no channel group mode',
+  title_pattern:  intf,
+  manifest_props: {
+    channel_group: 201,
+    description:   'chan group desc',
+    shutdown:      'false',
+  },
+  resource:       {
+    'channel_group' => '201',
+    'description'   => 'chan group desc',
+    'shutdown'      => 'false',
+  },
+}
+
+tests[:non_default_mode] = {
+  desc:           '2.2 Non Default Properties with channel group mode',
   title_pattern:  intf,
   manifest_props: {
     channel_group:      201,
@@ -79,6 +94,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default_no_mode)
+  test_harness_run(tests, :non_default_mode)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
+++ b/tests/beaker_tests/cisco_interface_channel_group/test_interface_channel_group.rb
@@ -37,13 +37,15 @@ tests[:default] = {
   title_pattern:  intf,
   code:           [0, 2],
   manifest_props: {
-    channel_group: 'default',
-    description:   'default',
-    shutdown:      'default',
+    channel_group:      'default',
+    channel_group_mode: 'default',
+    description:        'default',
+    shutdown:           'default',
   },
   resource:       {
-    'channel_group' => 'false',
-    'shutdown'      => 'true',
+    'channel_group'      => 'false',
+    'channel_group_mode' => 'false',
+    'shutdown'           => 'true',
   },
 }
 
@@ -51,14 +53,16 @@ tests[:non_default] = {
   desc:           '2.1 Non Default Properties commands',
   title_pattern:  intf,
   manifest_props: {
-    channel_group: 201,
-    description:   'chan group desc',
-    shutdown:      'false',
+    channel_group:      201,
+    channel_group_mode: 'active',
+    description:        'chan group desc',
+    shutdown:           'false',
   },
   resource:       {
-    'channel_group' => '201',
-    'description'   => 'chan group desc',
-    'shutdown'      => 'false',
+    'channel_group'      => '201',
+    'channel_group_mode' => 'active',
+    'description'        => 'chan group desc',
+    'shutdown'           => 'false',
   },
 }
 

--- a/tests/beaker_tests/file_service_package/test_package_patch.rb
+++ b/tests/beaker_tests/file_service_package/test_package_patch.rb
@@ -72,7 +72,7 @@ tests = {
 
 # Skip -ALL- tests if a top-level platform/os key exludes this platform
 skip_unless_supported(tests)
-skip_nexus_image('I2|I3', tests)
+skip_nexus_image(%w(I2 I3), tests)
 
 tests[:yum_patch_install] = {
   desc:           "1.1 Apply sample patch #{name} to image #{image?}",

--- a/tests/beaker_tests/file_service_package/test_package_patch.rb
+++ b/tests/beaker_tests/file_service_package/test_package_patch.rb
@@ -43,6 +43,9 @@ when /7.0.3.I4.1/
 when /7.0.3.I4.2/
   filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.2.lib32_n9000.rpm'
   version =  '1.0.0-7.0.3.I4.2'
+when /7.0.3.I4.5/
+  filename = 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.5.lib32_n9000.rpm'
+  version =  '1.0.0-7.0.3.I4.5'
 when /7.0.3.I5.1/
   name = 'nxos.sample-n9k_ALL'
   filename = 'nxos.sample-n9k_ALL-1.0.0-7.0.3.I5.1.lib32_n9000.rpm'

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1122,7 +1122,7 @@ end
 # On match will skip all testcases
 # Do not use this for skipping individual properties.
 def skip_nexus_image(image, tests)
-  return unless nexus_image[image]
+  return unless nexus_image.match(Regexp.union(image))
   msg = "Skipping all tests; '#{tests[:resource_name]}' "\
         "is not supported on #{image} images"
   banner = '#' * msg.length


### PR DESCRIPTION
This PR is for adding channel_group_mode to interface_channel_group provider. The new property channel_group_mode is optional (to keep backward compatibility). 
This PR also contains skip code for patch beaker tests if the version is I2 or I3. 
All tests pass on all platforms.