### PR TITLE
More idempotence logging please

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -437,8 +437,11 @@ DEVICE
         # if !$?.exitstatus == 0
         #   raise 'Errored idempotence test'
         # end
-        output = `#{agentless_command} --apply #{@temp_agentless_manifest.path}`
+        cmd = "#{agentless_command} --apply #{@temp_agentless_manifest.path}"
+        output = `#{cmd}`
         if output.include? "#{tests[:resource_name]}[#{tests[id][:title_pattern]}]: Updating:"
+          logger.info("Idempotence Command: #{cmd}")
+          logger.info("Command Result: #{output}")
           raise 'Errored idempotence test'
         end
       end


### PR DESCRIPTION
Logs important info on failure.

Now we get something like this:

```
  * TestStep :: 1.1 Create Radius Server Manifest Present :: IDEMPOTENCE 
    test_idempotence :: BEGIN
    Idempotence Command: bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures/modules --deviceconfig /tmp/acceptance-device20190207-30317-d6q6kl.conf --target sut --libdir lib/  --apply /tmp/temp_test_apply20190207-30317-1bifdkw
    Command Result: Notice: Compiled catalog for sut in environment production in 0.17 seconds
    Info: Applying configuration version '1549572024'
    Notice: /Stage[main]/Main/Radius_server[8.8.8.8]/key: key changed '\'44444444\'' to '44444444'
    Notice: radius_server[8.8.8.8]: Updating: Updating '8.8.8.8' with {:name=>"8.8.8.8", :ensure=>"present", :auth_port=>77, :acct_port=>66, :key=>"44444444", :key_format=>7, :timeout=>2, :retransmit_count=>4, :accounting_only=>true, :authentication_only=>true}
    Notice: radius_server[8.8.8.8]: Updating: Finished in 7.04 seconds
    Info: Class[Main]: Unscheduling all events on Class[Main]
    Notice: Applied catalog in 7.57 seconds
RuntimeError: Errored idempotence test
```