### PR TITLE
bgp timer name correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,7 +1320,7 @@ Specify timeout for the first best path after a restart, in seconds. Valid value
 ##### `timer_bestpath_limit_always`
 Enable/Disable update-delay-always option. Valid values are 'true', 'false', and 'default'.
 
-##### `timer_bgp_hold`
+##### `timer_bgp_holdtime`
 Set bgp hold timer. Valid values are Integer, keyword 'default'.
 
 ##### `timer_bgp_keepalive`

--- a/README.md
+++ b/README.md
@@ -2301,7 +2301,7 @@ Notes about `ensure => present` and `ensure => absent` on physical ethernet inte
 * Physical interfaces will be displayed as `ensure => absent` by the `puppet resource` command when they are in a default state.
 
 ###### `interface`
-Name of the interface on the network element. Valid value is a string.
+Name of the interface on the network element. No white space allowed in the name. Valid value is a string.
 
 #### Properties
 


### PR DESCRIPTION
This PR is for fixing a documentation error. 
The ```timer_bgp_holdtime``` is mentioned in the README file as ```timer_bgp_hold```. This is corrected.
Also the interface name should not have white space is mentioned.