### PR TITLE
Improve Facter performance

### DIFF
--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -28,7 +28,6 @@ Facter.add(:cisco) do
     hash['hardware']['cpu'] = Platform.cpu
     hash['hardware']['memory'] = Platform.memory
     hash['hardware']['board'] = Platform.board
-    hash['hardware']['uptime'] = Platform.uptime
     hash['hardware']['last_reset'] = Platform.last_reset
     hash['hardware']['reset_reason'] = Platform.reset_reason
 
@@ -49,6 +48,7 @@ Facter.add(:cisco) do
     hash['feature_compatible_module_iflist'] = {}
     interface_list = Feature.compatible_interfaces('fabricpath')
     hash['feature_compatible_module_iflist']['fabricpath'] = interface_list
+    hash['hardware']['uptime'] = Platform.uptime
 
     hash
   end


### PR DESCRIPTION
This PR is for improving the facts performance by a little bit.
As the 'uptime' facter flushes the cache (as it should), it is moved to the end so that the other facts can use the cache before it is flushed.
Beaker tests are run on n3k, n7k and n9k and they pass except few tests which are unrelated to this change.