### PR TITLE
(NETDEV-30) Enhance syslog, tacacs, radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `ensure => absent` for physical interfaces will put the interface into a default state.
   - `ensure => absent` for logical interfaces will cause them to be destroyed.
 
+- Extend `syslog_server` with attribute:
+ - `port`
+
+- Extend `syslog_settings` with attributes:
+ - `console`
+ - `monitor`
+ - `source_interface`
+ - `vrf`
+
+- Extend `radius_global` with attribute:
+ - `source_interface`
+
+- Extend `tacacs_global` with attribute:
+ - `source_interface`
+
 ### Removed
 
 ### Resolved Issues

--- a/lib/puppet/provider/syslog_settings/cisco.rb
+++ b/lib/puppet/provider/syslog_settings/cisco.rb
@@ -1,6 +1,6 @@
-# November, 2014
+# September, 2017
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,9 +31,15 @@ Puppet::Type.type(:syslog_settings).provide(:cisco) do
 
   mk_resource_methods
 
-  SYSLOG_SETTINGS_PROPS = {
-    time_stamp_units: :timestamp
-  }
+  SYSLOG_SETTINGS_NON_BOOL_PROPS = [
+    :console,
+    :monitor,
+    :source_interface,
+    :time_stamp_units,
+  ]
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@syslogsetting',
+                                            SYSLOG_SETTINGS_NON_BOOL_PROPS)
 
   def initialize(value={})
     super(value)
@@ -46,10 +52,14 @@ Puppet::Type.type(:syslog_settings).provide(:cisco) do
     debug "Checking instance, SyslogSetting #{syslogsetting_name}"
 
     current_state = {
-      name:             'default',
-      time_stamp_units: v.timestamp,
-      ensure:           :present,
+      name:   'default',
+      ensure: :present,
     }
+
+    SYSLOG_SETTINGS_NON_BOOL_PROPS.each do |prop|
+      val = v.send(prop)
+      current_state[prop] = val ? val : 'unset'
+    end
 
     new(current_state)
   end # self.properties_get
@@ -73,7 +83,7 @@ Puppet::Type.type(:syslog_settings).provide(:cisco) do
   end # self.prefetch
 
   def exists?
-    true
+    @property_hash[:ensure] == :present
   end
 
   def validate
@@ -83,26 +93,20 @@ Puppet::Type.type(:syslog_settings).provide(:cisco) do
     fail ArgumentError,
          "This provider does not support the 'enable' property. "\
          'Syslog servers are enabled implicitly when using the syslog_server resource.' if @resource[:enable]
-  end
-
-  def munge_flush(val)
-    if val.is_a?(String) && val.eql?('unset')
-      nil
-    elsif val.is_a?(Symbol)
-      val.to_s
-    else
-      val
-    end
+    fail ArgumentError,
+         "This provider does not support the 'vrf' property. " if @resource[:vrf]
   end
 
   def flush
     validate
 
-    SYSLOG_SETTINGS_PROPS.each do |puppet_prop, cisco_prop|
-      if @resource[puppet_prop]
-        @syslogsetting.send("#{cisco_prop}=", munge_flush(@resource[puppet_prop])) \
-          if @syslogsetting.respond_to?("#{cisco_prop}=")
-      end
+    SYSLOG_SETTINGS_NON_BOOL_PROPS.each do |prop|
+      next unless @resource[prop]
+      next if @property_flush[prop].nil?
+      # Call the AutoGen setters for the @syslogsetting node_utils object.
+      @property_flush[prop] = nil if @property_flush[prop] == 'unset'
+      @syslogsetting.send("#{prop}=", @property_flush[prop]) if
+        @syslogsetting.respond_to?("#{prop}=")
     end
   end
 end # Puppet::Type

--- a/lib/puppet/provider/tacacs_global/cisco.rb
+++ b/lib/puppet/provider/tacacs_global/cisco.rb
@@ -37,12 +37,21 @@ Puppet::Type.type(:tacacs_global).provide(:cisco) do
   ]
 
   TACACS_GLOBAL_SET_PROPS = [
-    :timeout,
-    :source_interface,
+    :timeout
+  ]
+
+  TACACS_GLOBAL_ARRAY_PROPS = [
+    :source_interface
   ]
 
   TACACS_GLOBAL_NON_BOOL_PROPS = TACACS_GLOBAL_GET_PROPS +
                                  TACACS_GLOBAL_SET_PROPS
+
+  TACACS_GLOBAL_CONFIG_PROPS = TACACS_GLOBAL_SET_PROPS +
+                               TACACS_GLOBAL_ARRAY_PROPS
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:array_flat, self, '@tacacs_global',
+                                            TACACS_GLOBAL_ARRAY_PROPS)
 
   PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@tacacs_global',
                                             TACACS_GLOBAL_NON_BOOL_PROPS)
@@ -64,7 +73,7 @@ Puppet::Type.type(:tacacs_global).provide(:cisco) do
       key:              v.key.nil? || v.key.empty? ? 'unset' : v.key,
       # Only return the key format if there is a key configured
       key_format:       v.key.nil? || v.key.empty? ? nil : v.key_format,
-      source_interface: v.source_interface.nil? || v.source_interface.empty? ? 'unset' : v.source_interface,
+      source_interface: v.source_interface.nil? || v.source_interface.empty? ? ['unset'] : [v.source_interface],
     }
 
     new(current_state)
@@ -132,9 +141,11 @@ Puppet::Type.type(:tacacs_global).provide(:cisco) do
   def flush
     validate
 
-    TACACS_GLOBAL_SET_PROPS.each do |prop|
+    TACACS_GLOBAL_CONFIG_PROPS.each do |prop|
       next unless @resource[prop]
       next if @property_flush[prop].nil?
+      # Other platforms require array for some types - Nexus does not
+      @property_flush[prop] = @property_flush[prop][0] if @property_flush[prop].is_a?(Array)
       # Call the AutoGen setters for the @tacacs_global node_utils object.
       @property_flush[prop] = nil if @property_flush[prop] == 'unset'
       @tacacs_global.send("#{prop}=", @property_flush[prop]) if

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/cisco/cisco-network-puppet-module",
   "issues_url": "https://github.com/cisco/cisco-network-puppet-module/issues",
   "dependencies": [
-    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.12.0" }
+    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.13.0" }
   ],
   "requirements": [
     {

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1253,6 +1253,11 @@ def find_interface(tests, id=nil, skipcheck=true)
     # Skip the first interface we find in case it's our access interface.
     # TODO: check the interface IP address like we do in node_utils
     intf = all.grep(%r{ethernet\d+/\d+$})[1]
+
+  when /mgmt/i
+    all = get_current_resource_instances(tests[:agent], 'network_interface')
+    # TODO: check the interface IP address like we do in node_utils
+    intf = all.grep(/mgmt\d+$/)[0]
   end
 
   if skipcheck && intf.nil?

--- a/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
+++ b/tests/beaker_tests/radius_global/radius_global_provider_defaults.rb
@@ -87,7 +87,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'retransmit_count' => '1' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'unset' },
+    search_pattern_in_output(output, { 'source_interface' => "['unset']" },
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '5' },
                              false, self, logger)

--- a/tests/beaker_tests/radius_global/radius_global_provider_nondefaults.rb
+++ b/tests/beaker_tests/radius_global/radius_global_provider_nondefaults.rb
@@ -106,7 +106,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'retransmit_count' => '4' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'loopback0' },
+    search_pattern_in_output(output, { 'source_interface' => "['loopback0']" },
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '2' },
                              false, self, logger)
@@ -139,7 +139,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'retransmit_count' => '2' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'loopback1' },
+    search_pattern_in_output(output, { 'source_interface' => "['loopback1']" },
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '2' },
                              false, self, logger)
@@ -170,7 +170,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'retransmit_count' => '1' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'unset' },
+    search_pattern_in_output(output, { 'source_interface' => "['unset']" },
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '5' },
                              false, self, logger)

--- a/tests/beaker_tests/radius_global/radius_global_provider_nondefaults.rb
+++ b/tests/beaker_tests/radius_global/radius_global_provider_nondefaults.rb
@@ -15,7 +15,7 @@
 ###############################################################################
 # TestCase Name:
 # -------------
-# RadiusGlobal-Provider-Defaults.rb
+# RadiusGlobal-Provider-NonDefaults.rb
 #
 # TestCase Prerequisites:
 # -----------------------
@@ -29,7 +29,7 @@
 #
 # TestCase:
 # ---------
-# This is a radius_global resource test that tests default attributes of
+# This is a radius_global resource test that tests non-default attributes of
 # tacacs_global resource.
 #
 # There are 2 sections to the testcase: Setup, group of teststeps.
@@ -71,10 +71,93 @@ def cleanup
   command_config(agent, "no radius-server key #{key[1]} #{key[2]}", "removing key #{key[2]}") if key
 end
 
-# @test_name [TestCase] Executes defaults testcase for radius_global Resource.
+# @test_name [TestCase] Executes non-defaults testcase for radius_global Resource.
 test_name "TestCase :: #{testheader}" do
   cleanup
   teardown { cleanup }
+
+  # @step [Step] Sets up switch for provider test.
+  step 'TestStep :: Setup switch for provider' do
+    logger.info('Setup switch for provider')
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, RadiusGlobalLib.create_radius_global_manifest)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [0, 2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks radius_global resource on agent using resource cmd.
+  step 'TestStep :: Check radius_global resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = PUPPET_BINPATH + 'resource radius_global default'
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '4' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'source_interface' => 'loopback0' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
+
+    logger.info("Check radius_global resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present (with changes)manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, RadiusGlobalLib.create_radius_global_manifest_change)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks radius_global resource on agent using resource cmd.
+  step 'TestStep :: Check radius_global resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = PUPPET_BINPATH + 'resource radius_global default'
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('55555555') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'retransmit_count' => '2' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'source_interface' => 'loopback1' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '2' },
+                             false, self, logger)
+
+    logger.info("Check radius_global resource presence on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present (with changes)manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, RadiusGlobalLib.create_radius_global_default)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
 
   # @step [Step] Checks radius_global resource on agent using resource cmd.
   step 'TestStep :: Check radius_global resource presence on agent' do

--- a/tests/beaker_tests/radius_global/radius_globallib.rb
+++ b/tests/beaker_tests/radius_global/radius_globallib.rb
@@ -40,6 +40,23 @@ module RadiusGlobalLib
 
   # A. Methods to create manifests for radius_global Puppet provider test cases.
 
+  # Method to create a default manifest for radius_global
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_radius_global_default
+    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  radius_global { 'default':
+    key                 => 'unset',
+    retransmit_count    => '1',
+    source_interface    => 'unset',
+    timeout             => '5',
+  }
+}
+EOF"
+    manifest_str
+  end
+
   # Method to create a manifest for radius_global
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
@@ -50,6 +67,7 @@ node default {
     key                 => '44444444',
     key_format          => '7',
     retransmit_count    => '4',
+    source_interface    => 'loopback0',
     timeout             => '2',
   }
 }
@@ -65,25 +83,11 @@ EOF"
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   radius_global { 'default':
-    key                 => '44444444',
+    key                 => '55555555',
     key_format          => '7',
-    retransmit_count    => '3',
-    timeout             => '1',
-  }
-}
-EOF"
-    manifest_str
-  end
-
-  # Method to create a manifest for radius_global resource
-  # with a few properties removed made from above.
-  # @param none [None] No input parameters exist.
-  # @result none [None] Returns no object.
-  def self.create_radius_global_manifest_change_removed
-    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-node default {
-  radius_global { 'default':
-    key                 => 'unset',
+    retransmit_count    => '2',
+    source_interface    => 'loopback1',
+    timeout             => '2',
   }
 }
 EOF"

--- a/tests/beaker_tests/syslog_server/syslog_server_provider_defaults.rb
+++ b/tests/beaker_tests/syslog_server/syslog_server_provider_defaults.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,6 +90,8 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
       search_pattern_in_output(stdout, { 'severity_level' => '2' },
                                false, self, logger)
+      search_pattern_in_output(stdout, { 'port' => '5555' },
+                               false, self, logger)
       search_pattern_in_output(stdout, { 'vrf' => 'default' },
                                false, self, logger)
     end
@@ -143,6 +145,8 @@ test_name "TestCase :: #{testheader}" do
       search_pattern_in_output(stdout, { 'ensure' => 'present' },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'severity_level' => '2' },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'port' => '5555' },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'vrf' => 'default' },
                                false, self, logger)

--- a/tests/beaker_tests/syslog_server/syslog_serverlib.rb
+++ b/tests/beaker_tests/syslog_server/syslog_serverlib.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ node default {
   syslog_server {'1.2.3.4':
     ensure         => present,
     severity_level => 2,
+    port           => 5555,
     vrf            => 'default',
   }
 }
@@ -84,6 +85,7 @@ node default {
   syslog_server {'2003::3':
     ensure         => present,
     severity_level => 2,
+    port           => 5555,
     vrf            => 'default',
   }
 }

--- a/tests/beaker_tests/syslog_settings/syslog_settings_provider_nondefaults.rb
+++ b/tests/beaker_tests/syslog_settings/syslog_settings_provider_nondefaults.rb
@@ -103,7 +103,7 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
       search_pattern_in_output(stdout, { 'monitor' => '1' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'source_interface' => "'#{intf}'" },
+      search_pattern_in_output(stdout, { 'source_interface' => "['#{intf}']" },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'time_stamp_units' => 'milliseconds' },
                                false, self, logger)
@@ -134,7 +134,7 @@ test_name "TestCase :: #{testheader}" do
                                false, self, logger)
       search_pattern_in_output(stdout, { 'monitor' => 'unset' },
                                false, self, logger)
-      search_pattern_in_output(stdout, { 'source_interface' => 'unset' },
+      search_pattern_in_output(stdout, { 'source_interface' => "['unset']" },
                                false, self, logger)
       search_pattern_in_output(stdout, { 'time_stamp_units' => 'seconds' },
                                false, self, logger)

--- a/tests/beaker_tests/syslog_settings/syslog_settings_provider_nondefaults.rb
+++ b/tests/beaker_tests/syslog_settings/syslog_settings_provider_nondefaults.rb
@@ -15,7 +15,7 @@
 ###############################################################################
 # TestCase Name:
 # -------------
-# SyslogSetting-Provider-Defaults.rb
+# SyslogSetting-Provider-NonDefaults.rb
 #
 # TestCase Prerequisites:
 # -----------------------
@@ -29,8 +29,8 @@
 #
 # TestCase:
 # ---------
-# This is a syslog_settings resource test that tests for default values for the
-# syslog_settings resource.
+# This is a syslog_settings resource test that tests for nondefault values for
+# the syslog_settings resource.
 #
 # There are 2 sections to the testcase: Setup, group of teststeps.
 # The 1st step is the Setup teststep that cleans up the switch state.
@@ -56,11 +56,20 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 require File.expand_path('../syslog_settingslib.rb', __FILE__)
 
 result = 'PASS'
-testheader = 'syslog_settings Resource :: All Attributes Defaults'
+testheader = 'syslog_settings Resource :: All Attributes Non-Defaults'
+
+tests = {
+  agent:         agent,
+  master:        master,
+  intf_type:     'mgmt',
+  resource_name: 'syslog_settings',
+}
 
 # @test_name [TestCase] Executes defaults testcase for syslog_settings Resource.
 test_name "TestCase :: #{testheader}" do
   raise_skip_exception('Not supported on IOS XR', self) if operating_system == 'ios_xr'
+  # Find an available test interface on this device
+  intf = find_interface(tests)
 
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider' do
@@ -72,17 +81,66 @@ test_name "TestCase :: #{testheader}" do
     logger.info('Setup switch for provider')
   end
 
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource non-default manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, SyslogSettingLib.create_syslog_settings_manifest_nondefault(intf))
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource non-default manifest from master :: #{result}")
+  end
+
   # @step [Step] Checks syslog_settings resource on agent using resource cmd.
-  step 'TestStep :: Check syslog_settings resource presence on agent' do
+  step 'TestStep :: Check syslog_settings non-default on agent' do
     # Expected exit_code is 0 since this is a puppet resource cmd.
     # Flag is set to false to check for presence of RegExp pattern in stdout.
     cmd_str = PUPPET_BINPATH + 'resource syslog_settings default'
     on(agent, cmd_str) do
+      search_pattern_in_output(stdout, { 'console' => '1' },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'monitor' => '1' },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'source_interface' => "'#{intf}'" },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'time_stamp_units' => 'milliseconds' },
+                               false, self, logger)
+    end
+
+    logger.info("Check syslog_settings non-default on agent :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource unset manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, SyslogSettingLib.create_syslog_settings_manifest_unset)
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource non-default manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks syslog_settings resource on agent using resource cmd.
+  step 'TestStep :: Check syslog_settings unset on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = PUPPET_BINPATH + 'resource syslog_settings default'
+    on(agent, cmd_str) do
+      search_pattern_in_output(stdout, { 'console' => 'unset' },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'monitor' => 'unset' },
+                               false, self, logger)
+      search_pattern_in_output(stdout, { 'source_interface' => 'unset' },
+                               false, self, logger)
       search_pattern_in_output(stdout, { 'time_stamp_units' => 'seconds' },
                                false, self, logger)
     end
 
-    logger.info("Check syslog_settings resource presence on agent :: #{result}")
+    logger.info("Check syslog_settings unset on agent :: #{result}")
   end
 
   # @raise [PassTest/FailTest] Raises PassTest/FailTest exception using result.

--- a/tests/beaker_tests/syslog_settings/syslog_settingslib.rb
+++ b/tests/beaker_tests/syslog_settings/syslog_settingslib.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,29 +40,50 @@ module SyslogSettingLib
 
   # A. Methods to create manifests for syslog_setting Puppet provider test cases.
 
-  # Method to create a manifest for syslog_setting resource attribute 'ensure'
-  # where 'ensure' is set to present.
+  # Method to create a manifest for syslog_setting with default attributes
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_syslog_settings_manifest_milliseconds
+  def self.create_syslog_settings_manifest_default
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
-  syslog_settings {'default':
-    time_stamp_units => 'milliseconds',
-  }
+    syslog_settings {'default':
+      console          => '2',
+      monitor          => '5',
+      source_interface => 'unset',
+      time_stamp_units => 'seconds',
+    }
 }
 EOF"
     manifest_str
   end
 
-  # Method to create a manifest for syslog_setting resource attribute 'ensure'
-  # where 'ensure' is set to absent.
-  # @param none [None] No input parameters exist.
+  # Method to create a manifest for syslog_setting with non-default attributes
+  # @param intf [String] source_interface
   # @result none [None] Returns no object.
-  def self.create_syslog_settings_manifest_seconds
+  def self.create_syslog_settings_manifest_nondefault(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
     syslog_settings {'default':
+      console          => '1',
+      monitor          => '1',
+      source_interface => '#{intf}',
+      time_stamp_units => 'milliseconds',
+    }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for syslog_setting with unset attributes
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_syslog_settings_manifest_unset
+    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+    syslog_settings {'default':
+      console          => 'unset',
+      monitor          => 'unset',
+      source_interface => 'unset',
       time_stamp_units => 'seconds',
     }
 }

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
@@ -91,7 +91,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '5' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'unset' },
+    search_pattern_in_output(output, { 'source_interface' => "['unset']" },
                              false, self, logger)
 
     logger.info("Check tacacs_global resource presence on agent :: #{result}")

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_nondefaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_nondefaults.rb
@@ -101,7 +101,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'key_format' => '7' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => "'#{intf}'" },
+    search_pattern_in_output(output, { 'source_interface' => "['#{intf}']" },
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '1' },
                              false, self, logger)
@@ -132,7 +132,7 @@ test_name "TestCase :: #{testheader}" do
                              false, self, logger)
     search_pattern_in_output(output, { 'timeout' => '5' },
                              false, self, logger)
-    search_pattern_in_output(output, { 'source_interface' => 'unset' },
+    search_pattern_in_output(output, { 'source_interface' => "['unset']" },
                              false, self, logger)
 
     logger.info("Check tacacs_global resource presence on agent :: #{result}")

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_nondefaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_nondefaults.rb
@@ -15,7 +15,7 @@
 ###############################################################################
 # TestCase Name:
 # -------------
-# TacacsGlobal-Provider-Defaults.rb
+# TacacsGlobal-Provider-NonDefaults.rb
 #
 # TestCase Prerequisites:
 # -----------------------
@@ -29,7 +29,7 @@
 #
 # TestCase:
 # ---------
-# This is a tacacs_global resource test that tests default attribute of
+# This is a tacacs_global resource test that tests non-default attribute of
 # tacacs_global resource.
 #
 # There are 2 sections to the testcase: Setup, group of teststeps.
@@ -56,7 +56,14 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 require File.expand_path('../tacacs_globallib.rb', __FILE__)
 
 result = 'PASS'
-testheader = 'tacacs_global Resource :: All Attributes Defaults'
+testheader = 'tacacs_global Resource :: All Attributes Non-Defaults'
+
+tests = {
+  agent:         agent,
+  master:        master,
+  intf_type:     'ethernet',
+  resource_name: 'tacacs_global',
+}
 
 def cleanup
   logger.info('Testcase Cleanup:')
@@ -67,6 +74,40 @@ end
 test_name "TestCase :: #{testheader}" do
   cleanup
   teardown { cleanup }
+
+  # Find an available test interface on this device
+  intf = find_interface(tests)
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get resource present (with changes) manifest from master' do
+    # Expected exit_code is 0 since this is a bash shell cmd.
+    on(master, TacacsGlobalLib.create_tacacs_global_non_default(intf))
+
+    # Expected exit_code is 2 since this is a puppet agent cmd with change.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [2])
+
+    logger.info("Get resource present manifest from master :: #{result}")
+  end
+
+  # @step [Step] Checks tacacs_global resource on agent using resource cmd.
+  step 'TestStep :: Check tacacs_global resource presence on agent' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => add_quotes('44444444') },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'key_format' => '7' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'source_interface' => "'#{intf}'" },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'timeout' => '1' },
+                             false, self, logger)
+
+    logger.info("Check tacacs_global resource presence on agent :: #{result}")
+  end
 
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do

--- a/tests/beaker_tests/tacacs_global/tacacs_globallib.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_globallib.rb
@@ -43,13 +43,13 @@ module TacacsGlobalLib
   # Method to create a manifest for tacacs_global
   # @param none [None] No input parameters exist.
   # @result none [None] Returns no object.
-  def self.create_tacacs_global_manifest
+  def self.create_tacacs_global_default
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   tacacs_global { 'default':
-    key                 => '44444444',
-    key_format          => '7',
-    timeout             => '2',
+    key               => 'unset',
+    source_interface  => 'unset',
+    timeout           => '5',
   }
 }
 EOF"
@@ -58,14 +58,15 @@ EOF"
 
   # Method to create a manifest for tacacs_global resource
   # with a few changes made from above.
-  # @param none [None] No input parameters exist.
+  # @param intf [String] source_interface
   # @result none [None] Returns no object.
-  def self.create_tacacs_global_manifest_change
+  def self.create_tacacs_global_non_default(intf)
     manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
 node default {
   tacacs_global { 'default':
     key                 => '44444444',
     key_format          => '7',
+    source_interface    => '#{intf}',
     timeout             => '1',
   }
 }


### PR DESCRIPTION
This PR enhances the existing syslog, tacacs, and radius types as specified in  puppetlabs/netdev_stdlib#25

syslog_server
- port

syslog_settings
- console
- monitor
- source_interface
- vrf

tacacs_global
- source_interface

radius_global
- source_interface