### PR TITLE
Update beaker to use unset for property

### DIFF
--- a/tests/beaker_tests/syslog_settings/test_syslog_settings.rb
+++ b/tests/beaker_tests/syslog_settings/test_syslog_settings.rb
@@ -73,7 +73,7 @@ tests[:unsetting] = {
     time_stamp_units:       'seconds',
     logfile_name:           'unset',
     logfile_severity_level: 'unset',
-    logfile_size:           -1,
+    logfile_size:           'unset',
   },
 }
 


### PR DESCRIPTION
Test was failing because it was looking for `-1` in the resource output instead of `unset`.  Updated the test to use `unset` because that is the documented method for unsetting the property.

https://github.com/puppetlabs/netdev_stdlib/blob/master/lib/puppet/type/syslog_settings.rb#L99