### PR TITLE
(maint) clearing down the node environment on new device instances

### DIFF
--- a/lib/puppet/util/network_device/cisco_nexus/device.rb
+++ b/lib/puppet/util/network_device/cisco_nexus/device.rb
@@ -6,6 +6,9 @@ module Puppet::Util::NetworkDevice::Cisco_nexus # rubocop:disable Style/ClassAnd
   class Device < Puppet::Util::NetworkDevice::Simple::Device
     def initialize(url_or_config, _options={})
       super
+      unless Cisco::Environment.environments.empty?
+        Cisco::Node.reset_instance # Clears the previous environment from nodeutil caches
+      end
       Cisco::Environment.add_env('default',
                                  host:        config['address'],
                                  port:        config['port'],

--- a/tests/beaker_tests/cisco_ospf_vrf/test_ospf_vrf.rb
+++ b/tests/beaker_tests/cisco_ospf_vrf/test_ospf_vrf.rb
@@ -152,8 +152,6 @@ tests[:non_default_arrays] = {
     redistribute: "#{redistribute}"
   },
 }
-
-# rubocop:disable Style/WordArray
 redistribute = [
   ['bgp 5',   'rm_bgp'],
   ['direct',  'rm_direct'],


### PR DESCRIPTION
Refer to https://github.com/cisco/cisco-network-node-utils/pull/601#issuecomment-440338013 for the explanation. This basically allows for multiple devices to be managed in the same catalog compilation without environmental bleeding.