### PR TITLE
Fix CISCO-67

### DIFF
--- a/lib/puppet/type/cisco_tacacs_server.rb
+++ b/lib/puppet/type/cisco_tacacs_server.rb
@@ -157,5 +157,9 @@ Puppet::Type.newtype(:cisco_tacacs_server) do
        self[:encryption_type] != :none
       fail("The encryption_password must be present in the manifest if encryption_type is present and not 'none'.")
     end
+    if !self[:encryption_password].nil? &&
+       (self[:encryption_type].nil? || self[:encryption_type] == :none)
+      fail("The encryption_type must be present and not 'none' in the manifest if encryption_password is present.")
+    end
   end
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_tacacs_server.rb
+++ b/lib/puppet/type/cisco_tacacs_server.rb
@@ -3,7 +3,7 @@
 #
 # March 2014
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ Puppet::Type.newtype(:cisco_tacacs_server) do
   end
 
   # encryption type
-  newparam(:encryption_type) do
+  newproperty(:encryption_type) do
     desc 'Specifies the global preshared key type for TACACS+ servers.'
 
     munge do |value|

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -17,17 +17,16 @@
 # limitations under the License.
 
 module PuppetX
-  # PuppetX::NUConst - Constants defined in cisco_node_utils for namespace
-  module NUConst
-    TACACS_SERVER_ENC_UNKNOWN = Cisco::TACACS_SERVER_ENC_UNKNOWN
-    TACACS_SERVER_ENC_NONE = Cisco::TACACS_SERVER_ENC_NONE
-    TACACS_SERVER_ENC_CISCO_TYPE_7 = Cisco::TACACS_SERVER_ENC_CISCO_TYPE_7
-  end
   module Cisco
     # PuppetX::Cisco::Utils: - Common helper methods shared by any Type/Provider
     # rubocop:disable Metrics/ClassLength
     class Utils
       require 'ipaddr'
+
+      TACACS_SERVER_ENC_NONE = 0
+      TACACS_SERVER_ENC_CISCO_TYPE_7 = 7
+      TACACS_SERVER_ENC_UNKNOWN = 8
+
       # Helper utility method for ip/prefix format networks.
       # For ip/prefix format '1.1.1.1/24' or '2000:123:38::34/64',
       # we need to mask the address using the prefix length so that they
@@ -266,11 +265,11 @@ module PuppetX
       # Convert encryption type to symbol
       def self.enc_type_to_sym(type)
         case type
-        when NUConst::TACACS_SERVER_ENC_UNKNOWN
+        when TACACS_SERVER_ENC_UNKNOWN
           :none
-        when NUConst::TACACS_SERVER_ENC_NONE
+        when TACACS_SERVER_ENC_NONE
           :clear
-        when NUConst::TACACS_SERVER_ENC_CISCO_TYPE_7
+        when TACACS_SERVER_ENC_CISCO_TYPE_7
           :encrypted
         end
       end
@@ -279,11 +278,11 @@ module PuppetX
       def self.enc_sym_to_type(sym)
         case sym
         when :none
-          NUConst::TACACS_SERVER_ENC_UNKNOWN
+          TACACS_SERVER_ENC_UNKNOWN
         when :clear, :default
-          NUConst::TACACS_SERVER_ENC_NONE
+          TACACS_SERVER_ENC_NONE
         when :encrypted
-          NUConst::TACACS_SERVER_ENC_CISCO_TYPE_7
+          TACACS_SERVER_ENC_CISCO_TYPE_7
         end
       end
     end # class Utils

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -2,7 +2,7 @@
 #
 # November 2015
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,12 @@
 # limitations under the License.
 
 module PuppetX
+  # PuppetX::NUConst - Constants defined in cisco_node_utils for namespace
+  module NUConst
+    TACACS_SERVER_ENC_UNKNOWN = Cisco::TACACS_SERVER_ENC_UNKNOWN
+    TACACS_SERVER_ENC_NONE = Cisco::TACACS_SERVER_ENC_NONE
+    TACACS_SERVER_ENC_CISCO_TYPE_7 = Cisco::TACACS_SERVER_ENC_CISCO_TYPE_7
+  end
   module Cisco
     # PuppetX::Cisco::Utils: - Common helper methods shared by any Type/Provider
     # rubocop:disable Metrics/ClassLength
@@ -255,6 +261,30 @@ module PuppetX
           fail "Unrecognized product_id: #{data['inventory']['chassis']['pid']}"
         end
         tag
+      end
+
+      # Convert encryption type to symbol
+      def self.enc_type_to_sym(type)
+        case type
+        when NUConst::TACACS_SERVER_ENC_UNKNOWN
+          :none
+        when NUConst::TACACS_SERVER_ENC_NONE
+          :clear
+        when NUConst::TACACS_SERVER_ENC_CISCO_TYPE_7
+          :encrypted
+        end
+      end
+
+      # Convert encryption symbol to type
+      def self.enc_sym_to_type(sym)
+        case sym
+        when :none
+          NUConst::TACACS_SERVER_ENC_UNKNOWN
+        when :clear, :default
+          NUConst::TACACS_SERVER_ENC_NONE
+        when :encrypted
+          NUConst::TACACS_SERVER_ENC_CISCO_TYPE_7
+        end
       end
     end # class Utils
     # rubocop:enable Metrics/ClassLength

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_negatives.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -157,6 +157,18 @@ test_name "TestCase :: #{testheader}" do
   step 'TestStep :: Get negative test resource manifest from master' do
     # Expected exit_code is 0 since this is a bash shell cmd.
     on(master, TacacsServerLib.create_tacacsserver_passwd_negative)
+
+    # Expected exit_code is 1 since this is a puppet agent cmd with error.
+    cmd_str = PUPPET_BINPATH + 'agent -t'
+    on(agent, cmd_str, acceptable_exit_codes: [1])
+
+    logger.info("Get negative test resource manifest from master :: #{result}")
+  end
+
+  # @step [Step] Requests manifest from the master server to the agent.
+  step 'TestStep :: Get negative test resource manifest from master' do
+    # Expected exit_code is 1 since this an intended failure.
+    on(master, TacacsServerLib.create_tacacsserver_passwd_type_negative)
 
     # Expected exit_code is 1 since this is a puppet agent cmd with error.
     cmd_str = PUPPET_BINPATH + 'agent -t'

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserver_provider_nondefaults.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ test_name "TestCase :: #{testheader}" do
                                'timeout'             => '50',
                                'deadtime'            => '0',
                                'encryption_password' => add_quotes('WXYZ12'),
+                               'encryption_type'     => 'encrypted',
                                'directed_request'    => 'false',
                                'source_interface'    => 'Ethernet1/4' },
                              false, self, logger)

--- a/tests/beaker_tests/cisco_tacacs_server/tacacsserverlib.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/tacacsserverlib.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -155,6 +155,22 @@ node default {
     ensure              => present,
     encryption_type     => 'default',
     encryption_password => #{TacacsServerLib::ENCRYPPASSWD_NEGATIVE},
+  }
+}
+EOF"
+    manifest_str
+  end
+
+  # Method to create a manifest for TACACSSERVER attribute 'encryption_password'.
+  # without encryption_type
+  # @param none [None] No input parameters exist.
+  # @result none [None] Returns no object.
+  def self.create_tacacsserver_passwd_type_negative
+    manifest_str = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+node default {
+  cisco_tacacs_server { 'test':
+    ensure              => present,
+    encryption_password => 'WXYZ12',
   }
 }
 EOF"


### PR DESCRIPTION
This PR fixes issue (https://tickets.puppetlabs.com/browse/CISCO-67)
If tacacs_server ```encryption_password``` is provided but not ```encryption_type```, it should be error out. 

Add check to see if the type is ```nil``` or ```none``` and throw error if password is present is the manifest.