### PR TITLE
fix system_image calls

### DIFF
--- a/lib/puppet/provider/cisco_route_map/cisco.rb
+++ b/lib/puppet/provider/cisco_route_map/cisco.rb
@@ -484,7 +484,7 @@ Puppet::Type.type(:cisco_route_map).provide(:cisco) do
 
   def legacy_image?
     fd = Facter.value('cisco')
-    image = fd['images']['system_image']
+    image = fd['images']['full_version']
     image[/7.0.3.I2|I3|I4/]
   end
 

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -242,7 +242,7 @@ module PuppetX
         data = Facter.value('cisco')
         case data['inventory']['chassis']['pid']
         when /N3/
-          tag = data['images']['system_image'][/7.0.3.F/] ? 'n3k-f' : 'n3k'
+          tag = data['images']['full_version'][/7.0.3.F/] ? 'n3k-f' : 'n3k'
         when /N5/
           tag = 'n5k'
         when /N6/
@@ -250,7 +250,7 @@ module PuppetX
         when /N7/
           tag = 'n7k'
         when /N9/
-          tag = data['images']['system_image'][/7.0.3.F/] ? 'n9k-f' : 'n9k'
+          tag = data['images']['full_version'][/7.0.3.F/] ? 'n9k-f' : 'n9k'
         else
           fail "Unrecognized product_id: #{data['inventory']['chassis']['pid']}"
         end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1136,7 +1136,7 @@ end
 @cached_img = nil
 def image?(reset_cache=false)
   return @cached_img unless @cached_img.nil? || reset_cache
-  on(agent, facter_cmd('-p cisco.images.system_image'))
+  on(agent, facter_cmd('-p cisco.images.full_version'))
   @cached_img = stdout.nil? ? '' : stdout
 end
 


### PR DESCRIPTION
This PR is for using full_version facter instead of system_image. The latter uses bin file name which could be anything and so prone to errors.
All tests pass on n9k-f platform where the problem is seen.