### PR TITLE
Add requirement for beaker-abs in Gemfile, add puppet_test_env group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,4 +68,8 @@ group :development, :unit_tests do
   gem 'puppet-blacksmith', '~> 3.4', require: false
 end
 
+group :puppet_test_env do
+  gem 'beaker-abs',                  require: false
+end
+
 # vim:ft=ruby


### PR DESCRIPTION
This commit does two things:

1. Adds the beaker-abs gem in to the gemfile (this gem is another required gem
for working in the test environment at Puppet.)

2. Adds a puppet_test_env group to the gemfile, to allow users at puppet to
test with the beaker-abs gem and the users at cisco to install gems without it
if necessary.