### PR TITLE
Add puppet-blacksmith puppet_spec_helper gems/rake tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 *~
 *.swp
 hosts.cfg
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :unit_tests do
   gem 'pry',                     require: false
   gem 'rubocop', '= 0.35.1',     require: false
   gem 'simplecov',               require: false
+  gem 'puppet-blacksmith', '~> 3.4', require: false
 end
 
 # vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,8 @@
 
 require 'facter'
 require 'rubocop/rake_task'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
 
 task default: %w(rubocop test)
 


### PR DESCRIPTION
This commit updates the Gemfile to include puppet-blacksmith and updates the
Rakefile to include requiring the rake tasks for both puppet_spec_helper and
puppet-blacksmith.

This will allow use of rake tasks from both projects useful in testing and
publishing this module