### PR TITLE
(maint) pin net-telnet version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.2
-  - 2.1.6
+  - 2.4.4
+  - 2.1.9

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :unit_tests do
   gem 'rubocop', '= 0.35.1',     require: false
   gem 'simplecov',               require: false
   gem 'puppet-blacksmith', '~> 3.4', require: false
+  gem 'net-telnet', '~> 0.1.1', require: false
 end
 
 group :puppet_test_env do


### PR DESCRIPTION
The 0.2.0 release of net-telnet requires ruby >= 2.3.  We need to test ruby 1.9.3 until 31-Dec-18

Also bumped the travis rvm versions to match what is currently supported in puppet-agent.

@mikewiebe @willmeek this should resolve the travis issues that have popped up.