### PR TITLE
Use correct host_reachability flood for vxlan_vtp_vni dependencies

### DIFF
--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -233,7 +233,7 @@ def dependency_manifest(_tests, _id)
   "
     cisco_vxlan_vtep {'nve1':
       ensure => present,
-      host_reachability  => 'evpn',
+      host_reachability  => 'flood',
       shutdown           => 'false',
     }
   "


### PR DESCRIPTION
Fixes the test to use the correct and supported option.