### PR TITLE
Add vlan property to unprops for I2 images

### DIFF
--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -167,6 +167,8 @@ class TestAce < BaseHarness
         :set_erspan_gre_proto <<
         :ttl
     end
+    # Vlan property is not supported on I2 images.
+    unprops << :vlan if ctx.image?[/7.0.3.I2/]
     unprops
   end
 end


### PR DESCRIPTION
The vlan property for the `cisco_acl` provider is not supported on `7.0(3)I2(x)` images.

Tested on:

* N9k (7.0(3)I2|I4|I7|) (9.X)
* N7K

**7.0(3)I2 Image**
```shell
n9k(config-acl)# 40 deny icmp any any time-exceeded dscp af12 ?
  <CR>                  
  packet-length         Match packets based on layer 3 packet length
  redirect              Redirect to interface(s). Syntax example: redirect Ethernet1/1,Ethernet1/2,port-channel1
  set-erspan-dscp       Syntax: set-erspan-dscp; Set ERSPAN outer IP DSCP value <0-63>
  set-erspan-gre-proto  Syntax: set-erspan-gre-proto; Set ERSPAN GRE protocol <0-65535>
  time-range            Specify a time range
  log                   Log matches against this entry

n9k(config-acl)# 40 deny icmp any any time-exceeded dscp af12 ^C
```

**7.0(3)I7 Image**
```shell
n9k(config-acl)# 40 deny icmp any any time-exceeded dscp af12 ?
  <CR>                  
  packet-length         Match packets based on layer 3 packet length
  redirect              Redirect to interface(s). Syntax example: redirect Ethernet1/1,Ethernet1/2,port-channel1
  set-erspan-dscp       Syntax: set-erspan-dscp; Set ERSPAN outer IP DSCP value <1-63>
  set-erspan-gre-proto  Syntax: set-erspan-gre-proto; Set ERSPAN GRE protocol <1-65535>
  time-range            Specify a time range
  vlan                  Configure match based on vlan   <-------------- Supported here
  log                   Log matches against this entry

n9k(config-acl)# 40 deny icmp any any time-exceeded dscp af12 redirect ?
```