### PR TITLE
fix test_route_map beaker test for I9

### DIFF
--- a/tests/beaker_tests/cisco_route_map/test_route_map.rb
+++ b/tests/beaker_tests/cisco_route_map/test_route_map.rb
@@ -26,7 +26,7 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
 # In I7 match_src_proto order is not maintained in running config.
 # This behavior is currently observed only on the N9K.
-if platform[/n9k/] && image_version.to_s.strip[/I7/]
+if platform[/n9k/] && image_version.to_s.strip[/I(7|8|9)/]
   @src_proto = %w(udp igmp tcp)
 else
   @src_proto = %w(tcp udp igmp)

--- a/tests/beaker_tests/cisco_upgrade/test_upgrade_idempotence.rb
+++ b/tests/beaker_tests/cisco_upgrade/test_upgrade_idempotence.rb
@@ -23,7 +23,11 @@
 ###############################################################################
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 @package = on(agent, facter_cmd('-p cisco.images.system_image')).stdout.chomp
-@version = image_version.to_s.strip
+if platform[/n9k/] && image_version.to_s.strip[/I9/]
+  @version = image_version.to_s.strip.split('I', 2)[0]
+else
+  @version = image_version.to_s.strip
+end
 # Test hash top-level keys
 tests = {
   master:           master,


### PR DESCRIPTION
Fixes the test_route_map ordering issue on 9k.