### PR TITLE
bridge_domain fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,13 +1701,13 @@ Determines whether or not the config should be present on the device. Valid valu
 ID of the Bridge Domain. Valid values are integer.
 
 ##### `bd_name`
-The bridge-domain name. Valid values are String or keyword 'default'.
+The bridge-domain name. Valid values are String or keyword 'default'. When the bd_name is set to 'default', this property is NOT idempotent.
 
 ##### `shutdown`
 Specifies the shutdown state of the bridge-domain. Valid values are true, false, 'default'.
 
 ##### `fabric_control`
-Specifies this bridge-domain as the fabric control bridge-domain. Only one bridge-domain or VLAN can be configured as fabric-control. Valid values are true, false.
+Specifies this bridge-domain as the fabric control bridge-domain. Only one bridge-domain or VLAN can be configured as fabric-control. Valid values are true, false, keyword 'default.
 
 --
 ### Type: cisco_bridge_domain_vni

--- a/lib/puppet/type/cisco_bridge_domain.rb
+++ b/lib/puppet/type/cisco_bridge_domain.rb
@@ -79,8 +79,7 @@ Puppet::Type.newtype(:cisco_bridge_domain) do
     desc "The bridge-domain name. Valid values are String or keyword 'default'."
 
     munge do |value|
-      fail 'BD Name is not a valid string' unless value.is_a?(String)
-      value = :false if value == 'default'
+      value = '' if value == 'default'
       value
     end
   end # property name

--- a/lib/puppet/type/cisco_bridge_domain.rb
+++ b/lib/puppet/type/cisco_bridge_domain.rb
@@ -88,18 +88,14 @@ Puppet::Type.newtype(:cisco_bridge_domain) do
   newproperty(:fabric_control) do
     desc %(Specifies this bridge-domain as the fabric control bridge-domain.
            Only one bridge-domain or VLAN can be configured as fabric-control.
-           Valid values are true, false.)
+           Valid values are true, false, 'default'.)
 
-    newvalues(
-      :true,
-      :false)
+    newvalues(:true, :false, :default)
   end # property fabric_control
 
   newproperty(:shutdown) do
     desc "Specifies the shutdown state of the bridge-domain. Valid values are true, false, 'default'."
 
-    newvalues(
-      :true,
-      :false)
+    newvalues(:true, :false, :default)
   end # property shutdown
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_bridge_domain.rb
+++ b/lib/puppet/type/cisco_bridge_domain.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:cisco_bridge_domain) do
 
     munge do |value|
       fail 'BD Name is not a valid string' unless value.is_a?(String)
-      value = :default if value == 'default'
+      value = :false if value == 'default'
       value
     end
   end # property name

--- a/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
+++ b/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
@@ -29,22 +29,6 @@ tests = {
   platform:      'n7k',
 }
 
-tests[:default] = {
-  desc:           '1.0 Common Defaults',
-  title_pattern:  '100',
-  manifest_props: {
-    bd_name:        'default',
-    fabric_control: 'default',
-    shutdown:       'default',
-  },
-  code:           [0, 2],
-  resource:       {
-    bd_name:        'Bridge-Domain100',
-    fabric_control: 'false',
-    shutdown:       'false',
-  },
-}
-
 # Skip -ALL- tests if a top-level platform/os key exludes this platform
 skip_unless_supported(tests)
 
@@ -76,7 +60,6 @@ test_name "TestCase :: #{testheader}" do
   remove_all_vlans(agent)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
-  test_harness_run(tests, :default)
   test_harness_run(tests, :non_default)
   test_harness_run(tests, :non_default_change_state)
 end

--- a/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
+++ b/tests/beaker_tests/cisco_bridge_domain/test_bridge_domain.rb
@@ -29,6 +29,22 @@ tests = {
   platform:      'n7k',
 }
 
+tests[:default] = {
+  desc:           '1.0 Common Defaults',
+  title_pattern:  '100',
+  manifest_props: {
+    bd_name:        'default',
+    fabric_control: 'default',
+    shutdown:       'default',
+  },
+  code:           [0, 2],
+  resource:       {
+    bd_name:        'Bridge-Domain100',
+    fabric_control: 'false',
+    shutdown:       'false',
+  },
+}
+
 # Skip -ALL- tests if a top-level platform/os key exludes this platform
 skip_unless_supported(tests)
 
@@ -60,6 +76,7 @@ test_name "TestCase :: #{testheader}" do
   remove_all_vlans(agent)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
+  test_harness_run(tests, :default)
   test_harness_run(tests, :non_default)
   test_harness_run(tests, :non_default_change_state)
 end


### PR DESCRIPTION
This PR is for fixing bridge-domain name default action and also adding 'default' keyword to fabric_control and shutdown properties. This is missing in the current code.