### PR TITLE
(maint) update beaker test_service

### DIFF
--- a/tests/beaker_tests/file_service_package/test_service.rb
+++ b/tests/beaker_tests/file_service_package/test_service.rb
@@ -30,7 +30,7 @@ tests = {
   resource_name: 'service',
 }
 
-os_service = 'crond'
+os_service = 'puppet'
 
 tests[:service_start] = {
   desc:           "1.1 Start Service '#{os_service}'",


### PR DESCRIPTION
This commit changes the system service under test from crond to puppet
We've been unable to make crond successfully test as it is not started by init.d, but some other task.
Using the puppet service keeps the test self contained.