### PR TITLE
(MAINT) Update ordering of transport parameters

### DIFF
--- a/lib/puppet/transport/schema/cisco_nexus.rb
+++ b/lib/puppet/transport/schema/cisco_nexus.rb
@@ -24,14 +24,6 @@ Puppet::ResourceApi.register_transport(
       type: 'Optional[Integer]',
       desc: 'The port of the device to connect to.',
     },
-    transport:   {
-      type: 'Optional[Enum["http", "https"]]',
-      desc: 'The type of transport protocol to use when connecting to the device. If not specified this will default to "http"',
-    },
-    verify_mode: {
-      type: 'Optional[Enum["peer", "client-once", "fail-no-peer", "none"]]',
-      desc: 'The type of OpenSSL client verification mode to use. Only applies if `transport` is `https`',
-    },
     user:        {
       type: 'String',
       desc: 'The username to use for authenticating all connections to the device.',
@@ -40,6 +32,14 @@ Puppet::ResourceApi.register_transport(
       type:      'String',
       desc:      'The password to use for authenticating all connections to the device.',
       sensitive: true,
+    },
+    transport:   {
+      type: 'Optional[Enum["http", "https"]]',
+      desc: 'The type of transport protocol to use when connecting to the device. If not specified this will default to "http"',
+    },
+    verify_mode: {
+      type: 'Optional[Enum["peer", "client-once", "fail-no-peer", "none"]]',
+      desc: 'The type of OpenSSL client verification mode to use. Only applies if `transport` is `https`',
     },
   },
 )


### PR DESCRIPTION
The ordering of the parameters here is used to determine the ordering of the parameters when displayed in the PE Console UI.  Since user and password are required and likely more utilized than transport and verify mode we move them up.