### PR TITLE
(CISCO-63) Confine package provider and fix inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
 * Support for Puppet Agent install into the `bash-shell` hosting environment. This is the native WRL Linux environment underlying NX-OS.
 
 ### Resolved Issues
+* https://tickets.puppetlabs.com/browse/CISCO-63
 * https://tickets.puppetlabs.com/browse/CISCO-66
 * https://tickets.puppetlabs.com/browse/CISCO-75
 * https://tickets.puppetlabs.com/browse/CISCO-76

--- a/lib/puppet/provider/package/cisco.rb
+++ b/lib/puppet/provider/package/cisco.rb
@@ -1,6 +1,6 @@
-# January, 2015
+# August, 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ Puppet::Type.type(:package).provide :cisco, parent: :yum do
   Cisco rpm installations from guestshell will utilize nxapi to install to host."
 
   confine feature: :cisco_node_utils
+  confine operatingsystem: :nexus
 
   # same features as yum plus :package_settings
   has_feature :install_options, :versionable, :virtual_packages, :package_settings
@@ -200,6 +201,7 @@ Puppet::Type.type(:package).provide :cisco, parent: :yum do
 
   # true if DSL defines "package_settings => {'target' => 'host'}"
   def target_host?
+    return unless @resource
     @resource[:package_settings] &&
       @resource[:package_settings]['target'] == 'host'
   end


### PR DESCRIPTION
Facter was updated to identify guestshell as nexus - confine the operating system so we do not try to inspect with cisco provider on Puppet Device Nodes
Also cleaned up error from package inspector poking around vs managing resources