### PR TITLE
Fix snmp_user test for older images

### DIFF
--- a/tests/beaker_tests/cisco_snmp_user/test_cisco_snmp_user.rb
+++ b/tests/beaker_tests/cisco_snmp_user/test_cisco_snmp_user.rb
@@ -92,14 +92,27 @@ tests[:negatives] = {
   code:           [1, 4],
 }
 
+def cleanup(agent)
+  resource_absent_cleanup(agent, 'cisco_snmp_user')
+end
+
 #################################################################
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
+  teardown { cleanup(agent) }
+  cleanup(agent)
+
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   test_harness_run(tests, :default)
   # -------------------------------------------------------------------
+
+  # A few image versions have a bug where the device displays the
+  # previously configured auth protocol.  Remove the snmp user
+  # before executing non-default property test.
+  cleanup(agent) if image?[/7.0.3.I2|I3|I4/]
+
   logger.info("\n#{'-' * 60}\nSection 2. Non-Default Property Testing")
   test_harness_run(tests, :non_default)
   # -------------------------------------------------------------------


### PR DESCRIPTION
This fixes a problem on older `/7.0.3.I2|I3|I4/` images.

A few image versions have a bug where the device displays the previously configured auth protocol.  This fix removes the snmp user before executing non-default property test for the impacted versions.