### PR TITLE
Add cleaup nve interface for ip_multicast test

### DIFF
--- a/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
+++ b/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
@@ -76,7 +76,7 @@ def cleanup(agent)
   # 'no shutdown' state.  Remove any nve interfaces before
   # starting this test.
   # NOTE: There can only be one nve interface.
-  command_config(agent, 'no interface nve1')
+  test_set(agent, 'no interface nve1', ignore_errors: true)
   resource_absent_cleanup(agent, 'cisco_ip_multicast')
 end
 

--- a/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
+++ b/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
@@ -71,6 +71,12 @@ tests[:non_default] = {
 }
 
 def cleanup(agent)
+  # On some image versions, overlay_distributed_dr cannot be
+  # configured if an nve interface is configured in in the
+  # 'no shutdown' state.  Remove any nve interfaces before
+  # starting this test.
+  # NOTE: There can only be one nve interface.
+  command_config(agent, 'no interface nve1')
   resource_absent_cleanup(agent, 'cisco_ip_multicast')
 end
 

--- a/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
+++ b/tests/beaker_tests/cisco_ip_multicast/test_ip_multicast.rb
@@ -72,7 +72,7 @@ tests[:non_default] = {
 
 def cleanup(agent)
   # On some image versions, overlay_distributed_dr cannot be
-  # configured if an nve interface is configured in in the
+  # configured if an nve interface is configured and in the
   # 'no shutdown' state.  Remove any nve interfaces before
   # starting this test.
   # NOTE: There can only be one nve interface.


### PR DESCRIPTION
This test only runs on n9k.  The failure in the beaker test indicated that the nve interface needed to be in the shutdown state before the multicast `overlay_distributed_dr`  property in question could be set.

This test does not validate nve but it should cleanup any nve interfaces as part of the setup step.  Currently only one nve interface can be configured.

Tested on N9k (GS and agentless)