### PR TITLE
Add NU gem version checks to allow backward-compatibility

### DIFF
--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -214,7 +214,11 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     # manifest interface individually. The threshold is only useful to
     # a certain point - it depends on the total number of interfaces on
     # the device - after which it's better to just get all interfaces.
-    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+    else
+      show_run_int_threshold = 0
+    end
     if resources.keys.length > show_run_int_threshold
       info '[prefetch all interfaces]:begin - please be patient...'
       interfaces = instances

--- a/lib/puppet/provider/cisco_interface/cisco.rb
+++ b/lib/puppet/provider/cisco_interface/cisco.rb
@@ -190,7 +190,15 @@ Puppet::Type.type(:cisco_interface).provide(:cisco) do
     # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
     all_intf = single_intf ? false : true
     interfaces = []
-    Cisco::Interface.interfaces(nil, single_intf).each do |interface_name, nu_obj|
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      nu_interfaces = Cisco::Interface.interfaces(nil, single_intf)
+    else
+      info '## Notice: Unable to prefetch independently, using legacy lookup instead.'
+      info '## Notice: cisco_node_utils gem does not contain interface lookup enhancements.'
+      info '## Notice: Please upgrade cisco_node_utils to v2.1.0 or newer'
+      nu_interfaces = Cisco::Interface.interfaces
+    end
+    nu_interfaces.each do |interface_name, nu_obj|
       begin
         # Some interfaces cannot or should not be managed by this type.
         # - NVE Interfaces (managed by cisco_vxlan_vtep type)

--- a/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
@@ -98,7 +98,15 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
     # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
     all_intf = single_intf ? false : true
     interfaces = []
-    Cisco::InterfaceChannelGroup.interfaces(single_intf).each do |interface_name, nu_obj|
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      nu_interfaces = Cisco::InterfaceChannelGroup.interfaces(single_intf)
+    else
+      info '## Notice: Unable to prefetch independently, using legacy lookup instead.'
+      info '## Notice: cisco_node_utils gem does not contain interface lookup enhancements.'
+      info '## Notice: Please upgrade cisco_node_utils to v2.1.0 or newer'
+      nu_interfaces = Cisco::InterfaceChannelGroup.interfaces
+    end
+    nu_interfaces.each do |interface_name, nu_obj|
       begin
         interfaces << properties_get(interface_name, nu_obj, all_intf: all_intf)
       end

--- a/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_channel_group/cisco.rb
@@ -119,8 +119,11 @@ Puppet::Type.type(:cisco_interface_channel_group).provide(:cisco) do
     # manifest interface individually. The threshold is only useful to
     # a certain point - it depends on the total number of interfaces on
     # the device - after which it's better to just get all interfaces.
-    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
-
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+    else
+      show_run_int_threshold = 0
+    end
     if resources.keys.length > show_run_int_threshold
       info '[prefetch all interfaces]:begin - please be patient...'
       interfaces = instances

--- a/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
@@ -101,8 +101,11 @@ Puppet::Type.type(:cisco_interface_evpn_multisite).provide(:cisco) do
     # manifest interface individually. The threshold is only useful to
     # a certain point - it depends on the total number of interfaces on
     # the device - after which it's better to just get all interfaces.
-    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
-
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+    else
+      show_run_int_threshold = 0
+    end
     if resources.keys.length > show_run_int_threshold
       info '[prefetch all interfaces]:begin - please be patient...'
       interfaces = instances

--- a/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_evpn_multisite/cisco.rb
@@ -80,7 +80,15 @@ Puppet::Type.type(:cisco_interface_evpn_multisite).provide(:cisco) do
     # 'puppet agent' callpath is initialize->prefetch; may pass a single intf.
     all_intf = single_intf ? false : true
     interfaces = []
-    Cisco::InterfaceEvpnMultisite.interfaces(single_intf).each do |interface_name, nu_obj|
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      nu_interfaces = Cisco::InterfaceEvpnMultisite.interfaces(single_intf)
+    else
+      info '## Notice: Unable to prefetch independently, using legacy lookup instead.'
+      info '## Notice: cisco_node_utils gem does not contain interface lookup enhancements.'
+      info '## Notice: Please upgrade cisco_node_utils to v2.1.0 or newer'
+      nu_interfaces = Cisco::InterfaceEvpnMultisite.interfaces
+    end
+    nu_interfaces.each do |interface_name, nu_obj|
       begin
         interfaces << properties_get(interface_name, nu_obj, all_intf: all_intf)
       end

--- a/lib/puppet/provider/cisco_interface_ospf/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_ospf/cisco.rb
@@ -139,8 +139,11 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
     # manifest interface individually. The threshold is only useful to
     # a certain point - it depends on the total number of interfaces on
     # the device - after which it's better to just get all interfaces.
-    show_run_int_threshold = Cisco::Interface.interface_count * 0.15
-
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      show_run_int_threshold = Cisco::Interface.interface_count * 0.15
+    else
+      show_run_int_threshold = 0
+    end
     # resource.key syntax is 'interface_name ospf_name'
     if resources.keys.length > show_run_int_threshold
       info '[prefetch all interfaces]:begin - please be patient...'

--- a/lib/puppet/provider/cisco_interface_ospf/cisco.rb
+++ b/lib/puppet/provider/cisco_interface_ospf/cisco.rb
@@ -118,7 +118,15 @@ Puppet::Type.type(:cisco_interface_ospf).provide(:cisco) do
       all_intf = true
     end
     interfaces = []
-    Cisco::InterfaceOspf.interfaces(ospf_name, single_intf).each do |intf_ospf, nu_obj|
+    if Gem::Version.new(CiscoNodeUtils::VERSION) > Gem::Version.new('2.0.2')
+      nu_interfaces = Cisco::InterfaceOspf.interfaces(ospf_name, single_intf)
+    else
+      info '## Notice: Unable to prefetch independently, using legacy lookup instead.'
+      info '## Notice: cisco_node_utils gem does not contain interface lookup enhancements.'
+      info '## Notice: Please upgrade cisco_node_utils to v2.1.0 or newer'
+      nu_interfaces = Cisco::InterfaceOspf.interfaces
+    end
+    nu_interfaces.each do |intf_ospf, nu_obj|
       begin
         interfaces << properties_get(intf_ospf, nu_obj, all_intf: all_intf)
       end

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -135,7 +135,7 @@ tests[:seq_50_icmp_v4] = {
     proto_option: 'fragments',
     dscp:         'af11',
     log:          'true',
-    ttl:          '10',
+    ttl:          '3',
     vlan:         '100',
   },
 }


### PR DESCRIPTION
This change allows the new puppet module to work with an older NU gem. 

Manually tested on n9k-108.