### PR TITLE
Puppet5 fixes

### DIFF
--- a/tests/beaker_tests/cisco_command_config/test_command_config.rb
+++ b/tests/beaker_tests/cisco_command_config/test_command_config.rb
@@ -192,6 +192,19 @@ def test_set_get
 
   logger.info('* check config')
   on(agent, cmd_prefix + "test_get='incl loopback1'")
+  # The output of test_get has changed in Puppet5 and newer versions of Puppet.
+  # Old output:
+  # cisco_command_config { 'cc':
+  #   test_get => '
+  # interface loopback1
+  # interface loopback10
+  # ',
+  # }
+  # New output:
+  # cisco_command_config { 'cc':
+  #   test_get => "\ninterface loopback1\ninterface loopback10\n",
+  # }
+  # Modifying the below regular expression to make ^ and \n optional.
   fail_test("TestStep :: set/get :: FAIL\nstdout:\n#{stdout}") unless
     stdout[/^?\n?interface loopback1/]
 

--- a/tests/beaker_tests/cisco_command_config/test_command_config.rb
+++ b/tests/beaker_tests/cisco_command_config/test_command_config.rb
@@ -193,7 +193,7 @@ def test_set_get
   logger.info('* check config')
   on(agent, cmd_prefix + "test_get='incl loopback1'")
   fail_test("TestStep :: set/get :: FAIL\nstdout:\n#{stdout}") unless
-    stdout[/^interface loopback1/]
+    stdout[/^?\n?interface loopback1/]
 
   logger.info("#{stepinfo} :: PASS\n#{'-' * 60}\n")
 end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1463,6 +1463,18 @@ def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
 end
 
 def remove_all_vrfs(agent)
+  # The output of test_get has changed in Puppet5 and newer versions of Puppet.
+  # Old output:
+  # cisco_command_config { 'cc':
+  #   test_get => '
+  # vrf context blue
+  # ',
+  # }
+  # New output:
+  # cisco_command_config { 'cc':
+  #   test_get => "\nvrf context blue\n",
+  # }
+  # Modifying the below regular expression to make ^ and \n optional.
   found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
   found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, found.compact.join(' ; '))

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1463,8 +1463,8 @@ def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
 end
 
 def remove_all_vrfs(agent)
-  found = test_get(agent, "incl 'vrf context' | excl management").split("\n")
-  found.map! { |cmd| "no #{cmd}" if cmd[/^vrf context/] }
+  found = test_get(agent, "incl 'vrf context' | excl management").split("\\n")
+  found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, found.compact.join(' ; '))
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1463,7 +1463,7 @@ def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
 end
 
 def remove_all_vrfs(agent)
-  found = test_get(agent, "incl 'vrf context' | excl management").split("\\n")
+  found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
   found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, found.compact.join(' ; '))
 end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -73,6 +73,9 @@ def hash_to_patterns(hash)
     # Becomes:
     #   \[\['192.168.5.0\/24', 'nrtemap1'\], \['192.168.6.0\/32'\]\]
     if /^\[.*\]$/.match(value)
+      # Handle Puppet 5 line wrap issue
+      value.gsub!(/^[\[]/) {|s| '[\n? *' }.gsub!(', [') {|s| ',\n? +?[' }
+      # END Handle Puppet 5 line wrap issue
       value.gsub!(/[\[\]]/) { |s| '\\' + "#{s}" }.gsub!(/\"/) { |_s| '\'' }
     end
     value.gsub!(/[\(\)]/) { |s| '\\' + "#{s}" } if /\(.*\)/.match(value)


### PR DESCRIPTION
Made fixes to issues seen in puppet5. Errors seen in the tests were because `remove_all_vrfs` was silently failing to do it's job. Should now be fixed. 

All failed/errored tests were retested with puppet5 and latest puppet and are passing. 