### PR TITLE
(DOC-3953) README update for 2.0 release

### DIFF
--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -27,6 +27,8 @@ This document describes Puppet agent installation and setup on Cisco Nexus switc
 
 See [References](#references) for alternative installation methods.
 
+**NOTE:** Agentless is the recommended mode of operation for the Cisco Nexus module. Agent installations are not recommended because the agent won't be supported beyond Puppet Enterprise 2018.1. For more information, see [Puppet Enterprise support lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle).
+
 ## <a name="pre-install-tasks">Pre-Install Tasks</a>
 
 #### *Step 1. Platform / Software Minimum Requirements*

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -27,7 +27,7 @@ This document describes Puppet agent installation and setup on Cisco Nexus switc
 
 See [References](#references) for alternative installation methods.
 
-**NOTE:** When using `OAC` and `Native Bash` hosting options, agentless is the recommended mode of operation for the Cisco Nexus module. Agent installations are not recommended because the agent won't be supported beyond Puppet Enterprise 2018.1. For more information, see [Puppet Enterprise support lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle).
+**NOTE:** The Puppet agent is not supported for the `OAC` or `Native Bash` hosting environments on NX-OS beyond Puppet Enterprise 2018.1. The agentless workflow is recommended for managing Cisco NX-OS devices. Agent based workflows will continue to be supported in the NX-OS Guestshell hosting environment.
 
 ## <a name="pre-install-tasks">Pre-Install Tasks</a>
 

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -27,7 +27,7 @@ This document describes Puppet agent installation and setup on Cisco Nexus switc
 
 See [References](#references) for alternative installation methods.
 
-**NOTE:** Agentless is the recommended mode of operation for the Cisco Nexus module. Agent installations are not recommended because the agent won't be supported beyond Puppet Enterprise 2018.1. For more information, see [Puppet Enterprise support lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle).
+**NOTE:** When using `OAC` and `Native Bash` hosting options, agentless is the recommended mode of operation for the Cisco Nexus module. Agent installations are not recommended because the agent won't be supported beyond Puppet Enterprise 2018.1. For more information, see [Puppet Enterprise support lifecycle](https://puppet.com/misc/puppet-enterprise-lifecycle).
 
 ## <a name="pre-install-tasks">Pre-Install Tasks</a>
 


### PR DESCRIPTION
This commit adds a note to the README about the agent being phased out after 2018.1. 

https://tickets.puppetlabs.com/browse/DOC-3953