### PR TITLE
Restrict package provider tests

### DIFF
--- a/lib/puppet/provider/package/cisco.rb
+++ b/lib/puppet/provider/package/cisco.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:package).provide :cisco, parent: :yum do
       rpm('--version')
       yum('--version')
       python('--version')
-    rescue Puppet::ExecutionFailure
+    rescue Puppet::ExecutionFailure, Puppet::MissingCommand
       commands_present = false
     end
     confine true: commands_present


### PR DESCRIPTION
With a master connected to AIX 6.1 and 7.1 and this module (and pre-reqs) installed, the following error would show on a puppet run of the aix agents:

`Info: Loading facts
Error: Could not autoload puppet/provider/package/cisco: Command yum is missing
Error: Facter: error while resolving custom facts in /opt/puppetlabs/puppet/cache/lib/facter/package_provider.rb: Could not autoload puppet/provider/package/cisco: Command yum is missing
Info: Caching catalog for aix-61-agent1.delivery.puppetlabs.net
Info: Applying configuration version '1510330826'`

Reviewing the provider for packages, an update to the rescue block makes sense to check for command missing, as that is the expected behavior on some other operating systems. 

Tested on 2017.3.2 master, agents 5.3.3
installed modules: 
/etc/puppetlabs/code/environments/production/modules
├── puppetlabs-ciscopuppet (v1.7.0)
├── puppetlabs-concat (v4.1.0)
├── puppetlabs-netdev_stdlib (v0.12.0)
└── puppetlabs-stdlib (v4.21.0)