### PR TITLE
(maint) Minor fixes

### DIFF
--- a/lib/puppet/transport/schema/cisco_nexus.rb
+++ b/lib/puppet/transport/schema/cisco_nexus.rb
@@ -21,7 +21,7 @@ Puppet::ResourceApi.register_transport(
       desc: 'The FQDN or IP address of the device to connect to.',
     },
     port:        {
-      type: 'Optional[String]',
+      type: 'Optional[Integer]',
       desc: 'The port of the device to connect to.',
     },
     transport:   {

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/resource_api",
-      "version_requirement": ">= 1.6.3 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/tests/beaker_presuite/presuite_deploy.rb
+++ b/tests/beaker_presuite/presuite_deploy.rb
@@ -224,7 +224,7 @@ test_name 'Prep Masters & Install Puppet' do
           credentials => {
             address => '#{beaker_config_connection_address}',
             username => #{default[:ssh][:user] || 'admin'},
-            port => #{default[:ssh][:port] || '80'},
+            port => #{default[:ssh][:port] || 80},
             password => #{default[:ssh][:password] || 'admin'},
           },
         }\n

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -117,7 +117,7 @@ class Beaker::TestCase
     @credentials_file.write <<CREDENTIALS
 host: "#{beaker_config_connection_address}"
 user: "#{@nexus_host.host_hash[:ssh][:user] || 'admin'}"
-port: "#{@nexus_host.host_hash[:ssh][:port] || '80'}"
+port: #{@nexus_host.host_hash[:ssh][:port] || 80}
 password: "#{@nexus_host.host_hash[:ssh][:password] || 'admin'}"
 CREDENTIALS
     @credentials_file.close


### PR DESCRIPTION
Transport schema Port should be an Integer rather than a String.
The metadata refers to the Resource API gem rather than module and so minimum should be the 1.0.0 release