### PR TITLE
CISCO-74 Fix puppet resource interface defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
 ### Resolved Issues
 * https://tickets.puppetlabs.com/browse/CISCO-63
 * https://tickets.puppetlabs.com/browse/CISCO-66
+* https://tickets.puppetlabs.com/browse/CISCO-74
 * https://tickets.puppetlabs.com/browse/CISCO-75
 * https://tickets.puppetlabs.com/browse/CISCO-76
 

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -244,6 +244,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     interface
   end
 
+  def check_methods(prop)
+    @nu.respond_to?("#{prop}=") && @nu.respond_to?("default_#{prop}")
+  end
+
   def properties_set(new_interface=false)
     INTF_ALL_PROPS.each do |prop|
       next unless @resource[prop]
@@ -251,6 +255,10 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
       unless @property_flush[prop].nil?
         @nu.send("#{prop}=", @property_flush[prop]) if
           @nu.respond_to?("#{prop}=")
+      end
+      if @resource[prop] == :default
+        @nu.send("#{prop}=", @nu.send("default_#{prop}")) if
+          check_methods(prop)
       end
     end
     ipv4_addr_mask_set
@@ -376,6 +384,7 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
         new_interface = true
         @nu = Cisco::Interface.new(@resource[:interface])
       end
+      puts "#{@property_flush}"
       properties_set(new_interface)
     end
   end

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -384,7 +384,6 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
         new_interface = true
         @nu = Cisco::Interface.new(@resource[:interface])
       end
-      puts "#{@property_flush}"
       properties_set(new_interface)
     end
   end

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -273,10 +273,15 @@ Puppet::Type.newtype(:cisco_interface) do
           downstream device. The vPC Peer switch must have an indentical
           configuration to the same downstream device. Valid values are in
           the range 1..4096'
-    range = *(1..4096)
-    validate do |id|
-      fail 'VPC ID must be in the range 1..4096' unless
-        range.include?(id.to_i)
+
+    munge do |value|
+      value = :default if value == 'default'
+      if value != :default
+        range = *(1..4096)
+        fail 'VPC ID must be in the range 1..4096' unless
+          range.include?(value.to_i)
+      end
+      value
     end
   end # property vpc_id
 

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -850,11 +850,11 @@ Puppet::Type.newtype(:cisco_interface) do
          'interface. ' + inputs
 
     validate do |value|
-      fail inputs unless value.delete(' ')[/^(default|[-,\d]+)$/]
+      fail inputs unless value.delete(' ')[/^(default|none|[-,\d]+)$/]
     end
 
     munge do |value|
-      if value.to_s[/default/]
+      if value.to_s[/default|none/]
         :default
       else
         PuppetX::Cisco::Utils.normalize_range_string(value)

--- a/tests/beaker_tests/cisco_hsrp/test_interface_hsrp.rb
+++ b/tests/beaker_tests/cisco_hsrp/test_interface_hsrp.rb
@@ -56,12 +56,12 @@ tests[:default] = {
   },
   code:               [0, 2],
   resource:           {
-    hsrp_bfd:           'false',
     hsrp_delay_minimum: 0,
     hsrp_delay_reload:  0,
-    hsrp_mac_refresh:   'false',
-    hsrp_use_bia:       'false',
     hsrp_version:       1,
+    # hsrp_bfd is nil when set to default
+    # hsrp_mac_refresh is nil when set to default
+    # hsrp_use_bia is nil when set to defaul
   },
 }
 

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -106,7 +106,7 @@ tests[:default_trunk] = {
     shutdown:                      'true',
     load_interval_counter_1_delay: '30',
     load_interval_counter_2_delay: '300',
-    load_interval_counter_3_delay: 'false',
+    # load_interval_counter_3_delay is nil when set to default
     storm_control_broadcast:       '100.00',
     storm_control_multicast:       '100.00',
     storm_control_unicast:         '100.00',

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -77,14 +77,13 @@ tests[:default] = {
     ipv4_redirects:                   operating_system == 'nexus' ? 'true' : 'false',
     ipv4_dhcp_relay_info_trust:       'false',
     ipv4_dhcp_relay_src_addr_hsrp:    'false',
-    ipv4_dhcp_relay_src_intf:         'false',
     ipv4_dhcp_relay_subnet_broadcast: 'false',
     ipv4_dhcp_smart_relay:            'false',
-    ipv6_dhcp_relay_src_intf:         'false',
     ipv6_redirects:                   'true',
     pim_bfd:                          'false',
     mtu:                              operating_system == 'nexus' ? '1500' : '1514',
     shutdown:                         'false',
+    # (ipv4|ipv6)_dhcp_relay_src_intf is nil when set to default
   },
 }
 

--- a/tests/beaker_tests/cisco_interface/test_interface_stp.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_stp.rb
@@ -64,15 +64,15 @@ tests[:default] = {
   },
   resource:       {
     'description'       => 'Test default properties',
-    'stp_bpdufilter'    => 'false',
-    'stp_bpduguard'     => 'false',
     'stp_cost'          => 'auto',
-    'stp_guard'         => 'false',
     'stp_link_type'     => 'auto',
     'stp_port_priority' => '128',
-    'stp_port_type'     => 'false',
+    # 'stp_bpdufilter' is nil when default
+    # 'stp_bpduguard' is nil when default
+    # 'stp_guard' is nil when default
     # 'stp_mst_cost' is nil when default
     # 'stp_mst_port_priority' is nil when default
+    # 'stp_port_type' is nil when default
     # 'stp_vlan_cost' is nil when default
     # 'stp_vlan_port_priority' is nil when default
   },


### PR DESCRIPTION
Fixes problem where cisco_interface returns illegal default values

Node Utils PR: https://github.com/cisco/cisco-network-node-utils/pull/595

**Tests:**

Puppet Manifest:

```puppet
node default {
  cisco_interface { 'vlan13':
    ensure => present,
  }
}
```

```puppet
[root@guestshell ~]# puppet resource cisco_interface 'vlan13'
cisco_interface { 'vlan13':
  ensure => 'absent',
}
[root@guestshell ~]# 
```

```puppet
[root@guestshell ~]# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for n9k.example.com
Info: Applying configuration version '1536270600'
Notice: /Stage[main]/Main/Node[default]/Cisco_interface[vlan13]/ensure: created
Notice: Applied catalog in 13.29 seconds
[root@guestshell ~]# 
[root@guestshell ~]# puppet resource cisco_interface 'vlan13'
cisco_interface { 'vlan13':
  ensure                                         => 'present',
  access_vlan                                    => '1',
  duplex                                         => 'auto',
  fabric_forwarding_anycast_gateway              => 'false',
  hsrp_bfd                                       => 'false',
  hsrp_delay_minimum                             => '0',
  hsrp_delay_reload                              => '0',
  hsrp_version                                   => '1',
  ipv4_arp_timeout                               => '700',
  ipv4_dhcp_relay_info_trust                     => 'false',
  ipv4_dhcp_relay_subnet_broadcast               => 'false',
  ipv4_dhcp_smart_relay                          => 'false',
  ipv4_forwarding                                => 'false',
  ipv4_pim_sparse_mode                           => 'false',
  ipv4_proxy_arp                                 => 'false',
  ipv4_redirects                                 => 'true',
  ipv6_redirects                                 => 'true',
  load_interval_counter_1_delay                  => '60',
  load_interval_counter_2_delay                  => '300',
  load_interval_counter_3_delay                  => '60',
  mtu                                            => '1500',
  negotiate_auto                                 => 'false',
  pim_bfd                                        => 'false',
  private_vlan_mapping                           => ['108-109'],
  pvlan_mapping                                  => ['108-109'],
  shutdown                                       => 'true',
  speed                                          => 'auto',
  storm_control_broadcast                        => '100.00',
  storm_control_multicast                        => '100.00',
  storm_control_unicast                          => '100.00',
  stp_cost                                       => 'auto',
  stp_link_type                                  => 'auto',
  stp_port_priority                              => '128',
  svi_autostate                                  => 'true',
  svi_management                                 => 'false',
  switchport_autostate_exclude                   => 'false',
  switchport_mode                                => 'disabled',
  switchport_mode_private_vlan_host              => 'disabled',
  switchport_mode_private_vlan_trunk_promiscuous => 'false',
  switchport_mode_private_vlan_trunk_secondary   => 'false',
  switchport_private_vlan_trunk_native_vlan      => '1',
  switchport_pvlan_host                          => 'false',
  switchport_pvlan_promiscuous                   => 'false',
  switchport_pvlan_trunk_allowed_vlan            => 'none',
  switchport_pvlan_trunk_native_vlan             => '1',
  switchport_pvlan_trunk_promiscuous             => 'false',
  switchport_pvlan_trunk_secondary               => 'false',
  switchport_trunk_allowed_vlan                  => '1-4094',
  switchport_trunk_native_vlan                   => '1',
  vpc_peer_link                                  => 'false',
}
[root@guestshell ~]# 
```

Use resource output in manifest:

```puppet
node default {
cisco_interface { 'vlan13':
  ensure                                         => 'present',
  access_vlan                                    => '1',
  duplex                                         => 'auto',
  fabric_forwarding_anycast_gateway              => 'false',
  hsrp_bfd                                       => 'false',
  hsrp_delay_minimum                             => '0',
  hsrp_delay_reload                              => '0',
  hsrp_version                                   => '1',
  ipv4_arp_timeout                               => '700',
  ipv4_dhcp_relay_info_trust                     => 'false',
  ipv4_dhcp_relay_subnet_broadcast               => 'false',
  ipv4_dhcp_smart_relay                          => 'false',
  ipv4_forwarding                                => 'false',
  ipv4_pim_sparse_mode                           => 'false',
  ipv4_proxy_arp                                 => 'false',
  ipv4_redirects                                 => 'true',
  ipv6_redirects                                 => 'true',
  load_interval_counter_1_delay                  => '60',
  load_interval_counter_2_delay                  => '300',
  load_interval_counter_3_delay                  => '60',
  mtu                                            => '1500',
  negotiate_auto                                 => 'false',
  pim_bfd                                        => 'false',
  private_vlan_mapping                           => ['108-109'],
  pvlan_mapping                                  => ['108-109'],
  shutdown                                       => 'true',
  speed                                          => 'auto',
  storm_control_broadcast                        => '100.00',
  storm_control_multicast                        => '100.00',
  storm_control_unicast                          => '100.00',
  stp_cost                                       => 'auto',
  stp_link_type                                  => 'auto',
  stp_port_priority                              => '128',
  svi_autostate                                  => 'true',
  svi_management                                 => 'false',
  switchport_autostate_exclude                   => 'false',
  switchport_mode                                => 'disabled',
  switchport_mode_private_vlan_host              => 'disabled',
  switchport_mode_private_vlan_trunk_promiscuous => 'false',
  switchport_mode_private_vlan_trunk_secondary   => 'false',
  switchport_private_vlan_trunk_native_vlan      => '1',
  switchport_pvlan_host                          => 'false',
  switchport_pvlan_promiscuous                   => 'false',
  switchport_pvlan_trunk_allowed_vlan            => 'none',
  switchport_pvlan_trunk_native_vlan             => '1',
  switchport_pvlan_trunk_promiscuous             => 'false',
  switchport_pvlan_trunk_secondary               => 'false',
  switchport_trunk_allowed_vlan                  => '1-4094',
  switchport_trunk_native_vlan                   => '1',
  vpc_peer_link                                  => 'false',
}
}
```

```puppet
[root@guestshell ~]# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for n9k.example.com
Info: Applying configuration version '1536270834'
Notice: Applied catalog in 12.62 seconds
[root@guestshell ~]# 
```