### PR TITLE
fix for issue cisco #497

### DIFF
--- a/README.md
+++ b/README.md
@@ -2286,7 +2286,7 @@ cisco_interface { 'ethernet1/10':
 ```
 
 ###### `speed`
-Speed of the interface. Valid values are 100, 1000, 10000, 40000, 1000000, and 'auto'.
+Speed of the interface. Valid values are 100, 1000, 10000, 40000, 100000, and 'auto'.
 
 ###### `shutdown`
 Shutdown state of the interface. Valid values are 'true', 'false', and

--- a/lib/puppet/provider/network_interface/cisco.rb
+++ b/lib/puppet/provider/network_interface/cisco.rb
@@ -118,7 +118,7 @@ Puppet::Type.type(:network_interface).provide(:cisco) do
     when '1g' then 1000
     when '10g' then 10_000
     when '40g' then 40_000
-    when '100g' then 1_000_000
+    when '100g' then 100_000
     else type
     end
   end

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -183,7 +183,7 @@ Puppet::Type.newtype(:cisco_interface) do
   newproperty(:speed) do
     desc "Configure the speed between interfaces. Default value is 'auto'."
 
-    newvalues(:auto, 10, 100, 1000, 10_000, 1_000_000, 40_000, :default)
+    newvalues(:auto, 10, 100, 1000, 10_000, 100_000, 40_000, :default)
   end # property speed
 
   newproperty(:duplex) do


### PR DESCRIPTION
This PR is for fixing 
https://github.com/cisco/cisco-network-puppet-module/issues/497

The wrong speed problem exists in the network_interface as well. It is corrected too,