### PR TITLE
cisco_interface_ospf: interface lookup performance enhancement

### DIFF
--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -154,7 +154,6 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
       all_intf = false
     end
     if all_intf
-      # 'puppet resource' caller
       @nu = Cisco::Interface.interfaces[@property_hash[:name]]
     elsif single_intf
       # 'puppet agent' caller

--- a/lib/puppet/provider/cisco_interface_ospf/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_ospf/cisco.rb
@@ -195,8 +195,8 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
       if @nu.nil?
         new_instance = true
         @nu = Cisco::InterfaceOspf.new(@resource[:interface],
-                                                 @resource[:ospf],
-                                                 @resource[:area])
+                                       @resource[:ospf],
+                                       @resource[:area])
       end
       properties_set(new_instance)
     end

--- a/lib/puppet/provider/cisco_interface_ospf/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_ospf/cisco.rb
@@ -55,23 +55,41 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
 
   INTF_OSPF_ALL_PROPS = INTF_OSPF_NON_BOOL_PROPS + INTF_OSPF_BOOL_PROPS
 
-  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@interface_ospf',
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:non_bool, self, '@nu',
                                             INTF_OSPF_NON_BOOL_PROPS)
-  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@interface_ospf',
+  PuppetX::Cisco::AutoGen.mk_puppet_methods(:bool, self, '@nu',
                                             INTF_OSPF_BOOL_PROPS)
 
   def initialize(value={})
     super(value)
-    @interface_ospf = Cisco::InterfaceOspf.interfaces[@property_hash[:interface]]
+
+    if value.is_a?(Hash)
+      # value is_a hash when initialized from properties_get()
+      all_intf = value[:all_intf]
+      single_intf = value[:interface]
+      ospf_name = value[:ospf]
+    else
+      # @property_hash[:name] is nil in this codepath; since it's nil
+      # it will cause @nu to become nil, thus @nu instantiation is just
+      # skipped altogether.
+      all_intf = false
+    end
+    if all_intf
+      @nu = Cisco::InterfaceOspf.interfaces[@property_hash[:interface]]
+    elsif single_intf
+      # 'puppet agent' caller
+      @nu = Cisco::InterfaceOspf.interfaces(ospf_name, single_intf)[@property_hash[:interface]]
+    end
     @property_flush = {}
   end
 
-  def self.properties_get(interface_name, interface_ospf)
+  def self.properties_get(interface_name, interface_ospf, all_intf: nil)
     current_state = {
       interface: interface_name,
       name:      "#{interface_name} #{interface_ospf.ospf_name}",
       ospf:      interface_ospf.ospf_name,
       ensure:    :present,
+      all_intf:  all_intf,
     }
 
     # Call node_utils getter for each property
@@ -89,23 +107,47 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
     new(current_state)
   end # self.properties_get
 
-  def self.instances
-    intf_ospf_instances = []
-
-    Cisco::InterfaceOspf.interfaces.each do |intf_name, intf_ospf|
+  def self.instances(name=nil)
+    # 'puppet resource' calls here directly; will always get all interfaces.
+    # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
+    if name
+      single_intf, ospf_name = name.split
+      all_intf = false
+    else
+      single_intf, ospf_name = nil
+      all_intf = true
+    end
+    interfaces = []
+    Cisco::InterfaceOspf.interfaces(ospf_name, single_intf).each do |name, nu_obj|
       begin
-        intf_ospf_instances << properties_get(intf_name, intf_ospf)
+        interfaces << properties_get(name, nu_obj, all_intf: all_intf)
       end
     end
-    intf_ospf_instances
+    interfaces
   end
 
   def self.prefetch(resources)
-    intf_ospf_instances = instances
+    # Set a threshold for getting all interfaces versus getting each
+    # manifest interface individually. The threshold is only useful to
+    # a certain point - it depends on the total number of interfaces on
+    # the device - after which it's better to just get all interfaces.
+    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
 
-    resources.keys.each do |name|
-      provider = intf_ospf_instances.find { |intf_ospf| intf_ospf.name == name }
-      resources[name].provider = provider unless provider.nil?
+    # resource.key syntax is 'interface_name ospf_name'
+    if resources.keys.length > show_run_int_threshold
+      info '[prefetch all interfaces]:begin - please be patient...'
+      interfaces = instances
+      resources.keys.each do |name|
+        provider = interfaces.find { |intf| intf.name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
+      info "[prefetch all interfaces]:end - found: #{interfaces.length}"
+    else
+      info "[prefetch each interface independently] (threshold: #{show_run_int_threshold.to_i})"
+      resources.keys.each do |name|
+        provider = instances(name).find { |intf| intf.name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
     end
   end
 
@@ -128,8 +170,8 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
       next unless @resource[prop]
       send("#{prop}=", @resource[prop]) if new_instance
       unless @property_flush[prop].nil?
-        @interface_ospf.send("#{prop}=", @property_flush[prop]) if
-          @interface_ospf.respond_to?("#{prop}=")
+        @nu.send("#{prop}=", @property_flush[prop]) if
+          @nu.respond_to?("#{prop}=")
       end
     end
     # custom setters which require one-shot multi-param setters
@@ -137,22 +179,22 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
   end
 
   def message_digest_key_set
-    key = @property_flush[:message_digest_key_id] ? @property_flush[:message_digest_key_id] : @interface_ospf.message_digest_key_id
-    pw = @property_flush[:message_digest_password] ? @property_flush[:message_digest_password] : @interface_ospf.message_digest_password
-    algtype = @property_flush[:message_digest_algorithm_type] ? @property_flush[:message_digest_algorithm_type] : @interface_ospf.message_digest_algorithm_type
-    enctype = @property_flush[:message_digest_encryption_type] ? @property_flush[:message_digest_encryption_type] : @interface_ospf.message_digest_encryption_type
-    @interface_ospf.message_digest_key_set(key, algtype.to_s, enctype, pw)
+    key = @property_flush[:message_digest_key_id] ? @property_flush[:message_digest_key_id] : @nu.message_digest_key_id
+    pw = @property_flush[:message_digest_password] ? @property_flush[:message_digest_password] : @nu.message_digest_password
+    algtype = @property_flush[:message_digest_algorithm_type] ? @property_flush[:message_digest_algorithm_type] : @nu.message_digest_algorithm_type
+    enctype = @property_flush[:message_digest_encryption_type] ? @property_flush[:message_digest_encryption_type] : @nu.message_digest_encryption_type
+    @nu.message_digest_key_set(key, algtype.to_s, enctype, pw)
   end
 
   def flush
     if @property_flush[:ensure] == :absent
-      @interface_ospf.destroy
-      @interface_ospf = nil
+      @nu.destroy
+      @nu = nil
     else
       new_instance = false
-      if @interface_ospf.nil?
+      if @nu.nil?
         new_instance = true
-        @interface_ospf = Cisco::InterfaceOspf.new(@resource[:interface],
+        @nu = Cisco::InterfaceOspf.new(@resource[:interface],
                                                    @resource[:ospf],
                                                    @resource[:area])
       end

--- a/lib/puppet/provider/cisco_interface_ospf/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_ospf/cisco.rb
@@ -118,9 +118,9 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
       all_intf = true
     end
     interfaces = []
-    Cisco::InterfaceOspf.interfaces(ospf_name, single_intf).each do |name, nu_obj|
+    Cisco::InterfaceOspf.interfaces(ospf_name, single_intf).each do |intf_ospf, nu_obj|
       begin
-        interfaces << properties_get(name, nu_obj, all_intf: all_intf)
+        interfaces << properties_get(intf_ospf, nu_obj, all_intf: all_intf)
       end
     end
     interfaces
@@ -195,8 +195,8 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
       if @nu.nil?
         new_instance = true
         @nu = Cisco::InterfaceOspf.new(@resource[:interface],
-                                                   @resource[:ospf],
-                                                   @resource[:area])
+                                                 @resource[:ospf],
+                                                 @resource[:area])
       end
       properties_set(new_instance)
     end

--- a/tests/beaker_tests/cisco_interface/test_interface_threshold.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_threshold.rb
@@ -115,7 +115,7 @@ providers = [
   :cisco_interface_ospf,
   :cisco_interface_channel_group,
 ]
-providers.push(:cisco_interface_evpn_multisite) if platform.match('n9k-ex')
+providers.push(:cisco_interface_evpn_multisite) if platform[/n9k-ex/]
 
 #################################################################
 # TEST CASE EXECUTION

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -709,6 +709,20 @@ DEVICE
     end
   end
 
+  # Helper to clean up a range of interfaces
+  def interface_cleanup_range(tests)
+    step "TestStep :: clean up interface range" do
+      logger.info("  * Set '#{tests[:intf_range]}' to default state")
+      cmd = "default interface #{tests[:intf_range]}"
+      if agent
+        cmd = PUPPET_BINPATH + "resource cisco_command_config 'interface_cleanup_range' command='#{cmd}'"
+        on(agent, cmd, acceptable_exit_codes: [0, 2])
+      else
+        nxapi_test_set(cmd)
+      end
+    end
+  end
+
   # Helper to remove all IP address configs from all interfaces. This is
   # needed to avoid IP conflicts with our test interface.
   def interface_ip_cleanup(agent, stepinfo='Pre Clean:')
@@ -1760,7 +1774,6 @@ DEVICE
 
     when /ethernet/i, /dot1q/
       all = get_current_resource_instances(tests[:agent], 'cisco_interface')
-      # Skip the first interface we find in case it's our access interface.
       # TODO: check the interface IP address like we do in node_utils
       array = all.grep(%r{ethernet\d+/\d+})
     end

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -711,7 +711,7 @@ DEVICE
 
   # Helper to clean up a range of interfaces
   def interface_cleanup_range(tests)
-    step "TestStep :: clean up interface range" do
+    step 'TestStep :: clean up interface range' do
       logger.info("  * Set '#{tests[:intf_range]}' to default state")
       cmd = "default interface #{tests[:intf_range]}"
       if agent


### PR DESCRIPTION
##### SUMMARY
- This is part 2 of the interface performance work started by #561.
  - This commit builds on the perf work done for that PR.
  - NU dependencies have already been merged.
    - https://github.com/cisco/cisco-network-node-utils/pull/637

- Beaker test `test_interface_threshold.rb` was updated to also test interface_ospf. Additional tests will be added for the other intf providers as the code is completed.
  - Tested on dt-n9k5-1