### PR TITLE
Bgp address family aggregate address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### New feature support
+#### Cisco Resources
+- `cisco_bgp_af_aa` type and provider.
 
 ### Added
 - Extend cisco_interface with attributes:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`cisco_vrf_af`](#type-cisco_vrf_af)
   * [`cisco_bgp`](#type-cisco_bgp)
   * [`cisco_bgp_af`](#type-cisco_bgp_af)
+  * [`cisco_bgp_af_aa`](#type-cisco_bgp_af_aa)
   * [`cisco_bgp_neighbor`](#type-cisco_bgp_neighbor)
   * [`cisco_bgp_neighbor_af`](#type-cisco_bgp_neighbor_af)
 
@@ -299,6 +300,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`cisco_bfd_global`](#type-cisco_bfd_global)
 * [`cisco_bgp`](#type-cisco_bgp)
 * [`cisco_bgp_af`](#type-cisco_bgp_af)
+* [`cisco_bgp_af_aa`](#type-cisco_bgp_af_aa)
 * [`cisco_bgp_neighbor`](#type-cisco_bgp_neighbor)
 * [`cisco_bgp_neighbor_af`](#type-cisco_bgp_neighbor_af)
 * [`cisco_bridge_domain`](#type-cisco_bridge_domain)
@@ -412,6 +414,7 @@ Symbol | Meaning | Description
 | [cisco_command_config](#type-cisco_command_config)         | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_bgp](#type-cisco_bgp)                               | ✅  | ✅  | ✅* | ✅* | ✅* | ✅ | \*[caveats](#cisco_bgp-caveats) |
 | [cisco_bgp_af](#type-cisco_bgp_af)                         | ✅* | ✅* | ✅  | ✅* | ✅  | ✅ | \*[caveats](#cisco_bgp_af-caveats) |
+| [cisco_bgp_af_aa](#type-cisco_bgp_af_aa)                   | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_bgp_neighbor](#type-cisco_bgp_neighbor)             | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_bgp_neighbor_af](#type-cisco_bgp_neighbor_af)       | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | [cisco_bridge_domain](#type-cisco_bridge_domain)           | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ |
@@ -1383,6 +1386,58 @@ Apply table-map to filter routes downloaded into URIB. Valid values are a string
 
 ##### `table_map_filter`
 Filters routes rejected by the route-map and does not download them to the RIB. Valid values are true, false, or 'default'.
+
+--
+### Type: cisco_bgp_af_aa
+
+Manages configuration of a BGP Address-family Aggregate-address instance.
+
+| Platform | OS Minimum Version | Module Minimum Version |
+|----------|:------------------:|:----------------------:|
+| N9k      | 7.0(3)I2(5)        | 1.7.0                  |
+| N3k      | 7.0(3)I2(5)        | 1.7.0                  |
+| N5k      | 7.3(0)N1(1)        | 1.7.0                  |
+| N6k      | 7.3(0)N1(1)        | 1.7.0                  |
+| N7k      | 7.3(0)D1(1)        | 1.7.0                  |
+| N9k-F    | 7.0(3)F1(1)        | 1.7.0                  |
+
+#### Parameters
+
+###### `ensure`
+Determine whether the BGP address family aggregate address should be present or not. Valid values
+ are 'present' and 'absent'.
+
+##### `asn`
+BGP autonomous system number. Required. Valid values are String, Integer in ASPLAIN or ASDOT notation.
+
+##### `vrf`
+VRF name. Required. Valid values are string. The name 'default' is a valid VRF representing the global bgp.
+
+##### `afi`
+Address Family Identifier (AFI). Required. Valid values are `ipv4`, `ipv6`, `vpnv4`, `vpnv6` and `l2vpn`.
+
+##### `safi`
+Sub Address Family Identifier (SAFI). Required. Valid values are `unicast`, `multicast` and `evpn`.
+
+##### `aa`
+Aggregate address prefix in ipv4/ipv6 format. Required. Valid values are string. For example, it could be '1.1.1.1/32' or '2000::1/128'.
+
+#### Properties
+
+##### `as_set`
+Generates AS-SET information. Valid values are true, false or 'default'.
+
+##### `advertise_map`
+Route-map to select attribute information from specific routes. Valid values are String or 'default'.
+
+##### `attribute_map`
+Route-map to set attribute information of aggregate. Valid values are String or 'default'.
+
+##### `summary_only`
+Stops advertising more specifics.  Valid values are true, false or 'default'.
+
+##### `suppress_map`
+Route-map to conditionally filter more specific routes. Valid values are String or 'default'.
 
 --
 ### Type: cisco_bgp_neighbor

--- a/README.md
+++ b/README.md
@@ -1420,24 +1420,24 @@ Address Family Identifier (AFI). Required. Valid values are `ipv4`, `ipv6`, `vpn
 Sub Address Family Identifier (SAFI). Required. Valid values are `unicast`, `multicast` and `evpn`.
 
 ##### `aa`
-Aggregate address prefix in ipv4/ipv6 format. Required. Valid values are string. For example, it could be '1.1.1.1/32' or '2000::1/128'.
+Aggregate address mask in ipv4/ipv6 format. Required. Valid values are string. Examples: 1.1.1.1/32 or 2000:1/128.
 
 #### Properties
 
 ##### `as_set`
-Generates AS-SET information. Valid values are true, false or 'default'.
+Generates autonomous system set path information. Valid values are true, false or 'default'.
 
 ##### `advertise_map`
-Route-map to select attribute information from specific routes. Valid values are String or 'default'.
+Name of the route map used to select the routes to create AS_SET origin communities. Valid values are string or 'default'.
 
 ##### `attribute_map`
-Route-map to set attribute information of aggregate. Valid values are String or 'default'.
+Name of the route map used to set the attribute of the aggregate route. Valid values are string or 'default'.
 
 ##### `summary_only`
-Stops advertising more specifics.  Valid values are true, false or 'default'.
+Filters all more-specific routes from updates.  Valid values are true, false or 'default'.
 
 ##### `suppress_map`
-Route-map to conditionally filter more specific routes. Valid values are String or 'default'.
+Name of the route map used to select the routes to be suppressed. Valid values are string or 'default'.
 
 --
 ### Type: cisco_bgp_neighbor

--- a/examples/cisco/demo_bgp.pp
+++ b/examples/cisco/demo_bgp.pp
@@ -207,6 +207,19 @@ class ciscopuppet::cisco::demo_bgp {
     redistribute                  => $ipv4_redistribute,
   }
 
+  cisco_bgp_af_aa { '55.77 default ipv4 unicast 1.1.1.1/32':
+    ensure        => present,
+    as_set        => true,
+    advertise_map => 'adm',
+    attribute_map => 'atm',
+    suppress_map  => 'sum',
+  }
+
+  cisco_bgp_af_aa { '55.77 default ipv4 unicast 2.2.2.2/32':
+    ensure        => present,
+    summary_only  => true,
+  }
+
   if platform_get() != 'n3k' {
     cisco_bgp_af { '55.77 default l2vpn evpn':
       ensure                      => present,

--- a/lib/puppet/provider/cisco_bgp_af_aa/cisco.rb
+++ b/lib/puppet/provider/cisco_bgp_af_aa/cisco.rb
@@ -1,0 +1,185 @@
+# May, 2017
+#
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:cisco_bgp_af_aa).provide(:cisco) do
+  desc 'The Cisco bgp_af_aa provider.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  BGP_AF_AA_NON_BOOL_PROPS = [
+    :advertise_map,
+    :attribute_map,
+    :suppress_map,
+  ]
+
+  BGP_AF_AA_BOOL_PROPS = [
+    :as_set,
+    :summary_only,
+  ]
+
+  BGP_AF_AA_ALL_PROPS = BGP_AF_AA_NON_BOOL_PROPS + BGP_AF_AA_BOOL_PROPS
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
+                                            BGP_AF_AA_NON_BOOL_PROPS)
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@nu',
+                                            BGP_AF_AA_BOOL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    asn  = @property_hash[:asn]
+    vrf  = @property_hash[:vrf]
+    afi  = @property_hash[:afi]
+    safi = @property_hash[:safi]
+    aa = @property_hash[:aa]
+    af = [afi.to_s, safi.to_s]
+
+    @nu = Cisco::RouterBgpAFAggrAddr.aas[asn][vrf][af][aa] unless asn.nil?
+    @property_flush = {}
+  end
+
+  def self.properties_get(asn, vrf, af, aa, nu_obj)
+    current_state = {
+      name:   [asn, vrf, af.first, af.last, aa].join(' '),
+      asn:    asn,
+      vrf:    vrf,
+      afi:    af.first,
+      safi:   af.last,
+      aa:     aa,
+      ensure: :present,
+    }
+
+    # Call node_utils getter for each property
+    BGP_AF_AA_NON_BOOL_PROPS.each do |prop|
+      current_state[prop] = nu_obj.send(prop)
+    end
+
+    BGP_AF_AA_BOOL_PROPS.each do |prop|
+      val = nu_obj.send(prop)
+      if val.nil?
+        current_state[prop] = nil
+      else
+        current_state[prop] = val ? :true : :false
+      end
+    end
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    aa_objs = []
+    Cisco::RouterBgpAFAggrAddr.aas.each do |asn, vrfs|
+      vrfs.each do |vrf, afs|
+        afs.each do |af, aas|
+          aas.each do |aa, nu_obj|
+            aa_objs << properties_get(asn, vrf, af, aa, nu_obj)
+          end
+        end
+      end
+    end
+    aa_objs
+  end # self.instances
+
+  def self.prefetch(resources)
+    aas = instances
+    resources.keys.each do |name|
+      provider = aas.find do |aga|
+        aga.asn.to_s == resources[name][:asn].to_s &&
+        aga.vrf == resources[name][:vrf] &&
+        aga.afi.to_s == resources[name][:afi].to_s &&
+        aga.safi.to_s == resources[name][:safi].to_s &&
+        aga.aa.to_s == resources[name][:aa].to_s
+      end
+      resources[name].provider = provider unless provider.nil?
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def properties_set(new_obj=false)
+    BGP_AF_AA_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      send("#{prop}=", @resource[prop]) if new_obj
+      unless @property_flush[prop].nil?
+        @nu.send("#{prop}=", @property_flush[prop]) if
+          @nu.respond_to?("#{prop}=")
+      end
+    end
+    # Custom set methods
+    aa_set
+  end
+
+  def aa_set
+    attrs = {}
+    vars = [
+      :advertise_map,
+      :attribute_map,
+      :suppress_map,
+      :as_set,
+      :summary_only,
+    ]
+    return unless vars.any? { |p| @property_flush.key?(p) }
+    # At least one var has changed, get all vals from manifest
+    vars.each do |p|
+      if @resource[p] == :default
+        attrs[p] = @nu.send("default_#{p}")
+      else
+        attrs[p] = @resource[p]
+        attrs[p] = PuppetX::Cisco::Utils.bool_sym_to_s(attrs[p])
+      end
+    end
+    @nu.aa_set(attrs)
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @nu.destroy
+      @nu = nil
+    else
+      # Create/Update
+      new_obj = false
+      if @nu.nil?
+        new_obj = true
+        @nu = Cisco::RouterBgpAFAggrAddr.new(@resource[:asn],
+                                             @resource[:vrf],
+                                             [@resource[:afi],
+                                              @resource[:safi]],
+                                             @resource[:aa])
+      end
+      properties_set(new_obj)
+    end
+  end
+end

--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -127,7 +127,7 @@ Example:
   end # property summary_only
 
   newproperty(:advertise_map) do
-    desc "Selects attribute information from specific routes. Valid values are String or 'default'"
+    desc "Route map to select attribute information from specific routes. Valid values are String or 'default'"
 
     munge do |value|
       value = :default if value == 'default'
@@ -136,7 +136,7 @@ Example:
   end # property advertise_map
 
   newproperty(:attribute_map) do
-    desc "Sets attribute information of aggregate. Valid values are String or 'default'"
+    desc "Route map to set attribute information of aggregate. Valid values are String or 'default'"
 
     munge do |value|
       value = :default if value == 'default'
@@ -145,7 +145,7 @@ Example:
   end # property attribute_map
 
   newproperty(:suppress_map) do
-    desc "Conditionally filters more specific routes. Valid values are String or 'default'"
+    desc "Route map to conditionally filter more specific routes. Valid values are String or 'default'"
 
     munge do |value|
       value = :default if value == 'default'

--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -96,12 +96,12 @@ Example:
   end
 
   newparam(:afi, namevar: true) do
-    desc 'BGP Address-family AFI (ipv4|ipv6|vpnv4|vpnv6|l2vpn). Valid values are string.'
+    desc 'BGP Address-family AFI (ipv4|ipv6). Valid values are string.'
     newvalues(:ipv4, :ipv6)
   end
 
   newparam(:safi, namevar: true) do
-    desc 'BGP Address-family SAFI (unicast|multicast|evpn). Valid values are string.'
+    desc 'BGP Address-family SAFI (unicast|multicast). Valid values are string.'
     newvalues(:unicast, :multicast)
   end
 

--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -1,0 +1,155 @@
+# Manages the Cisco Bgp_af_aa configuration resource.
+#
+# May 2017
+#
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Puppet::Type.newtype(:cisco_bgp_af_aa) do
+  @doc = "Manages a cisco BGP Address family aggregate address
+
+    cisco_bgp_af_aa { '<title>':
+      ..attributes..
+    }
+
+    `<title>` is the title of the bgp_af_aa resource
+
+Example:
+
+    cisco_bgp_af_aa{ '55.77 default ipv4 multicast 1.1.1.1/32':
+      ensure  => 'present',
+      as_set   => 'true',
+      summary_only   => 'false',
+      advertise_map   => 'adm',
+      attribute_map   => 'atm',
+      suppress_map   => 'sum',
+    }
+  "
+
+  ###################
+  # Resource Naming #
+  ###################
+
+  # Parse out the title to fill in the attributes in these
+  # patterns. These attributes can be overwritten later.
+  def self.title_patterns
+    identity = ->(x) { x }
+    [
+      [
+        /^(\d+|\d+\.\d+) (\S+) (\S+) (\S+) (\S+)$/,
+        [
+          [:asn, identity],
+          [:vrf, identity],
+          [:afi, identity],
+          [:safi, identity],
+          [:aa, identity],
+        ],
+      ]
+    ]
+  end
+
+  ##############
+  # Parameters #
+  ##############
+
+  ensurable
+
+  # Overwrites the name method which by default returns only
+  # self[:name].
+  def name
+    "#{self[:asn]} #{self[:vrf]} #{self[:afi]} #{self[:safi]} #{self[:aa]}"
+  end
+
+  # Only needed to satisfy name parameter.
+  newparam(:name) do
+  end
+
+  newparam(:asn, namevar: true) do
+    desc "BGP autonomous system number.  Valid values are String, Integer in
+          ASPLAIN or ASDOT notation"
+    validate do |value|
+      unless /^(\d+|\d+\.\d+)$/.match(value.to_s)
+        fail("BGP asn #{value} must be specified in ASPLAIN or ASDOT notation")
+      end
+    end
+
+    munge(&:to_s)
+  end
+
+  newparam(:vrf, namevar: true) do
+    desc 'BGP vrf name. Valid values are string. ' \
+      "The name 'default' is a valid VRF."
+
+    defaultto('default')
+    newvalues(/^\S+$/)
+  end
+
+  newparam(:afi, namevar: true) do
+    desc 'BGP Address-family AFI (ipv4|ipv6|vpnv4|vpnv6|l2vpn). Valid values are string.'
+    newvalues(:ipv4, :ipv6)
+  end
+
+  newparam(:safi, namevar: true) do
+    desc 'BGP Address-family SAFI (unicast|multicast|evpn). Valid values are string.'
+    newvalues(:unicast, :multicast)
+  end
+
+  newparam(:aa, namevar: true) do
+    desc 'BGP aggregate address prefix. Valid values are String.'
+    munge(&:to_s)
+  end
+
+  ##############
+  # Attributes #
+  ##############
+
+  newproperty(:as_set) do
+    desc "Generates AS-SET information. Valid values are true, false or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property as_set
+
+  newproperty(:summary_only) do
+    desc "Stops advertising more specifics.  Valid values are true, false or 'default'"
+
+    newvalues(:true, :false, :default)
+  end # property summary_only
+
+  newproperty(:advertise_map) do
+    desc "Selects attribute information from specific routes. Valid values are String or 'default'"
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property advertise_map
+
+  newproperty(:attribute_map) do
+    desc "Sets attribute information of aggregate. Valid values are String or 'default'"
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property attribute_map
+
+  newproperty(:suppress_map) do
+    desc "Conditionally filters more specific routes. Valid values are String or 'default'"
+
+    munge do |value|
+      value = :default if value == 'default'
+      value
+    end
+  end # property suppress_map
+end

--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -107,7 +107,14 @@ Example:
 
   newparam(:aa, namevar: true) do
     desc 'BGP aggregate address prefix. Valid values are String.'
-    munge(&:to_s)
+    munge do |value|
+      begin
+        value = PuppetX::Cisco::Utils.process_network_mask(value) unless value.nil?
+        value
+      rescue
+        raise 'aggregate address must be in valid address/length format'
+      end
+    end
   end
 
   ##############
@@ -115,41 +122,32 @@ Example:
   ##############
 
   newproperty(:as_set) do
-    desc "Generates AS-SET information. Valid values are true, false or 'default'"
+    desc "Generates autonomous system set path information. Valid values are true, false or 'default'"
 
     newvalues(:true, :false, :default)
   end # property as_set
 
   newproperty(:summary_only) do
-    desc "Stops advertising more specifics.  Valid values are true, false or 'default'"
+    desc "Filters all more-specific routes from updates.  Valid values are true, false or 'default'"
 
     newvalues(:true, :false, :default)
   end # property summary_only
 
   newproperty(:advertise_map) do
-    desc "Route map to select attribute information from specific routes. Valid values are String or 'default'"
+    desc "Name of the route map used to select the routes to create AS_SET origin communities. Valid values are String or 'default'"
 
-    munge do |value|
-      value = :default if value == 'default'
-      value
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property advertise_map
 
   newproperty(:attribute_map) do
-    desc "Route map to set attribute information of aggregate. Valid values are String or 'default'"
+    desc "Name of the route map used to set the attribute of the aggregate route. Valid values are String or 'default'"
 
-    munge do |value|
-      value = :default if value == 'default'
-      value
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property attribute_map
 
   newproperty(:suppress_map) do
-    desc "Route map to conditionally filter more specific routes. Valid values are String or 'default'"
+    desc "Name of the route map used to select the routes to be suppressed. Valid values are String or 'default'"
 
-    munge do |value|
-      value = :default if value == 'default'
-      value
-    end
+    munge { |value| value == 'default' ? :default : value }
   end # property suppress_map
 end

--- a/tests/beaker_tests/cisco_bgp_af_aa/test_bgp_af_aa.rb
+++ b/tests/beaker_tests/cisco_bgp_af_aa/test_bgp_af_aa.rb
@@ -1,0 +1,114 @@
+###############################################################################
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
+#
+###############################################################################
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Test hash top-level keys
+tests = {
+  master:           master,
+  agent:            agent,
+  operating_system: 'nexus',
+  resource_name:    'cisco_bgp_af_aa',
+}
+
+skip_unless_supported(tests)
+
+# Test hash test cases
+tests[:default] = {
+  desc:           '1.1 Default Properties',
+  title_pattern:  '2 default ipv4 unicast 1.1.1.1/32',
+  manifest_props: {
+    as_set:        'default',
+    summary_only:  'default',
+    advertise_map: 'default',
+    attribute_map: 'default',
+    suppress_map:  'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    as_set:       'false',
+    summary_only: 'false',
+  },
+}
+
+tests[:non_default1] = {
+  desc:           '2.1 Non Defaults',
+  title_pattern:  '2 red ipv6 multicast 2000::1/128',
+  manifest_props: {
+    as_set:        'true',
+    advertise_map: 'adm',
+    attribute_map: 'atm',
+    suppress_map:  'sum',
+  },
+}
+
+tests[:non_default2] = {
+  desc:           '2.2 Non Defaults',
+  title_pattern:  '2 red ipv6 multicast 2000::1/128',
+  manifest_props: {
+    summary_only: 'true'
+  },
+}
+
+def dependency_manifest(_tests, _id)
+  "
+    cisco_bgp { '2 default':
+      ensure => present,
+    }
+
+    cisco_bgp_af { '2 default ipv4 unicast':
+      ensure => present,
+    }
+
+    cisco_bgp_af { '2 red ipv6 multicast':
+      ensure => present,
+    }
+  "
+end
+
+def cleanup(agent)
+  test_set(agent, 'no feature bgp')
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{tests[:resource_name]}" do
+  teardown { cleanup(agent) }
+  cleanup(agent)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+  test_harness_run(tests, :default)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
+
+  test_harness_run(tests, :non_default1)
+  test_harness_run(tests, :non_default2)
+
+  # -------------------------------------------------------------------
+  skipped_tests_summary(tests)
+end
+
+logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
This PR is for adding a new provider bgp address family aggregate address. All tests pass on all platforms.

This is for addressing the enhancement request https://github.com/cisco/cisco-network-puppet-module/issues/452
