### PR TITLE
Fix ITD next-hop test for 9.x image versions

### DIFF
--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -106,7 +106,18 @@ tests[:default_plat_2] = {
   },
 }
 
-ingress_intf = [['vlan 2', '4.4.4.4'], [@ingress_eth_int, '5.5.5.5'], ['port-channel 100', '6.6.6.6']]
+# The next-hop setting as part of the ingress_interface
+# is not needed for n9k and in the latest images is not
+# even supported by the cli.
+next_hop1 = '4.4.4.4'
+next_hop2 = '5.5.5.5'
+next_hop3 = '6.6.6.6'
+if nexus_image[/9\.\d+/]
+  next_hop1 = ''
+  next_hop2 = ''
+  next_hop3 = ''
+end
+ingress_intf = [['vlan 2', next_hop1], [@ingress_eth_int, next_hop2], ['port-channel 100', next_hop3]]
 vip = ['ip 3.3.3.3 255.0.0.0 tcp 500 advertise enable']
 pv = %w(myVdc1 pvservice)
 
@@ -167,42 +178,46 @@ tests[:non_default_plat_2] = {
   },
 }
 
+next_hop = nexus_image[/9\.\d+/] ? '' : '2.2.2.2'
 tests[:non_default_shut] = {
   desc:           '3.1 Common create service and turn it on',
   title_pattern:  'myService',
   manifest_props: {
     device_group:      'udpGroup',
-    ingress_interface: [[@ingress_eth_int, '2.2.2.2']],
+    ingress_interface: [[@ingress_eth_int, next_hop]],
     shutdown:          'false',
   },
 }
 
+next_hop = nexus_image[/9\.\d+/] ? '' : '3.3.3.3'
 tests[:non_default_shut_2] = {
   desc:           '3.2 Common change params and turn off service',
   title_pattern:  'myService',
   manifest_props: {
     device_group:      'udpGroup',
-    ingress_interface: [[@ingress_eth_int, '3.3.3.3']],
+    ingress_interface: [[@ingress_eth_int, next_hop]],
     shutdown:          'true',
   },
 }
 
+next_hop = nexus_image[/9\.\d+/] ? '' : '4.4.4.4'
 tests[:non_default_shut_3] = {
   desc:           '3.3 Common change params and leave service off',
   title_pattern:  'myService',
   manifest_props: {
     device_group:      'udpGroup',
-    ingress_interface: [[@ingress_eth_int, '4.4.4.4']],
+    ingress_interface: [[@ingress_eth_int, next_hop]],
     shutdown:          'true',
   },
 }
 
+next_hop = nexus_image[/9\.\d+/] ? '' : '5.5.5.5'
 tests[:non_default_shut_4] = {
   desc:           '3.4 Common change params and turn service back on',
   title_pattern:  'myService',
   manifest_props: {
     device_group:      'udpGroup',
-    ingress_interface: [[@ingress_eth_int, '5.5.5.5']],
+    ingress_interface: [[@ingress_eth_int, next_hop]],
     shutdown:          'false',
   },
 }


### PR DESCRIPTION
The next-hop setting as part of the ingress_interface is not needed for n9k and in the latest images is not even supported by the cli.

Tested on n7k and n9k