### PR TITLE
Fix for CISCO-50, CISCO-51, CISCO-52

### DIFF
--- a/lib/puppet/provider/cisco_snmp_user/cisco.rb
+++ b/lib/puppet/provider/cisco_snmp_user/cisco.rb
@@ -214,7 +214,7 @@ Puppet::Type.type(:cisco_snmp_user).provide(:cisco) do
   end
 
   def unconfigure_snmp_user
-    @snmp_user.destroy
+    @snmp_user.destroy unless @resource[:user] == 'admin'
     @snmp_user = nil
     @property_hash[:ensure] = :absent
   end

--- a/lib/puppet/provider/cisco_snmp_user/cisco.rb
+++ b/lib/puppet/provider/cisco_snmp_user/cisco.rb
@@ -224,6 +224,9 @@ Puppet::Type.type(:cisco_snmp_user).provide(:cisco) do
 
   def flush
     if @property_flush[:ensure] == :absent
+      fail ArgumentError,
+           'The admin account cannot be deactivated on this platform. ' \
+            if @resource[:user] == 'admin'
       unconfigure_snmp_user
     elsif @property_flush[:ensure] == :present
       configure_snmp_user

--- a/lib/puppet/provider/cisco_snmp_user/cisco.rb
+++ b/lib/puppet/provider/cisco_snmp_user/cisco.rb
@@ -214,6 +214,9 @@ Puppet::Type.type(:cisco_snmp_user).provide(:cisco) do
   end
 
   def unconfigure_snmp_user
+    # admin user is always present on the device and it
+    # cannot be removed by using 'no' cmd or else
+    # errors will be thrown
     @snmp_user.destroy unless @resource[:user] == 'admin'
     @snmp_user = nil
     @property_hash[:ensure] = :absent

--- a/lib/puppet/provider/snmp_user/cisco.rb
+++ b/lib/puppet/provider/snmp_user/cisco.rb
@@ -116,7 +116,13 @@ Puppet::Type.type(:snmp_user).provide(:cisco) do
 
   def flush
     validate
-    @snmpuser.destroy if @snmpuser
+    if @resource[:name] == 'admin'
+      fail ArgumentError,
+           'The admin account cannot be deactivated on this platform. ' \
+          if @property_flush[:ensure] == :absent
+    else
+      @snmpuser.destroy if @snmpuser
+    end
     @snmpuser = nil
 
     return if @property_flush[:ensure] == :absent

--- a/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_cfg_svc) do
     end
 
     munge do |val|
-      val == 'default' ? :default : val.split
+      val == 'default' ? :default : val
     end
 
     def in_sync?(is)

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
     end
 
     munge do |val|
-      val == 'default' ? :default : val.split
+      val == 'default' ? :default : val
     end
 
     def in_sync?(is)

--- a/lib/puppet/type/cisco_ace.rb
+++ b/lib/puppet/type/cisco_ace.rb
@@ -291,4 +291,12 @@ Puppet::Type.newtype(:cisco_ace) do
     desc 'Log matches against this entry'
     newvalues(:true, :false)
   end
+
+  validate do
+    unless self[:remark].nil?
+      fail ArgumentError,
+           'established and log parameters must be nil when remark is not nil' unless
+        self[:log].nil? && self[:established].nil?
+    end
+  end
 end

--- a/lib/puppet/type/cisco_ace.rb
+++ b/lib/puppet/type/cisco_ace.rb
@@ -295,7 +295,7 @@ Puppet::Type.newtype(:cisco_ace) do
   validate do
     unless self[:remark].nil?
       fail ArgumentError,
-           'established and log parameters must be nil when remark is not nil' unless
+           "'established' and 'log' properties should not be set for remark ace" unless
         self[:log].nil? && self[:established].nil?
     end
   end


### PR DESCRIPTION
This PR is for fixing 3 customer reported issues:
1. snmp user throws error that user "admin" cannot be deleted
2. aaa_authorization_login_cfg_svc and aaa_authorization_login_exec_svc are not idempotent for groups property.
3. snmp_user 'admin' edge case