### PR TITLE
CISCO-77: cisco_interface add ipv6_redirects attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
 ### Added
 * Extend syslog_server with attribute:
    * `facility`
+* Extend cisco_interface with attribute:
+   * `ipv6_redirects`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -2243,6 +2243,7 @@ Manages a Cisco Network Interface. Any resource dependency should be run before 
 | `load_interval_counter_3_delay`       | Minimum puppet module version 1.6.0 |
 | `purge_config`                        | Minimum puppet module version 1.7.0 |
 | Ensure absent for ethernet interfaces | Minimum puppet module version 1.8.0 |
+| `ipv6_redirects`                      | Minimum puppet module version 1.10.0 |
 
 #### Parameters
 
@@ -2474,6 +2475,9 @@ ipv6_dhcp_relay_addr => ['2000::11', '2001::22']
 ```
 ###### `ipv6_dhcp_relay_src_intf`
 Source interface for the DHCPV6 relay. Valid values are string, keyword 'default'.
+
+###### `ipv6_redirects`
+Enables or disables sending of IPv6 redirect messages. Valid values are 'true', 'false', and 'default'.
 
 ###### `pim_bfd`
 Enables PIM BFD on the interface. Valid values are 'true', 'false', and 'default'.

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -1,6 +1,6 @@
 # May 2015
 #
-# Copyright (c) 2015-2017 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     :ipv4_dhcp_relay_src_addr_hsrp,
     :ipv4_dhcp_relay_subnet_broadcast,
     :ipv4_dhcp_smart_relay,
+    :ipv6_redirects,
     :negotiate_auto,
     :pim_bfd,
     :purge_config,
@@ -347,7 +348,8 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     l3_props = [
       :ipv4_proxy_arp, :ipv4_redirects,
       :ipv4_address, :ipv4_netmask_length,
-      :ipv4_address_secondary, :ipv4_netmask_length_secondary
+      :ipv4_address_secondary, :ipv4_netmask_length_secondary,
+      :ipv6_redirects
     ]
     l3_props.each do |prop|
       if @property_flush[prop].nil?

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -2,7 +2,7 @@
 #
 # May 2013
 #
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ Puppet::Type.newtype(:cisco_interface) do
      ipv4_dhcp_smart_relay          => true,
      ipv6_dhcp_relay_addr           => ['2000::11', '2001::22'],
      ipv6_dhcp_relay_src_intf       => 'ethernet 2/2',
+     ipv6_redirects                 => true,
      pim_bfd                        => true,
     }
     cisco_interface { 'ethernet1/17' :
@@ -461,6 +462,13 @@ Puppet::Type.newtype(:cisco_interface) do
       value
     end
   end # property ipv6_acl_out
+
+  newproperty(:ipv6_redirects) do
+    desc "<L3 attribute> Enables or disables sending of IPv6 redirect
+          messages."
+
+    newvalues(:true, :false, :default)
+  end # property ipv6_redirects
 
   # validate ipv4 address and mask combination
   validate do

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/FileName
 ###############################################################################
-# Copyright (c) 2014-2017 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ tests[:default] = {
     ipv4_dhcp_smart_relay:            'default',
     ipv6_dhcp_relay_addr:             'default',
     ipv6_dhcp_relay_src_intf:         'default',
+    ipv6_redirects:                   'default',
     pim_bfd:                          'default',
     mtu:                              'default',
     shutdown:                         'default',
@@ -80,6 +81,7 @@ tests[:default] = {
     ipv4_dhcp_relay_subnet_broadcast: 'false',
     ipv4_dhcp_smart_relay:            'false',
     ipv6_dhcp_relay_src_intf:         'false',
+    ipv6_redirects:                   'true',
     pim_bfd:                          'false',
     mtu:                              operating_system == 'nexus' ? '1500' : '1514',
     shutdown:                         'false',
@@ -120,6 +122,7 @@ tests[:non_default] = {
     ipv4_dhcp_smart_relay:            'true',
     ipv6_dhcp_relay_addr:             v6_relay,
     ipv6_dhcp_relay_src_intf:         'ethernet1/1',
+    ipv6_redirects:                   'false',
     pim_bfd:                          true,
     switchport_mode:                  'disabled',
     vrf:                              'test1',


### PR DESCRIPTION
Adds support to `cisco_interface` for `ipv6_redirects` attribute.

NodeUtils Changes: https://github.com/cisco/cisco-network-node-utils/pull/592