### PR TITLE
cisco_interface_: channel_group, evpn_multisite interface perf fixes

### DIFF
--- a/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
@@ -51,16 +51,32 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
 
   def initialize(value={})
     super(value)
-    @nu = Cisco::InterfaceChannelGroup.interfaces[@property_hash[:name]]
+    if value.is_a?(Hash)
+      # value is_a hash when initialized from properties_get()
+      all_intf = value[:all_intf]
+      single_intf = value[:interface]
+    else
+      # @property_hash[:name] is nil in this codepath; since it's nil
+      # it will cause @nu to become nil, thus @nu instantiation is just
+      # skipped altogether.
+      all_intf = false
+    end
+    if all_intf
+      @nu = Cisco::InterfaceChannelGroup.interfaces[@property_hash[:name]]
+    elsif single_intf
+      # 'puppet agent' caller
+      @nu = Cisco::InterfaceChannelGroup.interfaces(single_intf)[@property_hash[:name]]
+    end
     @property_flush = {}
   end
 
-  def self.properties_get(intf_name, nu_obj)
+  def self.properties_get(intf_name, nu_obj, all_intf: nil)
     debug "Checking instance, #{intf_name}."
     current_state = {
       interface: intf_name,
       name:      intf_name,
       ensure:    :present,
+      all_intf:  all_intf,
     }
     # Call node_utils getter for each property
     INTF_CG_NON_BOOL_PROPS.each do |prop|
@@ -77,21 +93,40 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
     new(current_state)
   end # self.properties_get
 
-  def self.instances
-    all_intf = []
-    Cisco::InterfaceChannelGroup.interfaces.each do |intf_name, nu_obj|
+  def self.instances(single_intf=nil)
+    # 'puppet resource' calls here directly; will always get all interfaces.
+    # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
+    all_intf = single_intf ? false : true
+    interfaces = []
+    Cisco::InterfaceChannelGroup.interfaces(single_intf).each do |interface_name, nu_obj|
       begin
-        all_intf << properties_get(intf_name, nu_obj)
+        interfaces << properties_get(interface_name, nu_obj, all_intf: all_intf)
       end
     end
-    all_intf
+    interfaces
   end # self.instances
 
   def self.prefetch(resources)
-    all_intf = instances
-    resources.keys.each do |name|
-      provider = all_intf.find { |intf| intf.instance_name == name }
-      resources[name].provider = provider unless provider.nil?
+    # Set a threshold for getting all interfaces versus getting each
+    # manifest interface individually. The threshold is only useful to
+    # a certain point - it depends on the total number of interfaces on
+    # the device - after which it's better to just get all interfaces.
+    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+
+    if resources.keys.length > show_run_int_threshold
+      info '[prefetch all interfaces]:begin - please be patient...'
+      interfaces = instances
+      resources.keys.each do |name|
+        provider = interfaces.find { |intf| intf.instance_name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
+      info "[prefetch all interfaces]:end - found: #{interfaces.length}"
+    else
+      info "[prefetch each interface independently] (threshold: #{show_run_int_threshold.to_i})"
+      resources.keys.each do |name|
+        provider = instances(name).find { |intf| intf.instance_name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
     end
   end # self.prefetch
 

--- a/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:cisco_interface_evpn_multisite).provide(:cisco) do
     @property_flush = {}
   end
 
-  def self.properties_get(interface_name, nu_obj, all_intf: all_intf)
+  def self.properties_get(interface_name, nu_obj, all_intf: nil)
     debug "Checking instance, #{interface_name}."
     current_state = {
       interface: interface_name,

--- a/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
@@ -43,34 +43,72 @@ Puppet::Type.type(:cisco_interface_evpn_multisite).provide(:cisco) do
 
   def initialize(value={})
     super(value)
-    @nu = Cisco::InterfaceEvpnMultisite.interfaces[@property_hash[:name]]
+    if value.is_a?(Hash)
+      # value is_a hash when initialized from properties_get()
+      all_intf = value[:all_intf]
+      single_intf = value[:interface]
+    else
+      # @property_hash[:name] is nil in this codepath; since it's nil
+      # it will cause @nu to become nil, thus @nu instantiation is just
+      # skipped altogether.
+      all_intf = false
+    end
+    if all_intf
+      @nu = Cisco::InterfaceEvpnMultisite.interfaces[@property_hash[:name]]
+    elsif single_intf
+      # 'puppet agent' caller
+      @nu = Cisco::InterfaceEvpnMultisite.interfaces(single_intf)[@property_hash[:name]]
+    end
+
     @property_flush = {}
   end
 
-  def self.properties_get(interface_name, nu_obj)
+  def self.properties_get(interface_name, nu_obj, all_intf: all_intf)
     debug "Checking instance, #{interface_name}."
     current_state = {
       interface: interface_name,
       name:      interface_name,
       ensure:    :present,
       tracking:  nu_obj.tracking,
+      all_intf:  all_intf,
     }
     new(current_state)
   end # self.properties_get
 
-  def self.instances
+  def self.instances(single_intf=nil)
+    # 'puppet resource' calls here directly; will always get all interfaces.
+    # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
+    all_intf = single_intf ? false : true
     interfaces = []
-    Cisco::InterfaceEvpnMultisite.interfaces.each do |interface_name, nu_obj|
-      interfaces << properties_get(interface_name, nu_obj)
+    Cisco::InterfaceEvpnMultisite.interfaces(single_intf).each do |interface_name, nu_obj|
+      begin
+        interfaces << properties_get(interface_name, nu_obj, all_intf: all_intf)
+      end
     end
     interfaces
   end # self.instances
 
   def self.prefetch(resources)
-    interfaces = instances
-    resources.keys.each do |name|
-      provider = interfaces.find { |nu_obj| nu_obj.instance_name == name }
-      resources[name].provider = provider unless provider.nil?
+    # Set a threshold for getting all interfaces versus getting each
+    # manifest interface individually. The threshold is only useful to
+    # a certain point - it depends on the total number of interfaces on
+    # the device - after which it's better to just get all interfaces.
+    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+
+    if resources.keys.length > show_run_int_threshold
+      info '[prefetch all interfaces]:begin - please be patient...'
+      interfaces = instances
+      resources.keys.each do |name|
+        provider = interfaces.find { |intf| intf.instance_name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
+      info "[prefetch all interfaces]:end - found: #{interfaces.length}"
+    else
+      info "[prefetch each interface independently] (threshold: #{show_run_int_threshold.to_i})"
+      resources.keys.each do |name|
+        provider = instances(name).find { |intf| intf.instance_name == name }
+        resources[name].provider = provider unless provider.nil?
+      end
     end
   end # self.prefetch
 

--- a/tests/beaker_tests/cisco_interface/test_interface_threshold.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_threshold.rb
@@ -115,7 +115,11 @@ providers = [
   :cisco_interface_ospf,
   :cisco_interface_channel_group,
 ]
-providers.push(:cisco_interface_evpn_multisite) if platform[/n9k-ex/]
+if platform[/n9k-ex/]
+  providers.push(:cisco_interface_evpn_multisite)
+else
+  logger.info("\n#{'-' * 60}\nNo support on this device for :cisco_interface_evpn_multisite\n")
+end
 
 #################################################################
 # TEST CASE EXECUTION


### PR DESCRIPTION
- This is part 3 of the interface performance work started by #561.
  - This commit builds on the perf work done for that PR.
  - NU dependencies have already been merged.
    - https://github.com/cisco/cisco-network-node-utils/pull/632

- Beaker test `test_interface_threshold.rb` was updated to also test these changes. 
 - Tested on dt-n9k5-1 and n9k-140
