### PR TITLE
beaker: Add NVE probes to vrf/vlan tests; test_manifest hidden errors

### DIFF
--- a/tests/beaker_tests/cisco_vlan/test_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_vlan.rb
@@ -108,11 +108,7 @@ if platform[/n3k$/]
   tests[:vn_segment_unsupported] = resource_probe(agent, cmd, pattern)
 end
 
-if platform[/n(5|6)k/]
-  pattern = 'NVE Feature NOT supported on this Platform'
-  cmd = 'feature nv overlay'
-  tests[:nv_overlay_unsupported] = resource_probe(agent, cmd, pattern)
-end
+tests[:nv_overlay_unsupported] = resource_probe_named(agent, :nve) if platform[/n(5|6)k/]
 
 # class to contain the test_dependencies specific to this test case
 class TestVlan < BaseHarness

--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -64,9 +64,11 @@ tests[:non_default] = {
   },
 }
 
+tests[:nv_overlay_unsupported] = resource_probe_named(agent, :nve) if platform[/n(5|6)k/]
+
 # class to contain the test_dependencies specific to this test case
 class TestVrf < BaseHarness
-  def self.unsupported_properties(ctx, _tests, _id)
+  def self.unsupported_properties(ctx, tests, _id)
     unprops = []
     if ctx.operating_system == 'nexus'
       unprops <<
@@ -76,7 +78,8 @@ class TestVrf < BaseHarness
         :vpn_id
 
       unprops << :vni unless ctx.platform[/n9k/]
-      unprops << :route_distinguisher if ctx.nexus_image['I2']
+      unprops << :route_distinguisher if ctx.nexus_image['I2'] ||
+                                         tests[:nv_overlay_unsupported]
       unprops << :description if ctx.image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
 
     else

--- a/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
+++ b/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
@@ -30,6 +30,8 @@ tests = {
   resource_name: 'cisco_vrf_af',
 }
 
+skip_if_nv_overlay_rejected(agent) if platform[/n(5|6)k/]
+
 # Test hash test cases
 tests[:default] = {
   desc:           'Default Properties, vrf-af',

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -360,9 +360,10 @@ DEVICE
           #  raise 'Errored test'
           # end
           on(tests[:proxy_agent], puppet_device_cmd, acceptable_exit_codes: [0, 1, 2])
-          if !(stdout.include? 'Applied catalog') && tests[id][:stderr_pattern].nil?
+          if tests[id][:stderr_pattern].nil? && (output[/Error: /] || !output[/Applied catalog/])
+            logger.info(tests[id][:manifest])
             logger.info(stdout)
-            raise 'Errored test as the command result did not match applied catalog'
+            raise 'Unexpected error while applying catalog'
           end
         else
           on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: code)
@@ -378,10 +379,11 @@ DEVICE
         # end
         output = `#{agentless_command} --apply #{@temp_agentless_manifest.path} 2>&1`
         # logger.debug("test_manifest :: output: \n#{output}")
-        if !(output.include? 'Applied catalog') && tests[id][:stderr_pattern].nil?
+        if tests[id][:stderr_pattern].nil? && (output[/Error: /] || !output[/Applied catalog/])
+          logger.info(`cat #{@temp_agentless_manifest.path}`)
           remove_temp_manifest
           logger.info(output)
-          raise 'Errored test as the command result did not match applied catalog'
+          raise 'Unexpected error while applying catalog'
         end
       end
       test_stderr(tests, id, output) if tests[id][:stderr_pattern]
@@ -1947,8 +1949,18 @@ DEVICE
     else
       out = nxapi_probe(cmd)
     end
-    logger.info("Resource Probe: out: " + out)
+    logger.info('Resource Probe: out: ' + out)
     out.match(pattern) ? true : false
+  end
+
+  # Wrapper for common resource probes
+  def resource_probe_named(agent, type)
+    case type
+    when :nve
+      pattern = 'NVE Feature NOT supported on this Platform'
+      cmd = 'feature nv overlay'
+    end
+    resource_probe(agent, cmd, pattern)
   end
 
   def vdc_limit_f3_no_intf_needed(action=:set)

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -360,6 +360,7 @@ DEVICE
           #  raise 'Errored test'
           # end
           on(tests[:proxy_agent], puppet_device_cmd, acceptable_exit_codes: [0, 1, 2])
+          output = stdout
           if tests[id][:stderr_pattern].nil? && (output[/Error: /] || !output[/Applied catalog/])
             logger.info(tests[id][:manifest])
             logger.info(stdout)


### PR DESCRIPTION
Mostly n6k test errors. Also noticed that `test_vrf` was not raising an error in `test_manifest` when it hit the `NVE Feature NOT supported on this Platform` failure, which passed because the `'Applied catalog'` string shows up in the output. The code logic also needs to know how to handle intended errors (negative testing) so my change is to explicitly look for `Error: ` in the output but only when the caller does not supply a `stderr_pattern`.

Tested with agentless on N6k; will update after testing with agentful.