### PR TITLE
(CISCO-71) Add banner provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
    * `logfile_severity_level`
    * `logfile_size`
 
+* Added `banner` with attributes:
+  * `motd`
+
+*note: due to bug in NXAPI multiline banners are only supported on n9k and n3k platforms running `7.0(3)I7.4` / `9.2(1)` or higher*
+
 ### Changed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The following resources include cisco types and providers along with cisco provi
 ### <a name="resource-by-tech">Resource Type Catalog (by Technology)<a>
 
 * Miscellaneous Types
+  * [`banner`](#type-banner)
   * [`cisco_command_config`](#type-cisco_command_config)
   * [`cisco_vdc`](#type-cisco_vdc)
   * [`cisco_upgrade`](#type-cisco_upgrade)
@@ -413,6 +414,7 @@ The following resources include cisco types and providers along with cisco provi
 
 ### <a name="resource-by-name-netdev">NetDev StdLib Resource Type Catalog (by Name)<a>
 
+* [`banner`](#type-banner)
 * [`domain_name`](#type-domain_name)
 * [`name_server`](#type-name_server)
 * [`network_dns`](#type-network_dns)
@@ -537,6 +539,7 @@ Symbol | Meaning | Description
 
 | ✅ = Supported <br> ➖ = Not Applicable | N9k | N3k | N5k | N6k | N7k | N9k-F | N3k-F | Caveats |
 |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [banner](#type-banner)                                     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | \*[caveats](#banner-caveats)
 | [domain_name](#type-domain_name)                           | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [name_server](#type-name_server)                           | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [network_dns](#type-network_dns)                           | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | \*[caveats](#network_dns-caveats)
@@ -5125,6 +5128,36 @@ The following resources are listed alphabetically.
 
 --
 
+### Type: banner
+
+Configure the banner of the device
+
+| Platform | OS Minimum Version | Module Minimum Version |
+|----------|:------------------:|:----------------------:|
+| N9k      | 7.0(3)I2(5)        | 1.10.0                 |
+| N3k      | 7.0(3)I2(5)        | 1.10.0                 |
+| N5k      | 7.3(0)N1(1)        | 1.10.0                 |
+| N6k      | 7.3(0)N1(1)        | 1.10.0                 |
+| N7k      | 7.3(0)D1(1)        | 1.10.0                 |
+| N9k-F    | 7.0(3)F1(1)        | 1.10.0                 |
+| N3k-F    | 7.0(3)F3(2)        | 1.10.0                 |
+
+
+#### <a name="banner-caveats">Caveats</a>
+
+| Property         | Caveat Description                                                        |
+|------------------|----------------------------------------------------------------------------------------------------------|
+| motd             | multiline banners are only supported on n9k and n3k platforms running `7.0(3)I7.4` / `9.2(1)` or higher  |
+
+#### Parameters
+
+##### `name`
+Resource name, not used to configure the device.  Should be 'default'.
+
+##### `motd`
+MOTD Banner. Valid value is a string.  Non-literal newlines will be escaped.
+
+--
 ### Type: domain_name
 
 Configure the domain name of the device

--- a/lib/puppet/provider/banner/cisco.rb
+++ b/lib/puppet/provider/banner/cisco.rb
@@ -1,0 +1,102 @@
+# August, 2018
+#
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:banner).provide(:cisco) do
+  desc 'The Cisco provider for banner.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  BANNER_ALL_PROPS = [
+    :motd
+  ]
+
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@banner',
+                                            BANNER_ALL_PROPS)
+
+  def initialize(value={})
+    super(value)
+    @banner = Cisco::Banner.banners[@property_hash[:name]]
+    @property_flush = {}
+    debug 'Created provider instance of banner'
+  end
+
+  def self.properties_get(banner_name, v)
+    debug "Checking instance, Banner #{banner_name}"
+
+    current_state = {
+      name:   'default',
+      ensure: :present,
+    }
+
+    # Call node_utils getter for each property
+    BANNER_ALL_PROPS.each do |prop|
+      val = v.send(prop)
+      current_state[prop] = val == v.default_motd ? 'default' : val
+    end
+    debug current_state
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    banners = []
+    Cisco::Banner.banners.each do |banner_name, v|
+      banners << properties_get(banner_name, v)
+    end
+
+    banners
+  end
+
+  def self.prefetch(resources)
+    banners = instances
+
+    resources.keys.each do |id|
+      provider = banners.find { |banner| banner.name.to_s == id.to_s }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def validate
+    fail ArgumentError, "This provider only supports a namevar of 'default'" unless @resource[:name].to_s == 'default'
+  end
+
+  def flush
+    validate
+    BANNER_ALL_PROPS.each do |prop|
+      next unless @resource[prop]
+      next if @property_flush[prop].nil?
+      # Call the AutoGen setters for the @banner node_utils object.
+      @property_flush[prop] = nil if @property_flush[prop] == 'default'
+      @banner.send("#{prop}=", @property_flush[prop]) if
+        @banner.respond_to?("#{prop}=")
+    end
+  end
+end # Puppet::Type

--- a/tests/beaker_tests/banner/test_banner.rb
+++ b/tests/beaker_tests/banner/test_banner.rb
@@ -1,0 +1,77 @@
+###############################################################################
+# Copyright (c) 2017-2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
+#
+###############################################################################
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Test hash top-level keys
+tests = {
+  agent:         agent,
+  master:        master,
+  resource_name: 'banner',
+  ensurable:     false,
+}
+
+# Skip -ALL- tests if a top-level platform/os key exludes this platform
+skip_unless_supported(tests)
+
+# Test hash test cases
+tests[:default] = {
+  desc:           '1.1 Default Properties',
+  title_pattern:  'default',
+  manifest_props: {
+    motd: 'default'
+  },
+  code:           [0, 2],
+}
+
+#
+# non_default_properties
+#
+tests[:non_default] = {
+  desc:           '2.1 Non Default Properties',
+  title_pattern:  'default',
+  manifest_props: {
+    motd: 'Test MOTD banner!'
+  },
+}
+
+def cleanup(agent)
+  test_set(agent, 'no banner motd')
+end
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{tests[:resource_name]}" do
+  teardown { cleanup(agent) }
+  cleanup(agent)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
+  test_harness_run(tests, :default)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
+  test_harness_run(tests, :non_default)
+end
+logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
This commit adds the provider for the new banner type (netdev_stdlib)
Currently the only banner supported is MOTD.

Provider supports multiline banners with the following caveats
  * module will attempt to escape any non-literal newlines
  * NXAPI does not correctly set newlines in versions prior to 7.0(3)I7.4 / 9.2(1)

Requires cisco/cisco-network-node-utils#586 
Requires netdev_stdlib 0.15.1 (unreleased)