### PR TITLE
Fix service test

### DIFF
--- a/tests/beaker_tests/file_service_package/test_service.rb
+++ b/tests/beaker_tests/file_service_package/test_service.rb
@@ -36,9 +36,10 @@ tests[:service_start] = {
   desc:           "1.1 Start Service '#{os_service}'",
   title_pattern:  os_service,
   manifest_props: {
-    name:   os_service,
-    ensure: 'running',
-    enable: 'true',
+    name:     os_service,
+    ensure:   'running',
+    enable:   'true',
+    provider: system_manager,
   },
   resource:       { 'ensure' => 'running' },
 }
@@ -47,9 +48,10 @@ tests[:service_stop] = {
   desc:           "1.2 Stop Service '#{os_service}'",
   title_pattern:  os_service,
   manifest_props: {
-    name:   os_service,
-    ensure: 'stopped',
-    enable: 'false',
+    name:     os_service,
+    ensure:   'stopped',
+    enable:   'false',
+    provider: system_manager,
   },
   resource:       { 'ensure' => 'stopped' },
 }

--- a/tests/beaker_tests/file_service_package/test_service.rb
+++ b/tests/beaker_tests/file_service_package/test_service.rb
@@ -30,7 +30,7 @@ tests = {
   resource_name: 'service',
 }
 
-os_service = 'crond'
+os_service = 'puppet'
 
 tests[:service_start] = {
   desc:           "1.1 Start Service '#{os_service}'",

--- a/tests/beaker_tests/file_service_package/test_service.rb
+++ b/tests/beaker_tests/file_service_package/test_service.rb
@@ -30,7 +30,11 @@ tests = {
   resource_name: 'service',
 }
 
-os_service = 'puppet'
+if system_manager[/systemd/]
+  os_service = 'crond'
+else
+  os_service = 'puppet'
+end
 
 tests[:service_start] = {
   desc:           "1.1 Start Service '#{os_service}'",

--- a/tests/beaker_tests/file_service_package/test_service.rb
+++ b/tests/beaker_tests/file_service_package/test_service.rb
@@ -30,11 +30,8 @@ tests = {
   resource_name: 'service',
 }
 
-if system_manager[/systemd/]
-  os_service = 'crond'
-else
-  os_service = 'puppet'
-end
+os_service = 'puppet'
+os_service = 'crond' if system_manager[/systemd|redhat/]
 
 tests[:service_start] = {
   desc:           "1.1 Start Service '#{os_service}'",

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1088,9 +1088,17 @@ end
 def system_manager
   return @system_manager unless @system_manager.nil?
   system_manager = on(agent, 'ls -l /proc/1/exe').stdout.chomp
-  # On NXOS hosting environments the system_manager is either
-  # systemd or init.
-  @system_manager = system_manager[/systemd/] ? 'systemd' : 'init'
+  # On NXOS hosting environments use different system_managers
+  # 1) Native bash-shell uses init
+  # 2) GuestShell uses systemd
+  # 3) OAC uses redhat
+  if system_manager[/systemd/]
+    @system_manager = 'systemd'
+  elsif platform[/n5k|n6k|n7k/]
+    @system_manager = 'redhat'
+  else
+    @system_manager = 'init'
+  end
   @system_manager
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1088,6 +1088,8 @@ end
 def system_manager
   return @system_manager unless @system_manager.nil?
   system_manager = on(agent, 'ls -l /proc/1/exe').stdout.chomp
+  # On NXOS hosting environments the system_manager is either
+  # systemd or init.
   @system_manager = system_manager[/systemd/] ? 'systemd' : 'init'
   @system_manager
 end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1084,6 +1084,14 @@ def virtual
   @virtual = on(agent, facter_cmd('virtual')).stdout.chomp
 end
 
+@system_manager = nil
+def system_manager
+  return @system_manager unless @system_manager.nil?
+  system_manager = on(agent, 'ls -l /proc/1/exe').stdout.chomp
+  @system_manager = system_manager[/systemd/] ? 'systemd' : 'init'
+  @system_manager
+end
+
 # Used to cache the cisco hardware type
 @cisco_hardware = nil
 # Use facter to return cisco hardware type


### PR DESCRIPTION
Currently we do not make any attempt to auto detect the system manager that is running inside of the various hosting environments on NXOS.  This PR attempts to address this problem.

1. Native bash-shell (init)
2. Guest-shell (systemd)
3. OAC (redhat)

Need to sort through the details of https://github.com/cisco/cisco-network-puppet-module/pull/493 before merging this PR.