### PR TITLE
(maint) adding in the requires for the puppet functions

### DIFF
--- a/lib/puppet/functions/find_linecard.rb
+++ b/lib/puppet/functions/find_linecard.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 Puppet::Functions.create_function(:find_linecard) do
+  require 'puppet/util'
+  require 'puppet/util/network_device'
   def find_linecard(linecard)
     if Puppet::Util::NetworkDevice.current.nil?
       data = Facter.value('cisco')

--- a/lib/puppet/functions/image_supports_trm.rb
+++ b/lib/puppet/functions/image_supports_trm.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 Puppet::Functions.create_function(:image_supports_trm) do
+  require 'puppet/util'
+  require 'puppet/util/network_device'
   def image_supports_trm
     if Puppet::Util::NetworkDevice.current.nil?
       data = Facter.value('os')['release']['full']

--- a/lib/puppet/functions/platform_fretta.rb
+++ b/lib/puppet/functions/platform_fretta.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 Puppet::Functions.create_function(:platform_fretta) do
+  require 'puppet/util'
+  require 'puppet/util/network_device'
   def platform_fretta
     if Puppet::Util::NetworkDevice.current.nil?
       data = Facter.value('cisco')

--- a/lib/puppet/functions/platform_get.rb
+++ b/lib/puppet/functions/platform_get.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 
 Puppet::Functions.create_function(:platform_get) do
+  require 'puppet/util'
+  require 'puppet/util/network_device'
   def platform_get
     if Puppet::Util::NetworkDevice.current.nil?
       data = Facter.value('cisco')


### PR DESCRIPTION
These requires were missed during a conversion and would lead to the following errors:

```
Error while evaluating a Function Call, uninitialized constant Puppet::Util::NetworkDevice
```