### PR TITLE
Puppet5 test fix

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -73,6 +73,9 @@ def hash_to_patterns(hash)
     # Becomes:
     #   \[\['192.168.5.0\/24', 'nrtemap1'\], \['192.168.6.0\/32'\]\]
     if /^\[.*\]$/.match(value)
+      # Handle Puppet 5 line wrap issue
+      value.gsub!(/^[\[]/) {|s| '[\n? *' }.gsub!(', [') {|s| ',\n? +?[' }
+      # END Handle Puppet 5 line wrap issue
       value.gsub!(/[\[\]]/) { |s| '\\' + "#{s}" }.gsub!(/\"/) { |_s| '\'' }
     end
     value.gsub!(/[\(\)]/) { |s| '\\' + "#{s}" } if /\(.*\)/.match(value)


### PR DESCRIPTION
This PR address the line wrap change that is seen in Puppet5. Changes made will be tested to retain compatibility with the existing Puppet version

Test Results :

Puppet 5 - 102P / 2 F / 11 S / 2 E
Puppet (current version) - 102/ 3F / 11S / 1E

2 of the failure are similar and needs to be investigated separately. The vrf testcases that errored out need to be investigated separately and they are not related to this diff.