### PR TITLE
ensure => absent for physical cisco_interface provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `cisco_interface` Refactored to allow physical ethernet interfaces to be managed as ensurable resources.
   - `ensure => absent` for physical interfaces will put the interface into a default state.
+  - `ensure => absent` for logical interfaces will cause them to be destroyed.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- `cisco_interface` Refactored to allow physical ethernet interfaces to be managed as ensurable resources.
+  - `ensure => absent` for physical interfaces will put the interface into a default state.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -5544,7 +5544,7 @@ Yum       | <https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified><br><http
 ## License
 
 ~~~text
-Copyright (c) 2014-2016 Cisco and/or its affiliates.
+Copyright (c) 2014-2017 Cisco and/or its affiliates.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2063,6 +2063,7 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 | `load_interval_counter_2_delay`       | Minimum puppet module version 1.6.0 |
 | `load_interval_counter_3_delay`       | Minimum puppet module version 1.6.0 |
 | `purge_config`                        | Minimum puppet module version 1.7.0 |
+| Ensure absent for ethernet ints       | Minimum puppet module version 1.8.0 |
 
 #### Parameters
 
@@ -2071,6 +2072,14 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 ###### `ensure`
 Determine whether the interface config should be present or not. Valid values
 are 'present' and 'absent'.
+
+Version `1.8.0` of the module allows physical ethernet interfaces to be managed as ensurable resources.
+
+Notes about `ensure => present` and `ensure => absent` on physical ethernet interfaces:
+* `ensure => present` by itself with no other managed interface properties will result in an action that is not idempotent.
+* Setting all interface properties to default values in the manifest will result in an action that is not idempotent.
+* `ensure => absent` will put the interface into a default state.
+* Physical interfaces will be displayed as `ensure => absent` by the `puppet resource` command when they are in a default state.
 
 ###### `interface`
 Name of the interface on the network element. Valid value is a string.

--- a/README.md
+++ b/README.md
@@ -2063,7 +2063,7 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 | `load_interval_counter_2_delay`       | Minimum puppet module version 1.6.0 |
 | `load_interval_counter_3_delay`       | Minimum puppet module version 1.6.0 |
 | `purge_config`                        | Minimum puppet module version 1.7.0 |
-| Ensure absent for ethernet ints       | Minimum puppet module version 1.8.0 |
+| Ensure absent for ethernet interfaces | Minimum puppet module version 1.8.0 |
 
 #### Parameters
 
@@ -2076,8 +2076,7 @@ are 'present' and 'absent'.
 Version `1.8.0` of the module allows physical ethernet interfaces to be managed as ensurable resources.
 
 Notes about `ensure => present` and `ensure => absent` on physical ethernet interfaces:
-* `ensure => present` by itself with no other managed interface properties will result in an action that is not idempotent.
-* Setting all interface properties to default values in the manifest will result in an action that is not idempotent.
+* `ensure => present` Will put the interface into a non-default state by setting `description` to `Managed by Puppet`.
 * `ensure => absent` will put the interface into a default state.
 * Physical interfaces will be displayed as `ensure => absent` by the `puppet resource` command when they are in a default state.
 

--- a/README.md
+++ b/README.md
@@ -2076,7 +2076,7 @@ are 'present' and 'absent'.
 Version `1.8.0` of the module allows physical ethernet interfaces to be managed as ensurable resources.
 
 Notes about `ensure => present` and `ensure => absent` on physical ethernet interfaces:
-* `ensure => present` Will put the interface into a non-default state by setting `description` to `Managed by Puppet`.
+* `ensure => present` along with non-default property values will put the interface into a non-default state.
 * `ensure => absent` will put the interface into a default state.
 * Physical interfaces will be displayed as `ensure => absent` by the `puppet resource` command when they are in a default state.
 

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -223,6 +223,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
   end # self.prefetch
 
   def exists?
+    return false if @nu.name[/ethernet/] && @nu.default?
     (@property_hash[:ensure] == :present)
   end
 
@@ -361,6 +362,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
         new_interface = true
         @nu = Cisco::Interface.new(@resource[:interface])
       end
+      new_interface = true if @nu.name[/ethernet/] && @nu.default?
       properties_set(new_interface)
     end
   end

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -1,6 +1,6 @@
 # May 2015
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -358,6 +358,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
   end
 
   def flush
+    if @resource['name'][/nve/]
+      msg = 'Use the cisco_vxlan_vtep type to manage nve interfaces'
+      fail msg
+    end
     if @property_flush[:ensure] == :absent
       @nu.destroy
       @nu = nil

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -206,8 +206,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     interfaces = []
     Cisco::Interface.interfaces.each do |interface_name, nu_obj|
       begin
-        # Not allowed to create an interface for mgmt0 or MgmtEth0/*
-        next if interface_name.match(/mgmt/i)
+        # Some interfaces cannot or should not be managed by this type.
+        # - Management Interface
+        # - NVE Interfaces (managed by cisco_vxlan_vtep type)
+        next if interface_name.match(/mgmt|nve/i)
         interfaces << properties_get(interface_name, nu_obj)
       end
     end

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -361,11 +361,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
       @nu = nil
     else
       # Create/Update
-      if @nu.nil?
+      if @nu.nil? || @nu.state_default
         new_interface = true
         @nu = Cisco::Interface.new(@resource[:interface])
       end
-      new_interface = true if @nu.state_default
       properties_set(new_interface)
     end
   end

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -54,11 +54,13 @@ tests[:default_access] = {
   sys_def_switchport: true,
   sys_def_sw_shut:    true,
   manifest_props:     {
+    description:                  'testing default access properties',
     shutdown:                     'default',
     switchport_autostate_exclude: 'default',
     switchport_mode:              'access',
   },
   resource:           {
+    description:                  'testing default access properties',
     shutdown:                     'true',
     switchport_autostate_exclude: 'false',
     switchport_mode:              'access',
@@ -85,6 +87,7 @@ tests[:default_trunk] = {
   sys_def_switchport: true,
   sys_def_sw_shut:    true,
   manifest_props:     {
+    description:                   'testing default trunk properties',
     shutdown:                      'default',
     load_interval_counter_1_delay: 'default',
     load_interval_counter_2_delay: 'default',
@@ -99,6 +102,7 @@ tests[:default_trunk] = {
 
   },
   resource:           {
+    description:                   'testing default trunk properties',
     shutdown:                      'true',
     load_interval_counter_1_delay: '30',
     load_interval_counter_2_delay: '300',
@@ -141,6 +145,9 @@ tests[:purge] = {
   manifest_props: {
     purge_config: 'true'
   },
+  resource:       {
+    ensure: 'absent'
+  },
 }
 
 def unsupported_properties(_tests, _id)
@@ -172,7 +179,8 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2.3 Purge_config Testing")
-  test_harness_run(tests, :purge)
+  skip_idempotence_check = true
+  test_harness_run(tests, :purge, skip_idempotence_check)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/FileName
 ###############################################################################
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -132,7 +132,6 @@ tests[:acl] = {
   operating_system:   'nexus',
   sys_def_switchport: false,
   manifest_props:     {
-    description:     'default',
     switchport_mode: 'disabled',
     ipv4_acl_in:     'v4_in',
     ipv4_acl_out:    'v4_out',

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/FileName
 ###############################################################################
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -44,11 +44,11 @@ dot1q = intf + '.1'
 tests[:default] = {
   desc:               '1.1 Default Properties',
   title_pattern:      intf,
-  code:               [0],
+  code:               [0, 2],
   sys_def_switchport: false,
   manifest_props:     {
+    description:                      'Verify default L3 properties',
     bfd_echo:                         'default',
-    description:                      'default',
     duplex:                           'default',
     ipv4_forwarding:                  'default',
     ipv4_pim_sparse_mode:             'default',
@@ -68,6 +68,7 @@ tests[:default] = {
     vrf:                              'default',
   },
   resource:           {
+    description:                      'Verify default L3 properties',
     duplex:                           'auto',
     ipv4_forwarding:                  'false',
     ipv4_pim_sparse_mode:             'false',
@@ -131,6 +132,7 @@ tests[:acl] = {
   operating_system:   'nexus',
   sys_def_switchport: false,
   manifest_props:     {
+    description:     'default',
     switchport_mode: 'disabled',
     ipv4_acl_in:     'v4_in',
     ipv4_acl_out:    'v4_out',

--- a/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
@@ -50,6 +50,7 @@ tests[:default] = {
   title_pattern:  intf,
   code:           [0, 2],
   manifest_props: {
+    description:     'Testing default properties',
     switchport_mode: 'disabled',
     # interface_pre_check() will define add'l properties
   },

--- a/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
@@ -49,9 +49,10 @@ intf = find_interface(tests)
 tests[:default] = {
   desc:               '1.1 Default Properties',
   title_pattern:      intf,
-  code:               [0],
+  code:               [0, 2],
   sys_def_switchport: true,
   manifest_props:     {
+    description:                         'Test default private vlan properties',
     switchport_pvlan_host:               'default',
     switchport_pvlan_host_association:   'default',
     switchport_pvlan_mapping:            'default',
@@ -64,6 +65,7 @@ tests[:default] = {
     switchport_pvlan_trunk_secondary:    'default',
   },
   resource:           {
+    description:                         'Test default private vlan properties',
     switchport_pvlan_host:               'false',
     # switchport_pvlan_host_association:  nil,
     # switchport_pvlan_mapping:           nil,

--- a/tests/beaker_tests/cisco_interface/test_interface_stp.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_stp.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/cisco_interface/test_interface_stp.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_stp.rb
@@ -46,8 +46,9 @@ intf = find_interface(tests)
 tests[:default] = {
   desc:           '1.1 Default Properties',
   title_pattern:  intf,
-  code:           [0],
+  code:           [0, 2],
   manifest_props: {
+    description:            'Test default properties',
     stp_bpdufilter:         'default',
     stp_bpduguard:          'default',
     stp_cost:               'default',
@@ -61,6 +62,7 @@ tests[:default] = {
     stp_vlan_port_priority: 'default',
   },
   resource:       {
+    'description'       => 'Test default properties',
     'stp_bpdufilter'    => 'false',
     'stp_bpduguard'     => 'false',
     'stp_cost'          => 'auto',

--- a/tests/beaker_tests/cisco_interface/test_interface_stp.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_stp.rb
@@ -49,6 +49,7 @@ tests[:default] = {
   code:           [0, 2],
   manifest_props: {
     description:            'Test default properties',
+    switchport_mode:        'access',
     stp_bpdufilter:         'default',
     stp_bpduguard:          'default',
     stp_cost:               'default',

--- a/tests/beaker_tests/cisco_interface/test_interface_svi.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_svi.rb
@@ -46,10 +46,12 @@ tests[:default_mgmt] = {
   desc:           "1.1 Default 'mgmt'",
   title_pattern:  intf,
   manifest_props: {
-    svi_management: 'default'
+    description:    'Test default properties',
+    svi_management: 'default',
   },
   resource:       {
-    svi_management: 'false'
+    description:    'Test default properties',
+    svi_management: 'false',
   },
 }
 

--- a/tests/beaker_tests/cisco_interface/test_interface_svi.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_svi.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -137,7 +137,7 @@ end
 
 # Full command string for puppet agent
 def puppet_agent_cmd
-  PUPPET_BINPATH + 'agent -t'
+  PUPPET_BINPATH + 'agent -t --trace'
 end
 
 # Auto generation of properties for manifests

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -178,7 +178,7 @@ end
 # Reserved keys
 # tests[id][:log_desc] - the final form of the log description
 #
-def test_harness_common(tests, id)
+def test_harness_common(tests, id, skip_idempotence_check)
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
   tests[id][:state] = false if tests[id][:state].nil?
   tests[id][:desc] = '' if tests[id][:desc].nil?
@@ -187,7 +187,7 @@ def test_harness_common(tests, id)
 
   test_manifest(tests, id)
   test_resource(tests, id)
-  test_idempotence(tests, id)
+  test_idempotence(tests, id) unless skip_idempotence_check
   tests[id].delete(:log_desc)
 end
 
@@ -745,7 +745,7 @@ end
 # - Creates manifests
 # - Creates puppet resource title strings
 # - Cleans resource
-def test_harness_run(tests, id)
+def test_harness_run(tests, id, skip_idempotence_check=false)
   return unless platform_supports_test(tests, id)
   logger.info("\n  * Process test_harness_run")
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
@@ -763,7 +763,7 @@ def test_harness_run(tests, id)
   # Check for additional pre-requisites
   test_harness_dependencies(tests, id)
 
-  test_harness_common(tests, id)
+  test_harness_common(tests, id, skip_idempotence_check)
   tests[id][:ensure] = nil
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -178,7 +178,7 @@ end
 # Reserved keys
 # tests[id][:log_desc] - the final form of the log description
 #
-def test_harness_common(tests, id, skip_idempotence_check)
+def test_harness_common(tests, id, skip_idempotence_check=false)
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
   tests[id][:state] = false if tests[id][:state].nil?
   tests[id][:desc] = '' if tests[id][:desc].nil?


### PR DESCRIPTION
This is the puppet side of https://github.com/cisco/cisco-network-node-utils/pull/562.  This update allows us to manage physical interfaces as `ensurable` resources.

**ensure => 'present'**
  * Non-Physical Interfaces (vlans, loopbacks, port-channels, sub-interfaces)
    * Created if absent
    * Manage properties if present.
  * Physical Interfaces (Ethernet)
    * Default state: Creates a logical object to manage the interface and sets properties as needed.  Description property is automatically set to 'Managed by Puppet'
    * Non-Default state: Manage properties.

**ensure => 'absent'**
  * Non-Physical Interfaces (vlans, loopbacks, port-channels, sub-interfaces)
    * Removed if present
    * No action if absent
  * Physical Interfaces (Ethernet)
    * Issues the `default interface <int>` command if they are in a non-default state.
    * No action if they are already in a default state.

**Puppet resource output for physical interfaces in various states:**
* Default State:
```puppet
root@n9k-109#puppet resource cisco_interface 'ethernet 1/7'
cisco_interface { 'ethernet1/7':
  ensure => 'absent',
}
```
* Non-default State:
```puppet
root@n9k-109#puppet resource cisco_interface 'ethernet1/6'
cisco_interface { 'ethernet1/6':
  ensure                                         => 'present',
  access_vlan                                    => 1,
  description                                    => 'Private-vlan Host Port',
  duplex                                         => 'auto',
  fabric_forwarding_anycast_gateway              => 'false',
  hsrp_bfd                                       => 'false',
  hsrp_delay_minimum                             => 0,
  hsrp_delay_reload                              => 0,
  hsrp_mac_refresh                               => false,
  hsrp_use_bia                                   => false,
  hsrp_version                                   => 1,
  ipv4_dhcp_relay_info_trust                     => 'false',
  ipv4_dhcp_relay_src_intf                       => false,
  ipv4_dhcp_relay_subnet_broadcast               => 'false',
  ipv4_dhcp_smart_relay                          => 'false',
  ipv4_forwarding                                => 'false',
  ipv4_pim_sparse_mode                           => 'false',
  ipv4_proxy_arp                                 => 'false',
  ipv4_redirects                                 => 'true',
  ipv6_dhcp_relay_src_intf                       => false,
  load_interval_counter_1_delay                  => 30,
  load_interval_counter_2_delay                  => 300,
  load_interval_counter_3_delay                  => false,
  mtu                                            => 1500,
  negotiate_auto                                 => 'true',
  pim_bfd                                        => 'false',
  purge_config                                   => 'false',
  shutdown                                       => 'true',
  speed                                          => 'auto',
  storm_control_broadcast                        => '100.00',
  storm_control_multicast                        => '100.00',
  storm_control_unicast                          => '100.00',
  stp_bpdufilter                                 => false,
  stp_bpduguard                                  => false,
  stp_cost                                       => 'auto',
  stp_guard                                      => false,
  stp_link_type                                  => 'auto',
  stp_port_priority                              => 128,
  stp_port_type                                  => false,
  switchport_autostate_exclude                   => 'false',
  switchport_mode                                => 'access',
  switchport_mode_private_vlan_host              => 'disabled',
  switchport_mode_private_vlan_trunk_promiscuous => 'false',
  switchport_mode_private_vlan_trunk_secondary   => 'false',
  switchport_private_vlan_trunk_native_vlan      => 1,
  switchport_pvlan_host                          => 'false',
  switchport_pvlan_promiscuous                   => 'false',
  switchport_pvlan_trunk_allowed_vlan            => 'none',
  switchport_pvlan_trunk_native_vlan             => '1',
  switchport_pvlan_trunk_promiscuous             => 'false',
  switchport_pvlan_trunk_secondary               => 'false',
  switchport_trunk_allowed_vlan                  => '1-4094',
  switchport_trunk_native_vlan                   => 1,
  switchport_vtp                                 => 'false',
  vpc_id                                         => false,
  vpc_peer_link                                  => 'false',
}
```

* Change `absent`(default) to `present`(non-default)
```puppet
root@n9k-109#puppet resource cisco_interface 'ethernet1/7' ensure='present' description='my test'
Notice: /Cisco_interface[ethernet1/7]/ensure: created
cisco_interface { 'ethernet1/7':
  ensure => 'absent',
}
root@n9k-109#puppet resource cisco_interface 'ethernet1/7'
cisco_interface { 'ethernet1/7':
  ensure                                         => 'present',
  access_vlan                                    => 1,
  description                                    => 'my test',
  duplex                                         => 'auto',
  fabric_forwarding_anycast_gateway              => 'false',
  hsrp_bfd                                       => 'false',
  hsrp_delay_minimum                             => 0,
  hsrp_delay_reload                              => 0,
  hsrp_mac_refresh                               => false,
  hsrp_use_bia                                   => false,
  hsrp_version                                   => 1,
  ipv4_dhcp_relay_info_trust                     => 'false',
  ipv4_dhcp_relay_src_intf                       => false,
  ipv4_dhcp_relay_subnet_broadcast               => 'false',
  ipv4_dhcp_smart_relay                          => 'false',
  ipv4_forwarding                                => 'false',
  ipv4_pim_sparse_mode                           => 'false',
  ipv4_proxy_arp                                 => 'false',
  ipv4_redirects                                 => 'true',
  ipv6_dhcp_relay_src_intf                       => false,
  load_interval_counter_1_delay                  => 30,
  load_interval_counter_2_delay                  => 300,
  load_interval_counter_3_delay                  => false,
  mtu                                            => 1500,
  negotiate_auto                                 => 'true',
  pim_bfd                                        => 'false',
  purge_config                                   => 'false',
  shutdown                                       => 'true',
  speed                                          => 'auto',
  storm_control_broadcast                        => '100.00',
  storm_control_multicast                        => '100.00',
  storm_control_unicast                          => '100.00',
  stp_bpdufilter                                 => false,
  stp_bpduguard                                  => false,
  stp_cost                                       => 'auto',
  stp_guard                                      => false,
  stp_link_type                                  => 'auto',
  stp_port_priority                              => 128,
  stp_port_type                                  => false,
  switchport_autostate_exclude                   => 'false',
  switchport_mode                                => 'disabled',
  switchport_mode_private_vlan_host              => 'disabled',
  switchport_mode_private_vlan_trunk_promiscuous => 'false',
  switchport_mode_private_vlan_trunk_secondary   => 'false',
  switchport_private_vlan_trunk_native_vlan      => 1,
  switchport_pvlan_host                          => 'false',
  switchport_pvlan_promiscuous                   => 'false',
  switchport_pvlan_trunk_allowed_vlan            => 'none',
  switchport_pvlan_trunk_native_vlan             => '1',
  switchport_pvlan_trunk_promiscuous             => 'false',
  switchport_pvlan_trunk_secondary               => 'false',
  switchport_trunk_allowed_vlan                  => '1-4094',
  switchport_trunk_native_vlan                   => 1,
  vpc_id                                         => false,
  vpc_peer_link                                  => 'false',
}
```

* Change `present`(non-default) to `absent`(default)
```puppet
root@n9k-109#puppet resource cisco_interface 'ethernet1/7' ensure=absent
Notice: /Cisco_interface[ethernet1/7]/ensure: removed
cisco_interface { 'ethernet1/7':
  ensure => 'present',
}
root@n9k-109#puppet resource cisco_interface 'ethernet1/7'
cisco_interface { 'ethernet1/7':
  ensure => 'absent',
}

```