### PR TITLE
Make agentless beaker easier to debug

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -379,8 +379,11 @@ DEVICE
         # if !code.include?($?.exitstatus)
         #  raise 'Errored test'
         # end
+        manifest_data = `cat #{@temp_agentless_manifest.path}`
+        logger.debug("test_manifest :: manifest contents :: \n#{manifest_data}")
+        logger.debug("test_manifest :: apply manifest command :: #{agentless_command} --apply #{@temp_agentless_manifest.path}")
         output = `#{agentless_command} --apply #{@temp_agentless_manifest.path} 2>&1`
-        # logger.debug("test_manifest :: output: \n#{output}")
+        logger.debug("test_manifest :: output: \n#{output}")
         if tests[id][:stderr_pattern].nil? && (output[/Error: /] || !output[/Applied catalog/])
           logger.info(`cat #{@temp_agentless_manifest.path}`)
           remove_temp_manifest


### PR DESCRIPTION
Display the following in beaker agentless run logs.

* Contents of the manifest data being applied
* Command used to apply the manifest in agentless mode.
* Output from applying the manifest.

**Sample output:**
```
  * TestStep :: 2.1 Common Non Defaults [ensure => present] :: MANIFEST    
    test_manifest :: manifest:
    0
    test_manifest :: check puppet apply cmd (code: [2])
    test_manifest :: manifest contents :: 
    
                                       cisco_itd_service { 'myService':
                                   ensure => present,
        access_list                              => 'iap',
        device_group                             => 'udpGroup',
        exclude_access_list                      => 'eap',
        fail_action                              => 'true',
        ingress_interface                        => [["vlan 2", "4.4.4.4"], ["ethernet 1/10", "5.5.5.5"], ["port-channel 100", "6.6.6.6"]],
        load_bal_buckets                         => '16',
        load_bal_enable                          => 'true',
        load_bal_mask_pos                        => '5',
        load_bal_method_bundle_hash              => 'ip-l4port',
        load_bal_method_bundle_select            => 'dst',
        load_bal_method_end_port                 => '100',
        load_bal_method_proto                    => 'udp',
        load_bal_method_start_port               => '50',
        shutdown                                 => 'true',
    
                                 }
    test_manifest :: apply manifest command :: bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures/modules --deviceconfig /tmp/acceptance-device20190806-9596-6ztljq.conf --target sut --libdir lib/  --apply /tmp/temp_test_apply20190806-9596-m9di1o
    test_manifest :: output: 
    Notice: Compiled catalog for sut in environment production in 0.08 seconds
    Info: Applying configuration version '1565118309'
    Notice: /Stage[main]/Main/Cisco_itd_service[myService]/ensure: created
    Info: Class[Main]: Unscheduling all events on Class[Main]
    Notice: Applied catalog in 2.51 seconds
```