### PR TITLE
Add 'redistribute' attribute to cisco_ospf_vrf provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ cache: bundler
 rvm:
   - 2.4.4
   - 2.1.9
+
+before_install:
+ - gem install bundler -v '< 2'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### New feature support
 
 ### Added
+* Extended `cisco_ospf_vrf` with attribute:
+   * `redistribute`
 * Extended `cisco_vpc_domain` with attributes:
    * `arp_synchronize`
    * `nd_synchronize`

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Symbol | Meaning | Description
 | [cisco_ip_multicast](#type-cisco_ip_multicast)         | ✅ * | ➖ | ➖  | ➖  | ➖   | ➖  | ➖  | \*[caveats](#cisco_ip_multicast-caveats) |
 | [cisco_itd_device_group](#type-cisco_itd_device_group)           | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
 | [cisco_itd_device_group_node](#type-cisco_itd_device_group_node) | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
-| [cisco_itd_service](#type-cisco_itd_service)                     | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
+| [cisco_itd_service](#type-cisco_itd_service)                     | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ | \*[caveats](#cisco_itd_service-caveats) |
 | [cisco_object_group](#type-cisco_object_group)             | ✅  | ✅  | ➖ | ➖  | ✅ | ✅ | ✅ |
 | [cisco_object_group_entry](#type-cisco_object_group_entry) | ✅  | ✅  | ➖ | ➖  | ✅ | ✅ | ✅ |
 | [cisco_ospf](#type-cisco_ospf)                             | ✅  | ✅  | ✅ | ✅  | ✅ | ✅ | ✅ |
@@ -3536,7 +3536,7 @@ Manages a VRF for an OSPF router.
 
 | Property | Caveat Description |
 |:-------------------|:-------------|
-| `redistribute`  | Minimum Module Version 1.11.0<br>No support for `redistribute maximum-prefixes` |
+| `redistribute`  | Minimum Module Version 2.0.0<br>No support for `redistribute maximum-prefixes` |
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -506,11 +506,11 @@ Symbol | Meaning | Description
 | [cisco_ip_multicast](#type-cisco_ip_multicast)         | ✅ * | ➖ | ➖  | ➖  | ➖   | ➖  | ➖  | \*[caveats](#cisco_ip_multicast-caveats) |
 | [cisco_itd_device_group](#type-cisco_itd_device_group)           | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
 | [cisco_itd_device_group_node](#type-cisco_itd_device_group_node) | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
-| [cisco_itd_service](#type-cisco_itd_service)                     | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ | \*[caveats](#cisco_itd_service-caveats) |
+| [cisco_itd_service](#type-cisco_itd_service)                     | ✅ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
 | [cisco_object_group](#type-cisco_object_group)             | ✅  | ✅  | ➖ | ➖  | ✅ | ✅ | ✅ |
 | [cisco_object_group_entry](#type-cisco_object_group_entry) | ✅  | ✅  | ➖ | ➖  | ✅ | ✅ | ✅ |
 | [cisco_ospf](#type-cisco_ospf)                             | ✅  | ✅  | ✅ | ✅  | ✅ | ✅ | ✅ |
-| [cisco_ospf_vrf](#type-cisco_ospf_vrf)                     | ✅  | ✅  | ✅ | ✅  | ✅ | ✅ | ✅ |
+| [cisco_ospf_vrf](#type-cisco_ospf_vrf)                     | ✅  | ✅  | ✅ | ✅  | ✅ | ✅ | ✅ | \*[caveats](#cisco_ospf_vrf-caveats) |
 | ✅ = Supported <br> ➖ = Not Applicable | N9k | N3k | N5k | N6k | N7k | N9k-F | N3k-F | Caveats |
 | [cisco_overlay_global](#type-cisco_overlay_global)         | ✅  | ✅* | ✅  | ✅  | ✅  | ✅ | ✅ | \*[caveats](#cisco_overlay_global-caveats) |
 | [cisco_pim](#type-cisco_pim)                               | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | ✅ | \*[caveats](#cisco_pim-caveats) |
@@ -3532,6 +3532,12 @@ Manages a VRF for an OSPF router.
 | N9k-F    | 7.0(3)F1(1)        | 1.5.0                  |
 | N3k-F    | 7.0(3)F3(2)        | 1.8.0                  |
 
+#### <a name="cisco_ospf_vrf-caveats">Caveats</a>
+
+| Property | Caveat Description |
+|:-------------------|:-------------|
+| `redistribute`  | Minimum Module Version 1.11.0<br>No support for `redistribute maximum-prefixes` |
+
 #### Parameters
 
 ##### `ensure`
@@ -3557,6 +3563,23 @@ Specify the default Metric value. Valid values are an  integer or the keyword
 ##### `log_adjacency`
 Controls the level of log messages generated whenever a neighbor changes state.
 Valid values are 'log', 'detail', 'none', and 'default'.
+
+##### `redistribute`
+A list of redistribute directives. Multiple redistribute entries are allowed. The list must be in the form of a nested array: the first entry of each array defines the source-protocol to redistribute from; the second entry defines a route-map name.
+
+Example:
+
+```ruby
+redistribute => [['direct',  'rm_direct'],
+                 ['lisp',    'rm_lisp'],
+                 ['static',  'rm_static'],
+                 ['eigrp 1', 'rm_eigrp'],
+                 ['isis 2',  'rm_isis'],
+                 ['ospf 3',  'rm_ospf'],
+                 ['rip 4',   'rm_rip']]
+```
+
+Note: `redistribute maximum-prefixes` is not currently supported for cisco_ospf_vrf.
 
 ##### `timer_throttle_lsa_start`
 Specify the start interval for rate-limiting Link-State Advertisement (LSA)

--- a/examples/cisco/demo_ospf.pp
+++ b/examples/cisco/demo_ospf.pp
@@ -51,6 +51,7 @@ class ciscopuppet::cisco::demo_ospf {
     bfd                      => true,
     default_metric           => '5',
     log_adjacency            => 'detail',
+    redistribute             => [['eigrp 1', 'rtmap_eigrp_1'], ['direct',  'rtmap_direct']]
     timer_throttle_lsa_hold  => '5500',
     timer_throttle_lsa_max   => '5600',
     timer_throttle_lsa_start => '5',
@@ -65,6 +66,7 @@ class ciscopuppet::cisco::demo_ospf {
     bfd                      => true,
     default_metric           => '10',
     log_adjacency            => 'log',
+    redistribute             => [['direct',  'rtmap_direct_2']]
     timer_throttle_lsa_hold  => '5600',
     timer_throttle_lsa_max   => '5800',
     timer_throttle_lsa_start => '8',

--- a/lib/puppet/type/cisco_ospf_vrf.rb
+++ b/lib/puppet/type/cisco_ospf_vrf.rb
@@ -28,12 +28,16 @@ Puppet::Type.newtype(:cisco_ospf_vrf) do
   <ospf> is the name of the ospf router instance. <vrf> is the name of the ospf vrf.
 
   Example:
+
+    $redistribute = [['bgp 1', 'rtmap_29'], ['direct',  'rtmap_direct']]
+
     cisco_ospf_vrf {\"green test\":
       ensure                   => present,
       router_id                => \"192.168.1.1\",
       bfd                      => true,
       default_metric           => 2,
       log_adjancency           => log,
+      redistribute             => $redistribute,
       timer_throttle_lsa_start => 0,
       timer_throttle_lsa_hold  => 5000,
       timer_throttle_lsa_max   => 5000,
@@ -143,6 +147,30 @@ Puppet::Type.newtype(:cisco_ospf_vrf) do
       :none,
       :default)
   end # property log adjacency
+
+  newproperty(:redistribute, array_matching: :all) do
+    format = "[['protocol', 'route_map'],['protocol', 'route_map']]"
+    desc 'A list of redistribute directives. Multiple redistribute entries ' \
+         'are allowed. The list must be in the form of a nested array: the ' \
+         'first entry of each array defines the source-protocol to ' \
+         'redistribute from; the second entry defines a route-map name. ' \
+         'There is currently no support for redistribute maximum-prefix'
+
+    # Override puppet's insync method, which checks whether current value is
+    # equal to value specified in manifest.  Make sure puppet considers
+    # 2 arrays with same elements but in different order as equal.
+    def insync?(is)
+      (is.size == should.size && is.sort == should.sort)
+    end
+
+    munge do |value|
+      begin
+        return value = :default if value == 'default'
+        fail("Value must match format #{format}") unless value.is_a?(Array)
+        value
+      end
+    end
+  end # property :redistribute
 
   newproperty(:timer_throttle_lsa_start) do
     desc "Specify the start interval for rate-limiting Link-State

--- a/tests/beaker_tests/cisco_ospf_vrf/test_ospf_vrf.rb
+++ b/tests/beaker_tests/cisco_ospf_vrf/test_ospf_vrf.rb
@@ -41,6 +41,7 @@ tests[:default_1] = {
     bfd:                      'default',
     default_metric:           'default',
     log_adjacency:            'default',
+    redistribute:             'default',
     timer_throttle_lsa_hold:  'default',
     timer_throttle_lsa_max:   'default',
     timer_throttle_lsa_start: 'default',
@@ -54,6 +55,7 @@ tests[:default_1] = {
     bfd:                      'false',
     default_metric:           '0',
     log_adjacency:            'none',
+    # 'redistribute' is nil when default
     timer_throttle_lsa_hold:  '5000',
     timer_throttle_lsa_max:   '5000',
     timer_throttle_lsa_start: '0',
@@ -130,6 +132,29 @@ tests[:non_default_2] = {
   },
 }
 
+# rubocop:disable Style/WordArray
+redistribute = [
+  ['bgp 5',   'rm_bgp'],
+  ['direct',  'rm_direct'],
+  ['eigrp 1', 'rm_eigrp'],
+  ['isis 2',  'rm_isis'],
+  ['lisp',    'rm_lisp'],
+  ['ospf 3',  'rm_ospf'],
+  ['rip 4',   'rm_rip'],
+  ['static',  'rm_static'],
+]
+# rubocop:enable Style/WordArray
+tests[:non_default_arrays] = {
+  desc:           '2.3 Non Default Properties: Arrays',
+  title_pattern:  'test green',
+  manifest_props: {
+    redistribute: redistribute
+  },
+  resource:       {
+    redistribute: "#{redistribute}"
+  },
+}
+
 def cleanup(agent)
   test_set(agent, 'no feature ospf ; no feature bfd')
 end
@@ -155,6 +180,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   test_harness_run(tests, :non_default_1)
   test_harness_run(tests, :non_default_2)
+  test_harness_run(tests, :non_default_arrays)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
This adds `redistribute` (from source protocol) support to router ospf via the `cisco_ospf_vrf` type/provider.

Note: route-maps are not optional with router ospf (redistribute from source protocol)
Note: `redistribute maximum-prefix` is not currently supported.

Travis bundler issue:  https://docs.travis-ci.com/user/languages/ruby/#bundler-20

runci test results: http://earms-trade.cisco.com/tradeui/resultsviewer.faces?ats=/auto/rtp-core/ats_shared/users/cvanheuv&client=web&host=rtp-ads-359&archive=/auto/rtp-core/ats_shared/users/cvanheuv/users/cvanheuv/archive/19-01/agents_job.2019Jan07_08:45:47.328021.zip

Resolves https://github.com/cisco/cisco-network-puppet-module/issues/531