### PR TITLE
Admin cookie override

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 1. [Module Description](#module-description)
 1. [Setup](#setup)
+   * [Puppet Master](#setup-puppet-master)
+   * [Puppet Agent](#setup-puppet-agent)
 1. [Example Manifests](#example-manifests)
 1. [Resource Reference](#resource-reference)
    * [Resource Type Catalog (by Technology)](#resource-by-tech)
@@ -29,7 +31,7 @@ Contributions to the `ciscopuppet` module are welcome. See [CONTRIBUTING.md][DEV
 
 ## <a href='setup'>Setup</a>
 
-#### Puppet Master
+### <a name="setup-puppet-master">Puppet Master<a>
 
 The `ciscopuppet` module must be installed on the Puppet Master server.
 
@@ -43,7 +45,7 @@ For more information on Puppet module installation see [Puppet Labs: Installing 
 
 PuppetLabs provides NetDev resource support for Cisco Nexus devices with their [`puppetlabs-netdev-stdlib`](https://forge.puppet.com/puppetlabs/netdev_stdlib) module. Installing the `ciscopuppet` module automatically installs both the `ciscopuppet` and `netdev_stdlib` modules.
 
-#### Puppet Agent
+### <a name="setup-puppet-agent">Puppet Agent<a>
 
 The Puppet Agent requires installation and setup on each device. Agent setup can be performed as a manual process or it may be automated. For more information please see the [README-agent-install.md][USER-1] document for detailed instructions on agent installation and configuration on Cisco Nexus devices.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ config term
 end
 ~~~
 
-Next create a file called `cisco_node_utils.yaml` under the `cisco-network-puppet-module` files directory and add a cookie `puppetuser:local` under the `default:` yaml key.
+Next create a file called `cisco_node_utils.yaml` under the `modules/ciscopuppet/files` directory on the puppet server and add a cookie `puppetuser:local` under the `default:` yaml key.
 
 ```bash
 puppetserver:> cat /etc/puppetlabs/code/environments/production/modules/ciscopuppet/files/cisco_node_utils.yaml


### PR DESCRIPTION
This update adds documentation for running puppet on Nexus with a user other then `admin`.