### PR TITLE
Fixes to support fretta F3 images.

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1475,7 +1475,7 @@ def remove_all_vrfs(agent)
   #   test_get => "\nvrf context blue\n",
   # }
   # Modifying the below regular expression to make ^ and \n optional.
-  found = test_get(agent, "incl 'vrf context' | excl management").split("\n")
+  found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
   found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, found.compact.join(' ; '))
 end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1475,7 +1475,7 @@ def remove_all_vrfs(agent)
   #   test_get => "\nvrf context blue\n",
   # }
   # Modifying the below regular expression to make ^ and \n optional.
-  found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
+  found = test_get(agent, "incl 'vrf context' | excl management").split("\n")
   found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, found.compact.join(' ; '))
 end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1142,8 +1142,8 @@ end
 
 @image = nil # Cache the lookup result
 def nexus_image
-  facter_opt = '-p cisco.images.system_image'
-  image_regexp = /.*\.(\S+\.\S+)\.bin/
+  facter_opt = '-p cisco.images.full_version'
+  image_regexp = /(\S+)/
   data = on(agent, facter_cmd(facter_opt)).output
   @image ||= image_regexp.match(data)[1]
 end


### PR DESCRIPTION
**This PR addresses two issues:**
  * Refactor the `nexus_image` method to use the `full_version` key.  Previously the method used the file name which is error prone.  System image files can be named anything the user desires.
  * Fixes a bug in the beaker line-wrap fix in the `remove_all_vrfs` method.

Beaker line-wrap fix details.

Failure before this fix:
```
 137928:   Beaker::Host::CommandFailure: Host 'n9k-157.cisco.com' exited with 127 running:
 137929:    source /etc/profile; sudo sh -c " ip netns exec management /opt/puppetlabs/bin/puppet resource cisco_command_config 'cc' test_set='no cisco_command_config { 'cc':
 137930:     test_get => '
 137931:   vrf context blue
```

Fix tested using both puppet and puppet5 rpms.

**UPDATE:** Reverted change to `remove_all_vrfs`.  After a bit more testing it seems that the `\\n` is needed still.