### PR TITLE
(CISCO-60) tacacs_global timeout undef

### DIFF
--- a/README.md
+++ b/README.md
@@ -5563,7 +5563,7 @@ Encryption key (plaintext or in hash form depending on key_format)
 Encryption key format [0-7]
 
 ##### `timeout`
-Number of seconds before the timeout period ends
+Number of seconds before the timeout period ends.  Also supports [undef](https://puppet.com/docs/puppet/5.3/lang_data_undef.html)
 
 --
 ### Type: tacacs_server

--- a/lib/puppet/provider/tacacs_global/cisco.rb
+++ b/lib/puppet/provider/tacacs_global/cisco.rb
@@ -1,4 +1,4 @@
-# September, 2017
+# December, 2017
 #
 # Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
@@ -69,7 +69,7 @@ Puppet::Type.type(:tacacs_global).provide(:cisco) do
     current_state = {
       ensure:           :present,
       name:             v.name,
-      timeout:          v.timeout ? v.timeout : -1,
+      timeout:          v.timeout,
       key:              v.key.nil? || v.key.empty? ? 'unset' : v.key,
       # Only return the key format if there is a key configured
       key_format:       v.key.nil? || v.key.empty? ? nil : v.key_format,

--- a/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
+++ b/tests/beaker_tests/tacacs_global/tacacs_global_provider_defaults.rb
@@ -68,6 +68,22 @@ test_name "TestCase :: #{testheader}" do
   cleanup
   teardown { cleanup }
 
+  # @step [Step] Checks tacacs_global resource on agent using resource cmd.
+  step 'TestStep :: Check tacacs_global resource unconfigured' do
+    # Expected exit_code is 0 since this is a puppet resource cmd.
+    # Flag is set to false to check for presence of RegExp pattern in stdout.
+    cmd_str = PUPPET_BINPATH + 'resource tacacs_global default'
+    on(agent, cmd_str)
+    output = stdout
+    search_pattern_in_output(output, { 'key' => 'unset' },
+                             false, self, logger)
+    search_pattern_in_output(output, { 'source_interface' => "['unset']" },
+                             false, self, logger)
+    search_pattern_in_output(output, [/timeout/], true, self, logger)
+
+    logger.info("Check tacacs_global resource unconfigured :: #{result}")
+  end
+
   # @step [Step] Requests manifest from the master server to the agent.
   step 'TestStep :: Get resource present manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.


### PR DESCRIPTION
This commit changes the output of timeout from -1 to undef when not set.  This more accurately reflects the real world state of the resource.  Also allows users to set undef in their manifest to accept default value when configured.