### PR TITLE
Remove host_reachability from dependency_manifest call

### DIFF
--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -255,17 +255,6 @@ def test_harness_dependencies(*)
   skip_if_nv_overlay_rejected(agent)
 end
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(_tests, _id)
-  "
-    cisco_vxlan_vtep {'nve1':
-      ensure => present,
-      host_reachability  => 'flood',
-      shutdown           => 'false',
-    }
-  "
-end
-
 def unsupported_properties(_tests, _id)
   unprops = []
   if platform[/n(5|6|7)k/]

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -269,6 +269,16 @@ def unsupported_properties(_tests, _id)
   unprops
 end
 
+# Overridden to properly handle dependencies for this test file.
+def dependency_manifest(_tests, _id)
+  "
+    cisco_vxlan_vtep {'nve1':
+      ensure => present,
+      shutdown           => 'false',
+    }
+  "
+end
+
 def version_unsupported_properties(_tests, _id)
   unprops = {}
   unprops[:suppress_uuc] = '8.1.1' if platform[/n7k/]


### PR DESCRIPTION
Setting the `host_reachability` in the dependency manifest call impacts tests since some versions of Nexus require it to be set properly for ingress_replication.  We let the setter for ingress replication set the value properly.

Tests pass on N9k (h_dev, greensboro) and N7k.