### PR TITLE
(maint) add more debugging to test_stderr

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -332,6 +332,7 @@ DEVICE
     if test_output =~ tests[id][:stderr_pattern]
       logger.debug("TestStep :: Match #{tests[id][:stderr_pattern]} :: PASS")
     else
+      logger.error("output:\n--\n#{test_output}\n--")
       fail_test("TestStep :: Match #{tests[id][:stderr_pattern]} :: FAIL")
     end
   end


### PR DESCRIPTION
Printing the output on test failures helps debugging them through allowing
inspection of the failure from CI logs.