### PR TITLE
Refactor remove_all_vrfs for puppet legacy and puppet5

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1475,14 +1475,12 @@ def remove_all_vrfs(agent)
   #   test_get => "\nvrf context blue\n",
   # }
   # Modifying the below regular expression to make ^ and \n optional.
-  #found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
   found = test_get(agent, "incl 'vrf context' | excl management")
-  if /.*test_get => \'(.*)\'/m.match(found)
-    vrfs = /.*test_get => \'(.*)\'/m.match(found)[1].split("\n")
-    vrfs.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
-    puts "VRFS:\n#{vrfs}\nVRFS:"
-    test_set(agent, vrfs.compact.join(' ; '))
-  end
+  return unless /.*test_get => \'(.*)\'/m.match(found)
+  vrfs = /.*test_get => \'(.*)\'/m.match(found)[1].split("\n")
+  vrfs.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
+  puts "VRFS:\n#{vrfs}\nVRFS:"
+  test_set(agent, vrfs.compact.join(' ; '))
 end
 
 # Return yum patch version from host

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1474,7 +1474,7 @@ def remove_all_vrfs(agent)
   # cisco_command_config { 'cc':
   #   test_get => "\nvrf context blue\n",
   # }
-  # Modifying the below regular expression to make ^ and \n optional.
+  # The following logic handles both output styles.
   found = test_get(agent, "incl 'vrf context' | excl management")
   found.gsub!(/\\n/, ' ')
   vrfs = found.scan(/(vrf context \S+)/)

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1476,10 +1476,10 @@ def remove_all_vrfs(agent)
   # }
   # Modifying the below regular expression to make ^ and \n optional.
   found = test_get(agent, "incl 'vrf context' | excl management")
-  return unless /.*test_get => \'(.*)\'/m.match(found)
-  vrfs = /.*test_get => \'(.*)\'/m.match(found)[1].split("\n")
-  vrfs.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
-  puts "VRFS:\n#{vrfs}\nVRFS:"
+  found.gsub!(/\\n/, ' ')
+  vrfs = found.scan(/(vrf context \S+)/)
+  return if vrfs.empty?
+  vrfs.flatten!.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
   test_set(agent, vrfs.compact.join(' ; '))
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1475,9 +1475,14 @@ def remove_all_vrfs(agent)
   #   test_get => "\nvrf context blue\n",
   # }
   # Modifying the below regular expression to make ^ and \n optional.
-  found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
-  found.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
-  test_set(agent, found.compact.join(' ; '))
+  #found = test_get(agent, "incl 'vrf context' | excl management").split('\\n')
+  found = test_get(agent, "incl 'vrf context' | excl management")
+  if /.*test_get => \'(.*)\'/m.match(found)
+    vrfs = /.*test_get => \'(.*)\'/m.match(found)[1].split("\n")
+    vrfs.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
+    puts "VRFS:\n#{vrfs}\nVRFS:"
+    test_set(agent, vrfs.compact.join(' ; '))
+  end
 end
 
 # Return yum patch version from host


### PR DESCRIPTION
This PR refactors the `remove_all_vrfs` method to better handle the differences in output between legacy and puppet5.

Tested on:
1. n7k: oac (puppet and puppet5)
2. n9k: native, guestshell (puppet and puppet5)
3. n9k-f: guestshell (puppet and puppet5)