### PR TITLE
bgp_af_aa

### DIFF
--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -16,6 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'ipaddr'
+begin
+  require 'puppet_x/cisco/cmnutils'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                     'puppet_x', 'cisco', 'cmnutils.rb'))
+end
+
 Puppet::Type.newtype(:cisco_bgp_af_aa) do
   @doc = "Manages a cisco BGP Address family aggregate address
 


### PR DESCRIPTION
For some reason, the type file did not get pushed properly. The "require" code was missing which can cause issues with the previous merge https://github.com/cisco/cisco-network-puppet-module/pull/454

Please check and merge this.