### PR TITLE
Fix for Cisco-73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The puppet agent software must be installed on a Cisco Nexus platform in the `Gu
 ### Resolved Issues
 * https://tickets.puppetlabs.com/browse/CISCO-63
 * https://tickets.puppetlabs.com/browse/CISCO-66
+* https://tickets.puppetlabs.com/browse/CISCO-73
 * https://tickets.puppetlabs.com/browse/CISCO-75
 * https://tickets.puppetlabs.com/browse/CISCO-76
 

--- a/README.md
+++ b/README.md
@@ -789,9 +789,9 @@ Manages configuration of an Access Control List (ACL) Access Control Entry (ACE)
 | `ttl`                | Not supported on N5k, N6k, N7k |
 | `tcp_option_length`  | ipv4 only <br> Not supported on N5k, N6k, N7k |
 | `vlan             `  | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
-| `set_erspan_gre_proto' | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
-| `set_erspan_dscp'    | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
-| `proto_option'       | Not supported on N5k, N6k. Minimum puppet module version 1.10.0 |
+| `set_erspan_gre_proto` | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
+| `set_erspan_dscp`    | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
+| `proto_option`       | Not supported on N5k, N6k. Minimum puppet module version 1.10.0 |
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Symbol | Meaning | Description
 | [cisco_aaa_<br>authorization_login_exec_svc](#type-cisco_aaa_authorization_login_exec_svc) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [cisco_aaa_group_tacacs](#type-cisco_aaa_group_tacacs)     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | ✅ |
 | [cisco_acl](#type-cisco_acl)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | ✅ |
-| [cisco_ace](#type-cisco_ace)                               | ✅  | ✅  | ✅* | ✅* | ✅* | ✅ | ✅ | \*[caveats](#cisco_ace-caveats) |
+| [cisco_ace](#type-cisco_ace)                               | ✅* | ✅* | ✅* | ✅* | ✅* | ✅*| ✅*| \*[caveats](#cisco_ace-caveats) |
 | [cisco_bfd_global](#type-cisco_bfd_global)                 | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | ✅* | \*[caveats](#cisco_bfd_global-caveats) |
 | [cisco_command_config](#type-cisco_command_config)         | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | ✅ |
 | [cisco_bgp](#type-cisco_bgp)                               | ✅  | ✅  | ✅* | ✅* | ✅* | ✅ | ✅ | \*[caveats](#cisco_bgp-caveats) |
@@ -788,6 +788,10 @@ Manages configuration of an Access Control List (ACL) Access Control Entry (ACE)
 | `time_range`         | Not supported on N5k, N6k |
 | `ttl`                | Not supported on N5k, N6k, N7k |
 | `tcp_option_length`  | ipv4 only <br> Not supported on N5k, N6k, N7k |
+| `vlan             `  | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
+| `set_erspan_gre_proto' | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
+| `set_erspan_dscp'    | Not supported on N5k, N6k, N7k. Minimum puppet module version 1.10.0 |
+| `proto_option'       | Not supported on N5k, N6k. Minimum puppet module version 1.10.0 |
 
 #### Example Usage
 
@@ -952,6 +956,13 @@ The protocol to match against. Valid values are String or Integer. Examples are:
 |:--
 | `proto => 'tcp'`
 
+##### `proto_option`
+Any protocol option which is valid for that protocol. Valid values are string. Currently this is valid only for icmp protocol.
+
+| Example
+|:--
+| `proto_option => 'time-exceeded'`
+
 ##### `redirect`
 (ipv4 only) Allows for redirecting traffic to one or more interfaces. This property is only useful with VLAN ACL (VACL) applications. Valid values are a String containing a list of interface names.
 
@@ -966,6 +977,20 @@ This is a Remark description for the ACL or ACE. Valid values are string.
 | Example
 |:--
 | `remark => 'East Branch'`
+
+##### `set_erspan_dscp`
+Sets ERSPAN outer IP DSCP value. Valid values are beween 1 and 63. Currently this is valid only for icmp protocol.
+
+| Example
+|:--
+| `set_erspan_dscp => '3'`
+
+##### `set_erspan_gre_proto`
+Sets ERSPAN GRE protocol. Valid values are beween 1 and 65535. Currently this is valid only for icmp protocol.
+
+| Example
+|:--
+| `set_erspan_gre_proto => '300'`
 
 ##### `src_addr`
 The Source Address to match against. Valid values are type String, which must be one of the following forms:
@@ -1029,6 +1054,13 @@ Allows matching based on Time-To-Live (TTL) value. Valid values are type Integer
 | Example
 |:--
 | `ttl => '128'`
+
+##### `vlan`
+Configure match based on vlan. Valid values are between 0 and 4095. Currently this is valid only for icmp protocol.
+
+| Example
+|:--
+| `vlan => '100'`
 
 --
 ### Type: cisco_bfd_global

--- a/lib/puppet/provider/cisco_ace/cisco.rb
+++ b/lib/puppet/provider/cisco_ace/cisco.rb
@@ -1,6 +1,6 @@
 # January 2016
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,10 @@ Puppet::Type.type(:cisco_ace).provide(:cisco) do
     :http_method,
     :tcp_option_length,
     :redirect,
+    :set_erspan_dscp,
+    :set_erspan_gre_proto,
+    :vlan,
+    :proto_option,
     :remark,
   ]
 
@@ -173,6 +177,10 @@ Puppet::Type.type(:cisco_ace).provide(:cisco) do
       :http_method,
       :tcp_option_length,
       :redirect,
+      :set_erspan_dscp,
+      :set_erspan_gre_proto,
+      :vlan,
+      :proto_option,
       :log,
     ]
     if vars.any? { |p| @property_flush.key?(p) }

--- a/lib/puppet/type/cisco_ace.rb
+++ b/lib/puppet/type/cisco_ace.rb
@@ -2,7 +2,7 @@
 #
 # January 2016
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,18 @@ Puppet::Type.newtype(:cisco_ace) do
         time_range                            => 'my_range',
         ttl                                   => '153',
         redirect                              => 'Ethernet1/1,Ethernet1/2,port-channel1',
+        log                                   => false,
+    }
+    cisco_ace { 'ipv4 my_icmp_acl 20':
+        action                                => 'permit',
+        proto                                 => 'icmp',
+        src_addr                              => 'any',
+        dst_addr                              => 'any',
+        dscp                                  => 'af11',
+        set_erspan_dscp                       => '3',
+        set_erspan_gre_proto                  => '300',
+        proto_option                          => 'time-exceeded',
+        vlan                                  => '2',
         log                                   => false,
     }
   ~~~
@@ -287,6 +299,26 @@ Puppet::Type.newtype(:cisco_ace) do
          'Ethernet1/2,port-channel1'
   end
 
+  newproperty(:proto_option) do
+    desc 'Any protocol option. Example: time-exceeded. Valid values are string.'\
+         'Currently this is valid only for icmp protocol.'
+  end
+
+  newproperty(:set_erspan_dscp) do
+    desc 'Set ERSPAN outer IP DSCP value. Valid values are bw 1 and 63'\
+         'Currently this is valid only for icmp protocol.'
+  end
+
+  newproperty(:set_erspan_gre_proto) do
+    desc 'Set ERSPAN GRE protocol. Valid values are bw 1 and 65535'\
+         'Currently this is valid only for icmp protocol.'
+  end
+
+  newproperty(:vlan) do
+    desc 'Configure match based on vlan. Valid values are bw 0 and 4095'\
+         'Currently this is valid only for icmp protocol.'
+  end
+
   newproperty(:log) do
     desc 'Log matches against this entry'
     newvalues(:true, :false)
@@ -295,8 +327,8 @@ Puppet::Type.newtype(:cisco_ace) do
   validate do
     unless self[:remark].nil?
       fail ArgumentError,
-           "'established' and 'log' properties should not be set for remark ace" unless
-        self[:log].nil? && self[:established].nil?
+           "'established', 'proto_option' and 'log' properties should not be set for remark ace" unless
+        self[:log].nil? && self[:established].nil? && self[:proto_option].nil?
     end
   end
 end

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -153,7 +153,6 @@ def unsupported_properties(tests, id)
       unprops <<
         :proto_option <<
         :packet_length <<
-        :proto_option <<
         :time_range
     end
     if platform[/n(5|6|7)k/]

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -102,6 +102,38 @@ tests[:seq_30_v4] = {
   },
 }
 
+tests[:seq_40_icmp_v4] = {
+  desc:           'IPv4 Seq 40',
+  title_pattern:  'ipv4 beaker icmp 40',
+  manifest_props: {
+    action:               'deny',
+    proto:                'icmp',
+    src_addr:             'any',
+    dst_addr:             'any',
+    proto_option:         'time-exceeded',
+    dscp:                 'af12',
+    log:                  'true',
+    redirect:             'port-channel10',
+    set_erspan_dscp:      '3',
+    set_erspan_gre_proto: '300',
+  },
+}
+
+tests[:seq_50_icmp_v4] = {
+  desc:           'IPv4 Seq 50',
+  title_pattern:  'ipv4 beaker icmp 50',
+  manifest_props: {
+    action:       'deny',
+    proto:        'icmp',
+    src_addr:     'any',
+    dst_addr:     'any',
+    proto_option: 'fragments',
+    dscp:         'af11',
+    log:          'true',
+    ttl:          '10',
+    vlan:         '100',
+  },
+}
 # Overridden to properly handle unsupported properties for this test file.
 def unsupported_properties(tests, id)
   unprops = []
@@ -119,14 +151,19 @@ def unsupported_properties(tests, id)
     end
     if platform[/n(5|6)k/]
       unprops <<
+        :proto_option <<
         :packet_length <<
+        :proto_option <<
         :time_range
     end
     if platform[/n(5|6|7)k/]
       unprops <<
         :http_method <<
         :redirect <<
+        :vlan <<
         :tcp_option_length <<
+        :set_erspan_dscp <<
+        :set_erspan_gre_proto <<
         :ttl
     end
   end
@@ -150,6 +187,8 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   test_harness_run(tests, :seq_20_v4)
   test_harness_run(tests, :seq_20_v6)
   test_harness_run(tests, :seq_30_v4)
+  test_harness_run(tests, :seq_40_icmp_v4)
+  test_harness_run(tests, :seq_50_icmp_v4)
 
   # ---------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -104,7 +104,7 @@ tests[:seq_30_v4] = {
 
 tests[:seq_40_icmp_v4] = {
   desc:           'IPv4 Seq 40',
-  title_pattern:  'ipv4 beaker icmp 40',
+  title_pattern:  'ipv4 beaker 40',
   manifest_props: {
     action:               'deny',
     proto:                'icmp',
@@ -121,7 +121,7 @@ tests[:seq_40_icmp_v4] = {
 
 tests[:seq_50_icmp_v4] = {
   desc:           'IPv4 Seq 50',
-  title_pattern:  'ipv4 beaker icmp 50',
+  title_pattern:  'ipv4 beaker 50',
   manifest_props: {
     action:       'deny',
     proto:        'icmp',

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -116,6 +116,7 @@ tests[:seq_40_icmp_v4] = {
     redirect:             'port-channel10',
     set_erspan_dscp:      '3',
     set_erspan_gre_proto: '300',
+    vlan:                 '100',
   },
 }
 

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR is for fixing issue cisco-73
https://tickets.puppetlabs.com/browse/CISCO-73

Tested on n7k, n3k and n9k.

For this config suggested in the bug:

```
ip access-list test-icp
  10 permit icmp any any echo dscp af11
  20 permit icmp any any precedence critical fragments
  30 permit icmp any any dscp af12
```

Here is the puppet resource output:
```
cisco_ace { 'ipv4 test-icp 10':            
  ensure       => 'present',               
  action       => 'permit',                
  dscp         => 'af11',                  
  dst_addr     => 'any',                   
  established  => 'false',                 
  log          => 'false',                 
  proto        => 'icmp',
  proto_option => 'echo',
  src_addr     => 'any',
}
cisco_ace { 'ipv4 test-icp 20':
  ensure       => 'present',
  action       => 'permit',
  dst_addr     => 'any',
  established  => 'false',
  log          => 'false',
  precedence   => 'critical',
  proto        => 'icmp',
  proto_option => 'fragments',
  src_addr     => 'any',
}
cisco_ace { 'ipv4 test-icp 30':
  ensure      => 'present',
  action      => 'permit',
  dscp        => 'af12',
  dst_addr    => 'any',
  established => 'false',
  log         => 'false',
  proto       => 'icmp',
  src_addr    => 'any',
}
```