### PR TITLE
(maint) Remove extra require from Rakefile

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -39,8 +39,6 @@ Gemfile:
     - /spec/fixtures/acceptance-credentials.conf
     - /spec/fixtures/acceptance-device.conf
 Rakefile:
-  requires:
-    - 'puppet-strings/tasks'
   extra_disabled_lint_checks:
     - 'autoloader_layout'
     - 'variable_scope'

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,6 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
-require 'puppet-strings/tasks'
 
 def changelog_user
   return unless Rake.application.top_level_tasks.include? "changelog"


### PR DESCRIPTION
PDK sync.yml updates the Rakefile to add an extra non-guarded puppet-strings/tasks.
Remove this.