### PR TITLE
(NETDEV-43) Add syslog_facility provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
 #### Cisco Resources
 
 ### Added
+* Added `syslog_facility` with attribute:
+   * `level`
 * Extend syslog_server with attribute:
    * `facility`
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ The following resources include cisco types and providers along with cisco provi
   * [`snmp_user (netdev_stdlib)`](#type-snmp_user)
 
 * SYSLOG Types
+  * [`syslog_facility (netdev_stdlib)`](#type-syslog_facility)
   * [`syslog_server (netdev_stdlib)`](#type-syslog_server)
   * [`syslog_settings (netdev_stdlib)`](#type-syslog_settings)
 
@@ -432,6 +433,7 @@ The following resources include cisco types and providers along with cisco provi
 * [`snmp_notification`](#type-snmp_notification)
 * [`snmp_notification_receiver`](#type-snmp_notification_receiver)
 * [`snmp_user`](#type-snmp_user)
+* [`syslog_facility`](#type-syslog_facility)
 * [`syslog_server`](#type-syslog_server)
 * [`syslog_settings`](#type-syslog_settings)
 * [`tacacs`](#type-tacacs)
@@ -555,6 +557,7 @@ Symbol | Meaning | Description
 | [snmp_notification](#type-snmp_notification)               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [snmp_notification_receiver](#type-snmp_notification_receiver) | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [snmp_user](#type-snmp_user)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
+| [syslog_facility](#type-syslog_facility)                   | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [syslog_server](#type-syslog_server)                       | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [syslog_settings](#type-syslog_settings)                   | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [tacacs](#type-tacacs)                                     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
@@ -5748,6 +5751,31 @@ Syslog severity level to log.  Valid value is an integer.
 
 ##### `vrf`
 Interface to send syslog data from, e.g. "management".  Valid value is a string.
+
+--
+### Type: syslog_facility
+
+| Platform | OS Minimum Version | Module Minimum Version |
+|----------|:------------------:|:----------------------:|
+| N9k      | 7.0(3)I2(5)        | 1.10.0                 |
+| N3k      | 7.0(3)I2(5)        | 1.10.0                 |
+| N5k      | 7.3(0)N1(1)        | 1.10.0                 |
+| N6k      | 7.3(0)N1(1)        | 1.10.0                 |
+| N7k      | 7.3(0)D1(1)        | 1.10.0                 |
+| N9k-F    | 7.0(3)F1(1)        | 1.10.0                 |
+| N3k-F    | 7.0(3)F3(2)        | 1.10.0                 |
+
+
+#### Parameters
+
+##### `ensure`
+Determines whether or not the config should be present on the device. Valid values are 'present' and 'absent'.
+
+##### `name`
+Global Syslog facility.  Valid value is a string.
+
+##### `level`
+Syslog severity level to log.  Valid value is an integer 0-7.
 
 --
 ### Type: syslog_settings

--- a/lib/puppet/provider/syslog_facility/cisco.rb
+++ b/lib/puppet/provider/syslog_facility/cisco.rb
@@ -1,0 +1,112 @@
+# August, 2018
+#
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'cisco_node_utils' if Puppet.features.cisco_node_utils?
+begin
+  require 'puppet_x/cisco/autogen'
+rescue LoadError # seen on master, not on agent
+  # See longstanding Puppet issues #4248, #7316, #14073, #14149, etc. Ugh.
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
+                                     'puppet_x', 'cisco', 'autogen.rb'))
+end
+
+Puppet::Type.type(:syslog_facility).provide(:cisco) do
+  desc 'The Cisco provider for syslog_facility.'
+
+  confine feature: :cisco_node_utils
+  defaultfor operatingsystem: :nexus
+
+  mk_resource_methods
+
+  SYSLOG_FACILITY_ALL_PROPS = [
+    :level
+  ]
+
+  def initialize(value={})
+    super(value)
+    @syslogfacility = Cisco::SyslogFacility.facilities[@property_hash[:name]]
+    @property_flush = {}
+    debug 'Created provider instance of syslog_facility'
+  end
+
+  def self.properties_get(facility, v)
+    debug "Checking instance, syslog_facility #{facility}"
+
+    current_state = {
+      ensure: :present,
+      name:   v.facility,
+      level:  v.level,
+    }
+
+    new(current_state)
+  end # self.properties_get
+
+  def self.instances
+    facilities = []
+    Cisco::SyslogFacility.facilities.each do |facility, v|
+      facilities << properties_get(facility, v)
+    end
+
+    facilities
+  end
+
+  def self.prefetch(resources)
+    facilities = instances
+
+    resources.keys.each do |id|
+      provider = facilities.find { |facility| facility.name.to_s == id.to_s }
+      resources[id].provider = provider unless provider.nil?
+    end
+  end # self.prefetch
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def validate
+    fail ArgumentError,
+         'Severity level must be integer 0-7.' unless @resource[:level].between?(0, 7)
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      @syslogfacility.destroy
+      @syslogfacility = nil
+    else
+      validate
+      # Create new instance with configured options
+      opts = { 'facility' => @resource[:name] }
+      SYSLOG_FACILITY_ALL_PROPS.each do |prop|
+        next unless @resource[prop]
+        opts[prop.to_s] = @resource[prop].to_s
+      end
+
+      begin
+        @syslogfacility = Cisco::SyslogFacility.new(opts)
+      rescue Cisco::CliError => e
+        error "Unable to set new values: #{e.message}"
+      end
+    end
+  end
+end # Puppet::Type

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/cisco/cisco-network-puppet-module",
   "issues_url": "https://github.com/cisco/cisco-network-puppet-module/issues",
   "dependencies": [
-    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.15.0" }
+    { "name": "puppetlabs/netdev_stdlib", "version_requirement": ">=0.16.0" }
   ],
   "requirements": [
     {

--- a/tests/beaker_tests/syslog_facility/test_syslog_facility.rb
+++ b/tests/beaker_tests/syslog_facility/test_syslog_facility.rb
@@ -1,0 +1,77 @@
+###############################################################################
+# Copyright (c) 2017-2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+# See README-develop-beaker-scripts.md (Section: Test Script Variable Reference)
+# for information regarding:
+#  - test script general prequisites
+#  - command return codes
+#  - A description of the 'tests' hash and its usage
+#
+###############################################################################
+require File.expand_path('../../lib/utilitylib.rb', __FILE__)
+
+# Test hash top-level keys
+tests = {
+  agent:         agent,
+  master:        master,
+  resource_name: 'syslog_facility',
+}
+
+# Skip -ALL- tests if a top-level platform/os key exludes this platform
+skip_unless_supported(tests)
+
+# Test hash test cases
+tests[:single_name] = {
+  title_pattern:  'aaa',
+  manifest_props: {
+    level: 4
+  },
+}
+
+tests[:double_name] = {
+  title_pattern:  'ip igmp',
+  manifest_props: {
+    level: 6
+  },
+}
+
+tests[:triple_name] = {
+  title_pattern:  'routing ipv4 multicast',
+  manifest_props: {
+    level: 7
+  },
+}
+
+#################################################################
+# TEST CASE EXECUTION
+#################################################################
+test_name "TestCase :: #{tests[:resource_name]}" do
+  teardown { resource_absent_cleanup(agent, 'syslog_facility') }
+  resource_absent_cleanup(agent, 'syslog_facility')
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 1. Single Name Testing")
+  test_harness_run(tests, :single_name)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 2. Double Name Testing")
+  test_harness_run(tests, :double_name)
+
+  # -------------------------------------------------------------------
+  logger.info("\n#{'-' * 60}\nSection 3. Triple Name Testing")
+  test_harness_run(tests, :triple_name)
+end
+logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
Adds provider for syslog_facility (netdev_stdlib)
Allows users to configure severity levels for global syslog facilities

Requires 
- puppetlabs/netdev_stdlib#48
- cisco/cisco-network-node-utils#587
