### PR TITLE
(CISCO-66) add missing confine to netdev_stdlib providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Resolved Issues
+* https://tickets.puppetlabs.com/browse/CISCO-66
 
 ## [1.9.0] - 2018-04-19
 

--- a/lib/puppet/provider/network_trunk/cisco.rb
+++ b/lib/puppet/provider/network_trunk/cisco.rb
@@ -1,6 +1,6 @@
-# November, 2015
+# May, 2018
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 Puppet::Type.type(:network_trunk).provide(:cisco, parent: Puppet::Type.type(:cisco_interface).provider(:cisco)) do
   @doc = 'network TRUNK'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
 
   mk_resource_methods
 

--- a/lib/puppet/provider/network_vlan/cisco.rb
+++ b/lib/puppet/provider/network_vlan/cisco.rb
@@ -1,6 +1,6 @@
-# October, 2015
+# May, 2018
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 Puppet::Type.type(:network_vlan).provide(:cisco, parent: Puppet::Type.type(:cisco_vlan).provider(:cisco)) do
   @doc = 'cisco VLAN'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
 
   mk_resource_methods
 

--- a/lib/puppet/provider/port_channel/cisco.rb
+++ b/lib/puppet/provider/port_channel/cisco.rb
@@ -1,6 +1,6 @@
-# October, 2015
+# May, 2018
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 Puppet::Type.type(:port_channel).provide(:cisco, parent: Puppet::Type.type(:cisco_interface_portchannel).provider(:cisco)) do
   @doc = 'port channel'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
 
   mk_resource_methods
 


### PR DESCRIPTION
The following providers were missing their confine.  This module supports netdev_stdlib and has to play nice with other providers.
A confine helps ensure this module does not interfere with other providers.

* network_trunk
* network_vlan
* port_channel