### PR TITLE
Fixes for n9k-f and n3k-f

### DIFF
--- a/README.md
+++ b/README.md
@@ -5086,8 +5086,8 @@ Creates a Virtual Network Identifier member (VNI) for an NVE overlay interface.
 
 | Property                        | Caveat Description                   |
 |---------------------------------|--------------------------------------|
-| ingress_replication             | Not supported on N3k, N5k, N6k, N7k  |
-| peer_list                       | Not supported on N3k, N5k, N6k, N7k  |
+| ingress_replication             | Not supported on N3k, N5k, N6k, N7k, N3k-F, N9k-F  |
+| peer_list                       | Not supported on N3k, N5k, N6k, N7k, N3k-F, N9k-F  |
 | suppress_uuc                    | Not supported on N3k, N3k-F, N9k, N9k-F <br> Supported in OS Version 8.1.1 and later on N7k |
 | multisite_ingress_replication | Only supported on N9K-EX and N9K-FX devices. For eg: N9K-C93180YC-EX. Minimum OS version 7.0(3)I7(1) and minimum Module Version 1.9.0 |
 

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Symbol | Meaning | Description
 | [cisco_vpc_domain](#type-cisco_vpc_domain)                 | ✅* | ✅* | ✅* | ✅* | ✅* | ➖ | \*[caveats](#cisco_vpc_domain-caveats) |
 | [cisco_vrf](#type-cisco_vrf)                               | ✅  | ✅* | ✅  | ✅  | ✅ | ✅ | ✅ | \*[caveats](#cisco_vrf-caveats) |
 | [cisco_vrf_af](#type-cisco_vrf_af)                         | ✅  | ✅* | ✅* | ✅* | ✅* | ✅ | ✅ | \*[caveats](#cisco_vrf_af-caveats) |
-| [cisco_vtp](#type-cisco_vtp)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | ✅ |
+| [cisco_vtp](#type-cisco_vtp)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ➖ | ➖ |
 | [cisco_vxlan_vtep](#type-cisco_vxlan_vtep)                 | ✅  | ➖ | ✅  | ✅  | ✅* | ✅ | ✅ | \*[caveats](#cisco_vxlan_vtep-caveats) |
 | [cisco_vxlan_vtep_vni](#type-cisco_vxlan_vtep_vni)         | ✅  | ➖ | ✅  | ✅  | ✅  | ✅ | ✅ | \*[caveats](#cisco_vxlan_vtep_vni-caveats) |
 
@@ -746,12 +746,14 @@ Manages configuration of a Access Control List (ACL) instance.
 | N5k      | 7.3(0)N1(1)        | 1.3.0                  |
 | N6k      | 7.3(0)N1(1)        | 1.3.0                  |
 | N7k      | 7.3(0)D1(1)        | 1.3.0                  |
+| N9k-F    | 9.2.1              | 1.10.0                 |
+| N3k-F    | 9.2.1              | 1.10.0                 |
 
 #### <a name="cisco_acl-caveats">Caveats</a>
 
 | Property | Caveat Description |
 |:--------|:-------------|
-| `fragments` | Not supported on N5k, N6k |
+| `fragments` | Not supported on N5k, N6k, N9k-F, N3k-F |
 
 #### Parameters
 

--- a/examples/cisco/demo_acl.pp
+++ b/examples/cisco/demo_acl.pp
@@ -17,7 +17,7 @@
 class ciscopuppet::cisco::demo_acl {
 
   $fragments = platform_get() ? {
-    /(n3k|n7k|n3k-f|n9k-f|n9k)/  => 'permit',
+    /(n3|n7|n9)k$/  => 'permit',
     default                => undef
   }
 

--- a/examples/cisco/demo_vtp.pp
+++ b/examples/cisco/demo_vtp.pp
@@ -16,7 +16,7 @@
 
 class ciscopuppet::cisco::demo_vtp {
 
-  if platform_get() =~ /n(3|5|6|7|8|9)k$/ {
+  if platform_get() =~ /n(3|5|6|7|9)k$/ {
 
     cisco_vtp { 'default':
       ensure   => present,

--- a/examples/cisco/demo_vtp.pp
+++ b/examples/cisco/demo_vtp.pp
@@ -15,11 +15,16 @@
 # limitations under the License.
 
 class ciscopuppet::cisco::demo_vtp {
-  cisco_vtp { 'default':
-    ensure   => present,
-    domain   => 'cisco1234',
-    password => 'test1234',
-    version  => 2,
-    filename => 'bootflash:/vlan.dat'
+
+  if platform_get() =~ /n(3|5|6|7|8|9)k$/ {
+
+    cisco_vtp { 'default':
+      ensure   => present,
+      domain   => 'cisco1234',
+      password => 'test1234',
+      version  => 2,
+      filename => 'bootflash:/vlan.dat'
+  } else {
+    notify{'SKIP: This platform does not support vtp': }
   }
 }

--- a/examples/cisco/demo_vxlan.pp
+++ b/examples/cisco/demo_vxlan.pp
@@ -18,7 +18,7 @@
 
 class ciscopuppet::cisco::demo_vxlan {
 
-  if platform_get() =~ /n(5|6|7|8|9)k/ {
+  if platform_get() =~ /n(5|6|7|9)k/ {
 
     if platform_get() =~ /n7k/ {
       cisco_vdc { 'default':
@@ -36,17 +36,17 @@ class ciscopuppet::cisco::demo_vxlan {
     }
 
     $source_interface_hold_down_time = platform_get() ? {
-      /n(8|9)k/  => '50',
+      /n9k/  => '50',
       default    => undef,
     }
 
     $ingress_replication = platform_get() ? {
-      /n(8|9)k/  => 'static',
+      /n9k$/  => 'static',
       default    => undef,
     }
 
     $peer_list = platform_get() ? {
-      /n(8|9)k/  => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
+      /n9k$/  => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
       default    => undef,
     }
 

--- a/lib/puppet/parser/functions/platform_fretta.rb
+++ b/lib/puppet/parser/functions/platform_fretta.rb
@@ -25,11 +25,13 @@ module Puppet
     #
     module Functions
       newfunction(:platform_fretta, type: :rvalue) do |_args|
-        data = lookupvar('os')
+        data = lookupvar('cisco')
         return '' if data.nil?
 
-        pat = '7.0\(3\)F'
-        data['release']['full'].match(pat) ? true : false
+        data['inventory'].each do |_x, slot|
+          return true if slot['pid'][/-R/]
+        end
+        false
       end
     end
   end

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -243,6 +243,14 @@ module PuppetX
         ranges.join(',').gsub('..', '-')
       end
 
+      # fretta check
+      def self.check_slot_pid(inv)
+        inv.each do |_x, slot|
+          return true if slot['pid'][/-R/]
+        end
+        false
+      end
+
       def self.product_tag
         data = Facter.value('cisco')
         case data['inventory']['chassis']['pid']
@@ -255,7 +263,7 @@ module PuppetX
         when /N7/
           tag = 'n7k'
         when /N9/
-          tag = data['images']['full_version'][/7.0.3.F/] ? 'n9k-f' : 'n9k'
+          tag = check_slot_pid(data['inventory']) ? 'n9k-f' : 'n9k'
         else
           fail "Unrecognized product_id: #{data['inventory']['chassis']['pid']}"
         end

--- a/lib/puppet_x/cisco/cmnutils.rb
+++ b/lib/puppet_x/cisco/cmnutils.rb
@@ -255,7 +255,7 @@ module PuppetX
         data = Facter.value('cisco')
         case data['inventory']['chassis']['pid']
         when /N3/
-          tag = data['images']['full_version'][/7.0.3.F/] ? 'n3k-f' : 'n3k'
+          tag = check_slot_pid(data['inventory']) ? 'n3k-f' : 'n3k'
         when /N5/
           tag = 'n5k'
         when /N6/

--- a/tests/beaker_tests/cisco_acl/test_acl.rb
+++ b/tests/beaker_tests/cisco_acl/test_acl.rb
@@ -83,7 +83,7 @@ def unsupported_properties(_tests, _id)
     # unprops << TBD: XR Support
 
   else
-    unprops << :fragments if platform[/n(5|6)k/]
+    unprops << :fragments if platform[/n(3k-f|5k|6k|9k-f)/]
   end
 
   unprops

--- a/tests/beaker_tests/cisco_evpn_multicast/test_evpn_multicast.rb
+++ b/tests/beaker_tests/cisco_evpn_multicast/test_evpn_multicast.rb
@@ -27,7 +27,7 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 tests = {
   agent:         agent,
   master:        master,
-  platform:      'n9k',
+  platform:      'n9k$|n9k-ex',
   resource_name: 'cisco_evpn_multicast',
 }
 

--- a/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
+++ b/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
@@ -27,7 +27,7 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 tests = {
   agent:         agent,
   master:        master,
-  platform:      'n9k',
+  platform:      'n9k$|n9k-ex',
   resource_name: 'cisco_ip_multicast',
 }
 

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
@@ -63,6 +63,8 @@ testheader = 'VTP Resource :: All Attributes Defaults'
 
 # @test_name [TestCase] Executes defaults testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
+  raise_skip_exception('Not supported on fretta', self) if
+    platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
@@ -61,6 +61,8 @@ testheader = 'VTP Resource :: All Attributes Negatives'
 
 # @test_name [TestCase] Executes negatives testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
+  raise_skip_exception('Not supported on fretta', self) if
+    platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
@@ -63,6 +63,8 @@ testheader = 'VTP Resource :: All Attributes NonDefaults'
 
 # @test_name [TestCase] Executes nondefaults testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
+  raise_skip_exception('Not supported on fretta', self) if
+    platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -70,7 +70,7 @@ skip_unless_supported(tests)
 tests[:default_properties_ingress_replication] = {
   desc:           '1.1 Default Properties Ingress replication',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication:           'default',
     suppress_arp:                  'default',
@@ -101,7 +101,7 @@ tests[:default_properties_multicast_group] = {
 tests[:ingress_replication_static_peer_list_empty] = {
   desc:           '2.1 Ingress Replication Static Peer List Empty',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication: 'static',
     peer_list:           [],
@@ -116,7 +116,7 @@ tests[:ingress_replication_static_peer_list_empty] = {
 tests[:peer_list] = {
   desc:           '2.2 Peer List',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication: 'static',
     peer_list:           ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
@@ -131,7 +131,7 @@ tests[:peer_list] = {
 tests[:peer_list_change_add] = {
   desc:           '2.3 Peer List Change Add',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication: 'static',
     peer_list:           ['1.1.1.1', '6.6.6.6', '3.3.3.3', '4.4.4.4'],
@@ -146,7 +146,7 @@ tests[:peer_list_change_add] = {
 tests[:peer_list_default] = {
   desc:           '2.4 Peer List Default',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication: 'static',
     peer_list:           'default',
@@ -161,7 +161,7 @@ tests[:peer_list_default] = {
 tests[:ingress_replication_bgp] = {
   desc:           '2.5 Ingress replication BGP',
   title_pattern:  'nve1 10000',
-  platform:       'n(3k-f|9k)',
+  platform:       'n9k$',
   manifest_props: {
     ingress_replication: 'bgp',
     suppress_arp:        'default',
@@ -257,11 +257,12 @@ end
 
 def unsupported_properties(_tests, _id)
   unprops = []
-  if platform[/n(5|6|7)k/]
+  if platform[/n(3k-f|5k|6k|7k|9k-f)/]
     unprops <<
       :ingress_replication <<
       :peer_list
-  elsif platform[/n(3k-f|9k)/]
+  end
+  if platform[/n(3k-f|9k)/]
     unprops <<
       :suppress_uuc
   end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1157,11 +1157,12 @@ end
 def fretta?(reset_cache=false)
   return @fretta_slot unless @fretta_slot.nil? || reset_cache
   data = on(agent, facter_cmd('-p cisco.inventory')).output.split("\n")
+  @fretta_slot = false
   data.each do |line|
     next unless line.include?('pid =>')
-    return true if line[/-R/]
+    @fretta_slot = true if line[/-R/]
   end
-  false
+  @fretta_slot
 end
 
 # Check if image matches pattern

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1142,7 +1142,7 @@ def platform
   when /Nexus\s?9\d+\s\S+-EX/
     @cisco_hardware = 'n9k-ex'
   when /(Nexus\s?9\d\d\d|NX-OSv Chassis)/
-    @cisco_hardware = image?[/7.0.3.F/] ? 'n9k-f' : 'n9k'
+    @cisco_hardware = fretta? ? 'n9k-f' : 'n9k'
   when /XRv9K/i
     @cisco_hardware = 'xrv9k'
   else
@@ -1150,6 +1150,18 @@ def platform
   end
   logger.info "\nFound Platform string: '#{pi}', Alias to: '#{@cisco_hardware}'"
   @cisco_hardware
+end
+
+# fretta check
+@fretta_slot = nil
+def fretta?(reset_cache=false)
+  return @fretta_slot unless @fretta_slot.nil? || reset_cache
+  data = on(agent, facter_cmd('-p cisco.inventory')).output.split("\n")
+  data.each do |line|
+    next unless line.include?('pid =>')
+    return true if line[/-R/]
+  end
+  false
 end
 
 # Check if image matches pattern

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1132,7 +1132,7 @@ def platform
   # - Cisco XRv9K Virtual Router
   case pi
   when /Nexus\s?3\d\d\d/
-    @cisco_hardware = image?[/7.0.3.F/] ? 'n3k-f' : 'n3k'
+    @cisco_hardware = fretta? ? 'n3k-f' : 'n3k'
   when /Nexus\s?5\d\d\d/
     @cisco_hardware = 'n5k'
   when /Nexus\s?6\d\d\d/


### PR DESCRIPTION
* This PR is for fixing beaker tests and software versioning scheme which changed from older versions to latest versions on n3k-f and n9k-f.
* Some of the features like vtp, acl, vxlan_vtp_vni etc. have a different behavior for these platforms and this is addressed.

All tests pass on n9k, n9k-f, n3k-f